### PR TITLE
Add artifact upload step in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,3 +36,11 @@ jobs:
         continue-on-error: true # When tests start passing, this line should be removed.
         run: |
           .\build\ps2xTest\Release\ps2x_tests.exe
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: PS2Recomp - Windows
+          path: |
+            build/ps2xAnalyzer/Release/*.exe
+            build/ps2xRecomp/Release/*.exe
+            build/ps2xTest/Release/*.exe


### PR DESCRIPTION
Add step to upload build artifacts for PS2Recomp.

<img width="1294" height="376" alt="image" src="https://github.com/user-attachments/assets/1357bf6e-9b62-44ff-9901-222d62ecf82f" />

<img width="745" height="405" alt="image" src="https://github.com/user-attachments/assets/82e87215-debe-4de5-8dd4-64ea78e1c219" />

<img width="138" height="80" alt="image" src="https://github.com/user-attachments/assets/d4583e70-43b3-4ce9-9077-35c5ff4bd0c9" />

<img width="125" height="81" alt="image" src="https://github.com/user-attachments/assets/9fb2f524-0bc1-4952-b3a4-bd6c3b29e983" />

<img width="122" height="85" alt="image" src="https://github.com/user-attachments/assets/a2451021-9120-401f-88be-408fcf598bff" />

