### PR TITLE
codegen: safety fallback + entry-slice boundary fix for truncated functions (#86)

### DIFF
--- a/ps2xRecomp/src/lib/code_generator.cpp
+++ b/ps2xRecomp/src/lib/code_generator.cpp
@@ -1003,6 +1003,12 @@ namespace ps2recomp
             }
         }
 
+        // Safety fallback: if execution reaches here, the function boundary
+        // was incomplete (missing jr $ra). Return via $ra to prevent ctx->pc
+        // from being left in a bad state, which would cascade returns up the
+        // entire call chain. For correctly-terminated functions this is
+        // unreachable dead code after the jr $ra return block.
+        ss << "    ctx->pc = GPR_U32(ctx, 31); return;\n";
         ss << "}\n";
         return ss.str();
     }

--- a/ps2xRecomp/src/lib/ps2_recompiler.cpp
+++ b/ps2xRecomp/src/lib/ps2_recompiler.cpp
@@ -636,10 +636,22 @@ namespace ps2recomp
 
                 const Function *containingFunction = findContainingFunction(function.start);
                 uint32_t sliceEndAddress = containingFunction ? containingFunction->end : function.end;
+                // Only clamp to boundaries OUTSIDE the containing function.
+                // Sub-functions inside the parent (e.g. Ghidra-detected sub_xxx)
+                // must not truncate sibling entry slices that share the parent range.
+                uint32_t parentEnd = sliceEndAddress;
                 auto nextIt = std::upper_bound(boundaryStarts.begin(), boundaryStarts.end(), function.start);
-                if (nextIt != boundaryStarts.end() && *nextIt < sliceEndAddress)
+                while (nextIt != boundaryStarts.end() && *nextIt < parentEnd)
                 {
+                    // Skip boundaries inside the containing function — they are
+                    // sub-functions, not real function starts that should truncate us.
+                    if (containingFunction && *nextIt < containingFunction->end)
+                    {
+                        ++nextIt;
+                        continue;
+                    }
                     sliceEndAddress = *nextIt;
+                    break;
                 }
 
                 if (sliceEndAddress <= function.start)


### PR DESCRIPTION
Addresses #86. Two small, independent fixes for functions whose last instruction is not `jr \$ra` — either because the source really lacks a tail return, or because the imported function boundary is wrong and the real `jr \$ra` lives past the reported end.

## Fix 1 — Implicit safety fallback at function end (`code_generator.cpp`)

Emit an implicit
```cpp
ctx->pc = GPR_U32(ctx, 31);
return;
```
at the end of every generated function body.

- For well-formed functions this is unreachable dead code (the preceding `jr \$ra` already returned).
- For functions with incorrect boundaries, it returns cleanly via `\$ra` instead of leaving `ctx->pc` at whatever value the last fall-through instruction set, which previously caused cascading wrong returns up the call chain.

## Fix 2 — Skip boundary starts inside a containing parent (`ps2_recompiler.cpp`)

When reslicing entry functions, skip any boundary start that falls *inside* the range of the containing parent function.

Ghidra-style `sub_xxx` children inside a parent were creating "boundary" entries that truncated sibling entry slices before their `jr \$ra`, producing half-functions that would fall off the end at runtime.

## Scope

- `ps2xRecomp/src/lib/code_generator.cpp`: +6 / -0
- `ps2xRecomp/src/lib/ps2_recompiler.cpp`: +13 / -1
- No change in behaviour for correct inputs.