### PR TITLE
Fix: correct MULT/MULTU rd-register write and EI/DI COP0 Status bit

### DIFF
--- a/ps2xRecomp/src/lib/code_generator.cpp
+++ b/ps2xRecomp/src/lib/code_generator.cpp
@@ -1258,9 +1258,9 @@ namespace ps2recomp
                     "return;"                      // Stop execution in this recompiled block
                 );
             case COP0_CO_EI:
-                return fmt::format("ctx->cop0_status |= 0x1; // Enable interrupts");
+                return fmt::format("ctx->cop0_status |= 0x10000; // Enable interrupts");
             case COP0_CO_DI:
-                return fmt::format("ctx->cop0_status &= ~0x1; // Disable interrupts");
+                return fmt::format("ctx->cop0_status &= ~0x10000; // Disable interrupts");
             default:
                 return fmt::format("// Unhandled COP0 CO-OP: 0x{:X}", function);
             }


### PR DESCRIPTION
- MULT/MULTU now write the rd register in addition to HI/LO, matching the R5900 extension behavior.
- EI/DI instructions now toggle COP0 Status bit 16 (EIE) instead of bit 0 (IE), matching the PS2 Emotion Engine specification .