### PR TITLE
Fix 'max'

### DIFF
--- a/ps2xRuntime/include/ps2_log.h
+++ b/ps2xRuntime/include/ps2_log.h
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <filesystem>
 #if defined(_WIN32)
+#define NOMINMAX
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
'(': ilegal token on right side of '::'
(std::max(0.0f, ft))

It was tested with the parameter `single_file_output = true`, but I believe that makes no difference.