### PR TITLE
Enable multithreaded compilation for ps2EntryRunner with MSVC /MP flag

### DIFF
--- a/ps2xRuntime/CMakeLists.txt
+++ b/ps2xRuntime/CMakeLists.txt
@@ -54,7 +54,7 @@ add_executable(ps2EntryRunner
 )
 
 if(MSVC)
-    target_compile_options(ps2EntryRunner PRIVATE /FS)
+    target_compile_options(ps2EntryRunner PRIVATE /FS /MP4)
 endif()
 
 target_include_directories(ps2_runtime PUBLIC


### PR DESCRIPTION
Add Multithreading for Building with /MP flag.
Tested this and it builds much faster