### PR TITLE
Convert CodeGenerator::m_symbols to unordered_map to fix O(n) lookups

### DIFF
--- a/ps2xRecomp/include/ps2recomp/code_generator.h
+++ b/ps2xRecomp/include/ps2recomp/code_generator.h
@@ -39,7 +39,7 @@ namespace ps2recomp
                                                                   const std::vector<Instruction> &instructions);
 
     public:
-        std::vector<Symbol> m_symbols;
+        std::unordered_map<uint32_t, Symbol> m_symbols;
         std::unordered_map<uint32_t, std::string> m_renamedFunctions;
         BootstrapInfo m_bootstrapInfo;
 

--- a/ps2xRecomp/src/code_generator.cpp
+++ b/ps2xRecomp/src/code_generator.cpp
@@ -28,8 +28,10 @@ namespace ps2recomp
 namespace ps2recomp
 {
     CodeGenerator::CodeGenerator(const std::vector<Symbol> &symbols)
-        : m_symbols(symbols)
     {
+      for (auto& symbol : symbols) {
+        m_symbols.emplace(symbol.address, symbol);
+      }
     }
 
     void CodeGenerator::setRenamedFunctions(const std::unordered_map<uint32_t, std::string> &renames)
@@ -2573,12 +2575,9 @@ namespace ps2recomp
 
     Symbol *CodeGenerator::findSymbolByAddress(uint32_t address)
     {
-        for (auto &symbol : m_symbols)
-        {
-            if (symbol.address == address)
-            {
-                return &symbol;
-            }
+        auto it = m_symbols.find(address);
+        if (it != m_symbols.end()) {
+          return &it->second;
         }
 
         return nullptr;


### PR DESCRIPTION
A game I'm testing on has some weird interactions that duplicate a ton of code. This leads to extremely slow code generation due to hitting the `findSymbolByAddress` codepath, which ends up being an O(n) lookup into a `vector`. Switching this over got me from 61s to 17s on my 9950X3D.

Ideally the code duplication issue can be looked into and solved at some point (I've not tried yet), but this is a small and easy optimization.