### PR TITLE
Feat: Add new Community Discord link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## PS2Recomp: PlayStation 2 Static Recompiler (Not ready)
 
+[![Discord](https://img.shields.io/badge/Discord-Join%20Server-5865F2?logo=discord&logoColor=white)](https://discord.gg/JQ8mawxUEf)
+
 * Note this is an experiment and doesn't work as it should, feel free to open a PR to help the project.
 
 PS2Recomp is a tool designed to statically recompile PlayStation 2 ELF binaries into C++ code that can be compiled for any modern platform. This enables running PS2 games natively on PC and other platforms without traditional emulation.


### PR DESCRIPTION
Fixes #7 

---

Displays Discord link badge on top of community.

Will start distributing through X / Twitter and with the help of the folks from the [PS1/PS2 Decompilation](https://discord.gg/VwCPdfbxgm) Discord server.