### PR TITLE
Fixed recompiler error when the cpp filename is too long

### DIFF
--- a/ps2xRecomp/include/ps2recomp/ps2_recompiler.h
+++ b/ps2xRecomp/include/ps2recomp/ps2_recompiler.h
@@ -40,6 +40,8 @@ namespace ps2recomp
             std::vector<Function> &functions,
             std::unordered_map<uint32_t, std::vector<Instruction>> &decodedFunctions);
 
+        static std::string ClampFilenameLength(const std::string& baseName, const std::string& extension, std::size_t maxLength);
+
     private:
         ConfigManager m_configManager;
         std::unique_ptr<ElfParser> m_elfParser;
@@ -70,7 +72,7 @@ namespace ps2recomp
         bool generateStubHeader();
         bool writeToFile(const std::string &path, const std::string &content);
         std::filesystem::path getOutputPath(const Function &function) const;
-        std::string clampFilenameLength(const std::string& baseName, const std::string& extension, std::size_t maxLength) const;
+        static std::string clampFilenameLength(const std::string& baseName, const std::string& extension, std::size_t maxLength);
         std::string sanitizeFunctionName(const std::string &name) const;       
     };
 

--- a/ps2xRecomp/src/lib/ps2_recompiler.cpp
+++ b/ps2xRecomp/src/lib/ps2_recompiler.cpp
@@ -1456,7 +1456,7 @@ namespace ps2recomp
         return outputPath;
     }
 
-    std::string PS2Recompiler::clampFilenameLength(const std::string& baseName, const std::string& extension, std::size_t maxLength) const
+    std::string PS2Recompiler::clampFilenameLength(const std::string& baseName, const std::string& extension, std::size_t maxLength)
     {
         if (maxLength == 0)
         {
@@ -1487,8 +1487,6 @@ namespace ps2recomp
 
         if (namePart.size() > available)
             namePart = namePart.substr(0, available);
-
-        std::cout << baseName << " filename will be truncated to " << namePart << " because is more than " << maxLength << " characters (" << baseName.length() << " characters)" << std::endl;
 
         return namePart + preservedSuffix + extension;
     }
@@ -1546,5 +1544,10 @@ namespace ps2recomp
             return StubTarget::Stub;
         }
         return StubTarget::Unknown;
+    }
+
+    std::string PS2Recompiler::ClampFilenameLength(const std::string& baseName, const std::string& extension, std::size_t maxLength)
+    {
+        return clampFilenameLength(baseName, extension, maxLength);
     }
 }

--- a/ps2xTest/src/ps2_recompiler_tests.cpp
+++ b/ps2xTest/src/ps2_recompiler_tests.cpp
@@ -513,5 +513,14 @@ void register_ps2_recompiler_tests()
 
             std::error_code removeError;
             std::filesystem::remove(elfPath, removeError);
-        }); });
+        });
+
+        tc.Run("respect max length for .cpp filenames", [](TestCase& t) {
+            
+            t.IsTrue(PS2Recompiler::ClampFilenameLength("ReallyLongFunctionNameReallyLongFunctionNameReallyLongFunctionName_0x12345678",".cpp",50).length() <= 50,"Function name must be max 50 characters");
+
+            t.IsTrue(PS2Recompiler::ClampFilenameLength("ReallyLongFunctionNameReallyLongFunctionNameReallyLongFunctionName_0x12345678", ".cpp", 50).rfind("0x12345678") != std::string::npos, "Function name must mantain the function address at the end, if present");
+            
+        });
+    });
 }


### PR DESCRIPTION
Fixes errors like:

`Failed to open file for writing: ./output/Insert__H1ZPC22AptFileSavedInputState_Q32EA6Stringt11BasicString2Zt22StringAsVectorEncoding1Z22AptFileSavedInputStateZ20StringAsVectorPolicyRCX00T1RCQ42EA6Stringt11BasicString2Zt22StringAsVectorEncoding1Z22AptFileSavedInputStateZ20StringAsVectorPolicy11DbgIterator_v_0x3d0768.cpp`

Now filename is truncated to a max of 100 characters, like this:

`Insert__H1ZPC22AptFileSavedInputState_Q32EA6Stringt11BasicString2Zt22StringAsVectorEnco_0x3d0768.cpp`

I decided 100 as max filename length, with 200 characters I was getting unspecified compiler errors. Under 100 characters looks like the sweet spot.