### PR TITLE
fix: trailing backslash in PS2_STUB_LIST macro

### DIFF
--- a/ps2xRuntime/include/ps2_call_list.h
+++ b/ps2xRuntime/include/ps2_call_list.h
@@ -603,4 +603,4 @@
     X(syHwInit2)                              \
     X(syMallocInit)                           \
     X(syRtcInit)                              \
-    /* Game/middleware */                     \
+    /* Game/middleware */


### PR DESCRIPTION
Remove trailing backslash without continuation that was causing preprocessor errors during array initialization in ps2_runtime_calls.h.

This should fix #45 build problems too