### PR TITLE
codegen: emit lookupFunction dispatch for external jump-table targets

### DIFF
--- a/ps2xRecomp/include/ps2recomp/code_generator.h
+++ b/ps2xRecomp/include/ps2recomp/code_generator.h
@@ -38,6 +38,10 @@ namespace ps2recomp
         struct AnalysisResult {
             std::unordered_set<uint32_t> entryPoints;
             std::unordered_map<uint32_t, std::vector<uint32_t>> jumpTableTargets;
+            // Targets from TOML-configured jump tables that are OUTSIDE the
+            // function boundary. Codegen emits lookupFunction calls for these
+            // instead of internal goto labels.
+            std::unordered_set<uint32_t> externalJumpTableTargets;
         };
 
         std::string generateFunction(const Function &function, const std::vector<Instruction> &instructions, const bool &useHeaders);

--- a/ps2xRecomp/src/lib/code_generator.cpp
+++ b/ps2xRecomp/src/lib/code_generator.cpp
@@ -432,7 +432,22 @@ namespace ps2recomp
                 ss << "        switch (jumpTarget) {\n";
                 for (uint32_t t : sortedInternalTargets)
                 {
-                    ss << fmt::format("            case 0x{:X}u: goto label_{:x};\n", t, t);
+                    if (analysisResult.externalJumpTableTargets.contains(t))
+                    {
+                        // External target from TOML config: emit lookupFunction
+                        // call. The target is in a different compiled function
+                        // (e.g., a jump table case block in another CSV entry).
+                        // After the call, chain if pc stays in the external range.
+                        ss << fmt::format("            case 0x{:X}u: {{\n", t);
+                        ss << "                auto __extFn = runtime->lookupFunction(jumpTarget);\n";
+                        ss << "                if (__extFn) __extFn(rdram, ctx, runtime);\n";
+                        ss << "                return;\n";
+                        ss << "            }\n";
+                    }
+                    else
+                    {
+                        ss << fmt::format("            case 0x{:X}u: goto label_{:x};\n", t, t);
+                    }
                 }
                 ss << "            default: break;\n";
                 ss << "        }\n";
@@ -781,26 +796,48 @@ namespace ps2recomp
                             const auto configuredTableIt = m_configJumpTableTargetsByAddress.find(tableAddress);
                             if (configuredTableIt != m_configJumpTableTargetsByAddress.end())
                             {
-                                std::vector<uint32_t> jrTargets;
-                                jrTargets.reserve(configuredTableIt->second.size());
+                                std::vector<uint32_t> internalTargets;
+                                std::vector<uint32_t> externalTargets;
                                 for (uint32_t target : configuredTableIt->second)
                                 {
                                     if (target >= function.start && target < function.end &&
                                         instructionAddresses.contains(target))
                                     {
-                                        jrTargets.push_back(target);
+                                        internalTargets.push_back(target);
+                                    }
+                                    else
+                                    {
+                                        externalTargets.push_back(target);
                                     }
                                 }
 
-                                if (!jrTargets.empty())
+                                // Internal targets: handled as goto labels (existing path)
+                                if (!internalTargets.empty())
                                 {
-                                    std::sort(jrTargets.begin(), jrTargets.end());
-                                    jrTargets.erase(std::unique(jrTargets.begin(), jrTargets.end()), jrTargets.end());
-                                    result.jumpTableTargets[jrInst->address] = jrTargets;
-                                    for (uint32_t target : jrTargets)
+                                    std::sort(internalTargets.begin(), internalTargets.end());
+                                    internalTargets.erase(std::unique(internalTargets.begin(), internalTargets.end()), internalTargets.end());
+                                    result.jumpTableTargets[jrInst->address] = internalTargets;
+                                    for (uint32_t target : internalTargets)
                                     {
                                         result.entryPoints.insert(target);
                                     }
+                                    foundTable = true;
+                                }
+
+                                // External targets: will be emitted as function calls
+                                // in the jr dispatch switch. Store them alongside internal
+                                // targets so the codegen can emit both gotos and calls.
+                                if (!externalTargets.empty())
+                                {
+                                    auto &targets = result.jumpTableTargets[jrInst->address];
+                                    for (uint32_t target : externalTargets)
+                                    {
+                                        targets.push_back(target);
+                                    }
+                                    std::sort(targets.begin(), targets.end());
+                                    targets.erase(std::unique(targets.begin(), targets.end()), targets.end());
+                                    // Mark external targets so codegen emits calls not gotos
+                                    result.externalJumpTableTargets.insert(externalTargets.begin(), externalTargets.end());
                                     foundTable = true;
                                 }
                             }


### PR DESCRIPTION
## Problem

When a `[[jump_tables.table]]` entry in the TOML config has targets that live *outside* the enclosing function's boundary, the previous codegen silently filtered them out. Those external targets would then be unreachable from the recompiled jump, which at runtime manifests as a wrong branch destination (or a no-op, depending on the dispatch path).

## Fix

- Teach analysis to distinguish internal jump-table targets (which still use `goto`-to-label dispatch inside the function body) from external ones.
- Emit a runtime `lookupFunction(0x…)` dispatch call for the external targets, matching the fallback path already used for unresolved static `J`/`JAL` sites (per the README's "unresolved static J/JAL" behaviour).
- Add an `externalJumpTableTargets` field to `AnalysisResult` so the two categories can be separated during codegen instead of being decided in the emitter.

## Scope

- `ps2xRecomp/include/ps2recomp/code_generator.h`: +4 / -0
- `ps2xRecomp/src/lib/code_generator.cpp`: +46 / -9

## Rationale

The recompiler already has a principled fallback for unresolved static calls (`runtime->lookupFunction(...)`), so routing external jump-table targets through the same mechanism fits the existing model and makes the previously-filtered targets actually reachable at runtime.