### PR TITLE
codegen: use GPR_S64 for EE sign-tested branches (BLEZ/BGTZ/BLTZ/BGEZ + variants)

### DIFF
--- a/ps2xRecomp/src/lib/code_generator.cpp
+++ b/ps2xRecomp/src/lib/code_generator.cpp
@@ -478,10 +478,10 @@ namespace ps2recomp
                 conditionStr = fmt::format("GPR_U64(ctx, {}) != GPR_U64(ctx, {})", rs_reg, rt_reg);
                 break;
             case OPCODE_BLEZ:
-                conditionStr = fmt::format("GPR_S32(ctx, {}) <= 0", rs_reg);
+                conditionStr = fmt::format("GPR_S64(ctx, {}) <= 0", rs_reg);
                 break;
             case OPCODE_BGTZ:
-                conditionStr = fmt::format("GPR_S32(ctx, {}) > 0", rs_reg);
+                conditionStr = fmt::format("GPR_S64(ctx, {}) > 0", rs_reg);
                 break;
             case OPCODE_BEQL:
                 conditionStr = fmt::format("GPR_U64(ctx, {}) == GPR_U64(ctx, {})", rs_reg, rt_reg);
@@ -490,40 +490,40 @@ namespace ps2recomp
                 conditionStr = fmt::format("GPR_U64(ctx, {}) != GPR_U64(ctx, {})", rs_reg, rt_reg);
                 break;
             case OPCODE_BLEZL:
-                conditionStr = fmt::format("GPR_S32(ctx, {}) <= 0", rs_reg);
+                conditionStr = fmt::format("GPR_S64(ctx, {}) <= 0", rs_reg);
                 break;
             case OPCODE_BGTZL:
-                conditionStr = fmt::format("GPR_S32(ctx, {}) > 0", rs_reg);
+                conditionStr = fmt::format("GPR_S64(ctx, {}) > 0", rs_reg);
                 break;
             case OPCODE_REGIMM:
                 switch (rt_reg)
                 {
                 case REGIMM_BLTZ:
-                    conditionStr = fmt::format("GPR_S32(ctx, {}) < 0", rs_reg);
+                    conditionStr = fmt::format("GPR_S64(ctx, {}) < 0", rs_reg);
                     break;
                 case REGIMM_BGEZ:
-                    conditionStr = fmt::format("GPR_S32(ctx, {}) >= 0", rs_reg);
+                    conditionStr = fmt::format("GPR_S64(ctx, {}) >= 0", rs_reg);
                     break;
                 case REGIMM_BLTZL:
-                    conditionStr = fmt::format("GPR_S32(ctx, {}) < 0", rs_reg);
+                    conditionStr = fmt::format("GPR_S64(ctx, {}) < 0", rs_reg);
                     break;
                 case REGIMM_BGEZL:
-                    conditionStr = fmt::format("GPR_S32(ctx, {}) >= 0", rs_reg);
+                    conditionStr = fmt::format("GPR_S64(ctx, {}) >= 0", rs_reg);
                     break;
                 case REGIMM_BLTZAL:
-                    conditionStr = fmt::format("GPR_S32(ctx, {}) < 0", rs_reg);
+                    conditionStr = fmt::format("GPR_S64(ctx, {}) < 0", rs_reg);
                     unconditionalLinkCode = fmt::format("SET_GPR_U32(ctx, 31, 0x{:X}u);", fallthroughPc);
                     break;
                 case REGIMM_BGEZAL:
-                    conditionStr = fmt::format("GPR_S32(ctx, {}) >= 0", rs_reg);
+                    conditionStr = fmt::format("GPR_S64(ctx, {}) >= 0", rs_reg);
                     unconditionalLinkCode = fmt::format("SET_GPR_U32(ctx, 31, 0x{:X}u);", fallthroughPc);
                     break;
                 case REGIMM_BLTZALL:
-                    conditionStr = fmt::format("GPR_S32(ctx, {}) < 0", rs_reg);
+                    conditionStr = fmt::format("GPR_S64(ctx, {}) < 0", rs_reg);
                     conditionalLinkCode = fmt::format("SET_GPR_U32(ctx, 31, 0x{:X}u);", fallthroughPc);
                     break;
                 case REGIMM_BGEZALL:
-                    conditionStr = fmt::format("GPR_S32(ctx, {}) >= 0", rs_reg);
+                    conditionStr = fmt::format("GPR_S64(ctx, {}) >= 0", rs_reg);
                     conditionalLinkCode = fmt::format("SET_GPR_U32(ctx, 31, 0x{:X}u);", fallthroughPc);
                     break;
                 default:


### PR DESCRIPTION
## Problem

The codegen for EE sign-tested branches — `BLEZ`, `BGTZ`, `BLTZ`, `BGEZ`, and all of their `*L` (likely) and `*AL` (link) variants — was comparing `GPR_S32`, i.e. only the low 32 bits of the register treated as signed.

The PS2 EE evaluates these branches against the **full 64-bit GPR**. A GPR with non-zero upper bits whose low 32 bits happened to look positive (or negative) under truncation would branch the opposite way from how real hardware does.

## Fix

Switch the comparisons for all eight instructions (`BLEZ`, `BGTZ`, `BLTZ`, `BGEZ`, `BLEZL`, `BGTZL`, `BLTZL`, `BGEZL` — plus `BLTZAL`, `BGEZAL` and their likely variants) from `GPR_S32` to `GPR_S64`.

## Scope

- One file: `ps2xRecomp/src/lib/code_generator.cpp`
- +12 / -12 (one format-string change per branch opcode)

## Rationale

The EE's GPRs are 64-bit, and `blez`/`bgtz`/`bltz`/`bgez` sign-test the whole register per the R5900 Core User's Manual. The `GPR_S32` emission was a latent bug that only manifests when a register legitimately holds a value whose 32-bit truncation flips the sign — uncommon in hand-written asm, but not rare in compiler output that manipulates 64-bit quantities.

Fully standalone; no dependencies on other PRs.