### PR TITLE
elf_parser: clamp overlapping function boundaries from external sources

### DIFF
--- a/ps2xRecomp/src/lib/elf_parser.cpp
+++ b/ps2xRecomp/src/lib/elf_parser.cpp
@@ -797,6 +797,27 @@ namespace ps2recomp
             func.end = (nextStart > func.start) ? nextStart : (func.start + 4);
         }
 
+        // Clamp overlapping functions.  Ghidra sometimes reports parent functions
+        // whose range includes nested sub-functions (e.g. 0x1046B8 spanning
+        // 456 bytes when it should be 52).  Without this clamp the recompiler
+        // emits one giant body containing the sub-functions inline, and the
+        // pc-mismatch checks on sub-calls cause cascading early returns.
+        //
+        // Entry slices (alternate entry points into the same function body)
+        // start within a few bytes of the parent (e.g. 0x15D680 and
+        // game_loop_body at 0x15D684).  These must NOT be clamped — doing so
+        // would truncate the parent to just a few bytes.  We use a 16-byte
+        // threshold: if the next function starts within 16 bytes, it is likely
+        // an entry slice and we skip the clamp.
+        for (size_t index = 0; index + 1 < functions.size(); index++)
+        {
+            uint32_t gap = functions[index + 1].start - functions[index].start;
+            if (functions[index].end > functions[index + 1].start && gap >= 16)
+            {
+                functions[index].end = functions[index + 1].start;
+            }
+        }
+
         return functions;
     }
 


### PR DESCRIPTION
## Problem

When function boundaries come from an external source (e.g. a Ghidra auto-analysis export), the reported ranges can overlap: a parent function's length is reported as including its nested sub-functions. A concrete example seen in the wild is a 52-byte function reported as 456 bytes because Ghidra's auto-analysis folded nested `sub_xxx` children into the parent's size.

When the recompiler imports these, `extractFunctions()` happily keeps both the oversized parent and the nested children. The parent then gets code-generated with all the sub-function bodies inlined, and the per-call PC-mismatch safety checks inside the inlined sub-calls cascade early-returns up the entire call chain at runtime.

## Fix

After merging all function sources in `extractFunctions()`, walk the sorted function list and clamp each function's end to the start of the next function. An exemption is carved out when the gap is `< 16` bytes so that the legitimate "entry-slice" pattern (multiple entry points into a single logical function, spaced a few instructions apart) is preserved.

## Scope

- One file touched: `ps2xRecomp/src/lib/elf_parser.cpp`
- +21 / -0
- No behavioural change for well-formed function maps — the clamp only fires when the imported data is actually inconsistent.

## Rationale

This is purely defensive. The recompiler already expects non-overlapping function ranges; this commit enforces that invariant at import time instead of letting the downstream codegen produce wrong output silently.