### PR TITLE
Handle dots in function names during sanitization

### DIFF
--- a/ps2xRecomp/src/code_generator.cpp
+++ b/ps2xRecomp/src/code_generator.cpp
@@ -73,18 +73,23 @@ namespace ps2recomp
         return kKeywords.find(name) != kKeywords.end();
     }
 
-    static std::string sanitizeFunctionName(const std::string &name)
+    static std::string sanitizeFunctionName(const std::string& name)
     {
+        std::string sanitized = name;
+
+        std::replace(sanitized.begin(), sanitized.end(), '.', '_');
+
         // ugly but will do for now
-        if (name == "main")
+        if (sanitized == "main")
             return "ps2_main";
 
-        if (isReservedCxxKeyword(name))
-            return "ps2_" + name;
+        if (isReservedCxxKeyword(sanitized))
+            return "ps2_" + sanitized;
 
-        if (!isReservedCxxIdentifier(name))
-            return name;
-        return "ps2_" + name;
+        if (!isReservedCxxIdentifier(sanitized))
+            return sanitized;
+
+        return "ps2_" + sanitized;
     }
 
     std::string CodeGenerator::getGeneratedFunctionName(const Function &function)

--- a/ps2xRecomp/src/ps2_recompiler.cpp
+++ b/ps2xRecomp/src/ps2_recompiler.cpp
@@ -714,22 +714,29 @@ namespace ps2recomp
         return outputPath;
     }
 
-    std::string PS2Recompiler::sanitizeFunctionName(const std::string &name) const
+    std::string PS2Recompiler::sanitizeFunctionName(const std::string& name) const
     {
-        if (name == "main")
+        std::string sanitized = name;
+        std::replace(sanitized.begin(), sanitized.end(), '.', '_');
+
+        if (sanitized == "main")
         {
             return "ps2_main";
         }
 
-        if (ps2recomp::kKeywords.find(name) != ps2recomp::kKeywords.end())
+        if (ps2recomp::kKeywords.find(sanitized) != ps2recomp::kKeywords.end())
         {
-            return "ps2_" + name;
+            return "ps2_" + sanitized;
         }
 
-        if (name.size() >= 2 && name[0] == '_' && (name[1] == '_' || std::isupper(static_cast<unsigned char>(name[1]))))
+        if (sanitized.size() >= 2 &&
+            sanitized[0] == '_' &&
+            (sanitized[1] == '_' ||
+                std::isupper(static_cast<unsigned char>(sanitized[1]))))
         {
-            return "ps2_" + name;
+            return "ps2_" + sanitized;
         }
-        return name;
+
+        return sanitized;
     }
 }


### PR DESCRIPTION
Decompiled PS2 function names may contain dots, which are invalid in C++.
This change replaces dots with underscores during name sanitization.

.   ->   _


<img width="984" height="277" alt="image" src="https://github.com/user-attachments/assets/43906617-40e2-46f5-b1ee-5172764224e9" />
