### PR TITLE
GS rasterizer rework

### DIFF
--- a/ps2xRuntime/CMakeLists.txt
+++ b/ps2xRuntime/CMakeLists.txt
@@ -167,6 +167,7 @@ add_library(ps2_runtime STATIC
     src/lib/ps2_audio.cpp
     src/lib/ps2_audio_vag.cpp
     src/lib/ps2_gs_gpu.cpp
+    src/lib/ps2_gs_memory.cpp
     src/lib/ps2_gs_rasterizer.cpp
     src/lib/ps2_iop.cpp
     src/lib/ps2_iop_audio.cpp

--- a/ps2xRuntime/include/runtime/ps2_gs_gpu.h
+++ b/ps2xRuntime/include/runtime/ps2_gs_gpu.h
@@ -1,11 +1,14 @@
 #ifndef PS2_GS_GPU_H
 #define PS2_GS_GPU_H
 
-#include "ps2_gs_rasterizer.h"
+#include <functional>
 #include <cstdint>
 #include <cstring>
 #include <mutex>
 #include <vector>
+
+#include "ps2_gs_rasterizer.h"
+#include "ps2_gs_memory.h"
 
 enum GSPrimType : uint8_t
 {
@@ -249,6 +252,9 @@ public:
 
     void refreshDisplaySnapshot();
 
+    inline void WriteVram(u32 psm, uint32_t base, uint32_t bw, uint32_t x, uint32_t y, uint32_t value);
+    inline u32 ReadVram(u32 psm, u32 base, u32 bw, u32 x, u32 y) const;
+
 private:
     void snapshotVRAM();
     void writeRegisterPacked(uint8_t regDesc, uint64_t lo, uint64_t hi);
@@ -324,6 +330,22 @@ private:
     size_t m_localToHostReadPos = 0;
 
     GSRasterizer m_rasterizer;
+
+    using WriteVramFunc = std::function<void(u8*, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t)>;
+    using ReadVramFunc = std::function<u32(u8*, u32, u32, u32, u32)>;
+
+    std::array<ReadVramFunc, 0x3F> m_read_vram_funcs{ };
+    std::array<WriteVramFunc, 0x3F> m_write_vram_funcs{ };
 };
+
+inline u32 GS::ReadVram(u32 psm, u32 base, u32 bw, u32 x, u32 y) const
+{
+    return m_read_vram_funcs[psm & 0x3F](m_vram, base, bw, x, y);
+}
+
+inline void GS::WriteVram(u32 psm, u32 base, u32 bw, u32 x, u32 y, u32 value)
+{
+    m_write_vram_funcs[psm & 0x3F](m_vram, base, bw, x, y, value);
+}
 
 #endif

--- a/ps2xRuntime/include/runtime/ps2_gs_gpu.h
+++ b/ps2xRuntime/include/runtime/ps2_gs_gpu.h
@@ -108,7 +108,9 @@ enum GSRegId : uint8_t
 
 struct GSVertex
 {
-    float x, y, z;
+    float x, y;
+    // double because float isnt accurate enough for values near UINT32_MAX
+    double z;
     uint8_t r, g, b, a;
     float q;
     float s, t;
@@ -122,6 +124,13 @@ struct GSFrameReg
     uint32_t fbw;
     uint8_t psm;
     uint32_t fbmsk;
+};
+
+struct GSZbufReg
+{
+    u32 zbp;
+    u8 psm;
+    bool zmask;
 };
 
 struct GSScissorReg
@@ -171,7 +180,7 @@ struct GSContext
     GSScissorReg scissor;
     GSTex0Reg tex0;
     GSXYOffsetReg xyoffset;
-    uint64_t zbuf;
+    GSZbufReg zbuf;
     uint64_t tex1;
     uint64_t clamp;
     uint64_t alpha;

--- a/ps2xRuntime/include/runtime/ps2_gs_gpu.h
+++ b/ps2xRuntime/include/runtime/ps2_gs_gpu.h
@@ -292,8 +292,14 @@ private:
     GSTrxPos m_trxpos{};
     GSTrxReg m_trxreg{};
     uint32_t m_trxdir = 3;
-    uint32_t m_hwregX = 0;
-    uint32_t m_hwregY = 0;
+
+    struct
+    {
+        uint32_t x{ 0 };
+        uint32_t y{ 0 };
+        uint32_t total_pixels{ 0 };
+        uint32_t copied_pixels{ 0 };
+    } m_transferState;
 
     static constexpr int kMaxVerts = 6;
     GSVertex m_vtxQueue[kMaxVerts];

--- a/ps2xRuntime/include/runtime/ps2_gs_memory.h
+++ b/ps2xRuntime/include/runtime/ps2_gs_memory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include <type_traits>
 #include <array>
 #include <span>

--- a/ps2xRuntime/include/runtime/ps2_gs_memory.h
+++ b/ps2xRuntime/include/runtime/ps2_gs_memory.h
@@ -553,6 +553,8 @@ namespace GSMem
 	void WriteP4HH(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
 	void WriteP4HL(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
 
+	void WriteNull(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
+
 	u32 ReadCT32(u8* data, u32 bp, u32 bw, u32 x, u32 y);
 	u32 ReadZ32(u8* data, u32 bp, u32 bw, u32 x, u32 y);
 
@@ -573,4 +575,6 @@ namespace GSMem
 	u32 ReadP4(u8* data, u32 bp, u32 bw, u32 x, u32 y);
 	u32 ReadP4HL(u8* data, u32 bp, u32 bw, u32 x, u32 y);
 	u32 ReadP4HH(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+
+	u32 ReadNull(u8* data, u32 bp, u32 bw, u32 x, u32 y);
 }

--- a/ps2xRuntime/include/runtime/ps2_gs_memory.h
+++ b/ps2xRuntime/include/runtime/ps2_gs_memory.h
@@ -1,0 +1,575 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+#include <array>
+#include <span>
+
+#include "types.h"
+
+namespace GSMem
+{
+	constexpr usz MEMORY_SIZE = 4_mb;
+	constexpr usz PAGE_SIZE = 8_kb;
+
+	// these are all the same regardless of storage mode
+	constexpr usz BLOCKS_PER_PAGE = 32;
+	constexpr usz COLUMNS_PER_BLOCK = 4;
+
+	// note:
+	// there are others (FFX uses 0x11 as an alias for CT24)
+	// these are just the official ones
+	enum class PixelStorageMode
+	{
+		C32 = 0x00, // 32 bit color
+		C24 = 0x01, // 24 bit color
+		C16 = 0x02, // 16 bit color
+		C16S = 0x0A, // 16 bit color (32 bit compatible memory layout)
+		P8 = 0x13, // 8 bit index
+		P4 = 0x14, // 4 bit index
+		P8H = 0x1B, // 8 bit index (stored in upper 8 bits of 32 bit)
+		P4HL = 0x24, // 4 bit index (stored in low nibble of upper 8 bits of 32 bit)
+		P4HH = 0x2C, // 4 bit index (stored in high nibble of upper 8 bits of 32 bit)
+		Z32 = 0x30, // 32 bit depth
+		Z24 = 0x31, // 24 bit depth
+		Z16 = 0x32, // 16 bit depth
+		Z16S = 0x3A, // 16 bit depth (32 bit compatible memory layout)
+		Max = 0x3F // 6 bits of values
+	};
+
+	struct Extent2D
+	{
+		u32 x{ 0 };
+		u32 y{ 0 };
+	};
+
+	template<typename T, Extent2D Extent>
+	using LookupTable = std::array<std::array<T, Extent.x>, Extent.y>;
+
+	constexpr bool IsValidPsm(PixelStorageMode psm)
+	{
+		using enum PixelStorageMode;
+
+		switch (psm)
+		{
+		case C32:
+		case Z32:
+		case C24:
+		case Z24:
+		case C16:
+		case C16S:
+		case Z16:
+		case Z16S:
+		case P8:
+		case P8H:
+		case P4:
+		case P4HH:
+		case P4HL:
+			return true;
+		}
+
+		return false;
+	}
+
+	// Bits per pixel in unpacked format (GS memory)
+	constexpr usz UnpackedBitWidth(PixelStorageMode psm)
+	{
+		using enum PixelStorageMode;
+
+		switch (psm)
+		{
+		case C32:
+		case Z32:
+		case C24:
+		case Z24:
+		case P8H:  // unpacked to alpha of 32
+		case P4HH: // unpacked to alpha of 32
+		case P4HL: // unpacked to alpha of 32
+			return 32;
+		case C16:
+		case C16S:
+		case Z16:
+		case Z16S:
+			return 16;
+		case P8:
+			return 8;
+		case P4:
+			return 4;
+		}
+
+		return 32;
+	}
+
+	// bits per pixel (packed width)
+	constexpr usz BitsPerPixel(PixelStorageMode psm)
+	{
+		using enum PixelStorageMode;
+
+		switch (psm)
+		{
+		case C32:
+		case Z32:
+			return 32;
+		case C24:
+		case Z24:
+			return 24;
+		case C16:
+		case C16S:
+		case Z16:
+		case Z16S:
+			return 16;
+		case P8:
+		case P8H:
+			return 8;
+		case P4:
+		case P4HH:
+		case P4HL:
+			return 4;
+		default:
+			break;
+		}
+
+		return 32;
+	}
+
+	constexpr bool IsDepth(PixelStorageMode psm)
+	{
+		using enum PixelStorageMode;
+
+		switch (psm)
+		{
+		case Z16:
+		case Z16S:
+		case Z24:
+		case Z32:
+			return true;
+		default:
+			break;
+		}
+
+		return false;
+	}
+
+	constexpr bool IsColor(PixelStorageMode psm)
+	{
+		return !IsDepth(psm);
+	}
+
+	constexpr bool IsPaletted(PixelStorageMode psm)
+	{
+		using enum PixelStorageMode;
+
+		switch (psm)
+		{
+		case P8:
+		case P8H:
+		case P4:
+		case P4HL:
+		case P4HH:
+			return true;
+		}
+
+		return false;
+	}
+
+	template<usz BitCount>
+	struct BitStorageHelper;
+
+	template<>
+	struct BitStorageHelper<4>
+	{
+		using Type = u8;
+	};
+
+	template<>
+	struct BitStorageHelper<8>
+	{
+		using Type = u8;
+	};
+
+	template<>
+	struct BitStorageHelper<16>
+	{
+		using Type = u16;
+	};
+
+	template<>
+	struct BitStorageHelper<24>
+	{
+		using Type = u32;
+	};
+
+	template<>
+	struct BitStorageHelper<32>
+	{
+		using Type = u32;
+	};
+
+	template<PixelStorageMode psm>
+	struct PixelStorageTraits
+	{
+		using enum PixelStorageMode;
+
+		// page extent, in units of pixels
+		static constexpr Extent2D PageExtent();
+
+		// block size in a page, in units of blocks
+		static constexpr Extent2D BlockExtent();
+
+		// column extent in a block, in units of pixels
+		static constexpr Extent2D ColumnExtent();
+
+		// block count in a page (always 32 for valid psm)
+		static constexpr usz BlocksPerPage();
+
+		// pixel count in a block
+		static constexpr usz PixelsPerBlock();
+
+		// pixel count in a page
+		static constexpr usz PixelsPerPage();
+
+		using BlockLookupTableT = LookupTable<u8, BlockExtent()>;
+		using ColumnLookupTableT = LookupTable<u16, ColumnExtent()>;
+		using PageLookupTableT = std::array<LookupTable<u16, PageExtent()>, BlocksPerPage()>;
+
+		// calculates the column offset
+		static constexpr usz ColumnId(const ColumnLookupTableT& table, u32 x, u32 y);
+
+		// calculates the block offset
+		static constexpr usz BlockId(const BlockLookupTableT& table, u32 x, u32 y);
+
+		// calculates the page offset
+		static constexpr usz PageId(u32 base, u32 bw, u32 x, u32 y);
+
+		// sets up the lookup table which precomputes a bunch of math for us
+		static constexpr void InitPageLookupTable(PageLookupTableT& table, const BlockLookupTableT& block_table, const ColumnLookupTableT& column_table);
+
+		// gets a pixel address
+		static constexpr u32 Address(const PageLookupTableT& table, u32 block, u32 bw, u32 x, u32 y);
+
+		using PackedT = BitStorageHelper<BitsPerPixel(psm)>::Type;
+		using UnapckedT = BitStorageHelper<UnpackedBitWidth(psm)>::Type;
+
+		// returns a offset into a 32 bit word (P8H, P4HH, P4HL)
+		static constexpr usz BitOffset();
+
+		// writes the pixel
+		static constexpr void Write(const PageLookupTableT& table, u8* data, u32 block, u32 bw, u32 x, u32 y, PackedT value);
+
+		// reads the pixel
+		static constexpr auto Read(const PageLookupTableT& table, u8* data, u32 block, u32 bw, u32 x, u32 y) -> PackedT;
+
+		static_assert(BlocksPerPage() == BLOCKS_PER_PAGE);
+		static_assert(IsValidPsm(psm));
+	};
+
+	template<PixelStorageMode psm>
+	constexpr Extent2D PixelStorageTraits<psm>::PageExtent()
+	{
+		switch (psm)
+		{
+		case C32:
+		case Z32:
+		case C24:
+		case Z24:
+		case P8H:
+		case P4HL:
+		case P4HH:
+			return { 64, 32 };
+		case C16:
+		case C16S:
+		case Z16:
+		case Z16S:
+			return { 64, 64 };
+		case P8:
+			return { 128, 64 };
+		case P4:
+			return { 128, 128 };
+		}
+	}
+
+	template<PixelStorageMode psm>
+	constexpr Extent2D PixelStorageTraits<psm>::BlockExtent()
+	{
+		switch (psm)
+		{
+		case C32:
+		case C24:
+		case P8H:
+		case P4HL:
+		case P4HH:
+		case Z32:
+		case Z24:
+		case P8:
+			return { 8, 4 };
+		case C16:
+		case C16S:
+		case Z16:
+		case Z16S:
+		case P4:
+			return { 4, 8 };
+		default:
+			break;
+		}
+
+		return { 0, 0 };
+	}
+
+	template<PixelStorageMode psm>
+	constexpr Extent2D PixelStorageTraits<psm>::ColumnExtent()
+	{
+		switch (psm)
+		{
+		case C32:
+		case Z32:
+		case C24:
+		case P8H:
+		case P4HL:
+		case P4HH:
+			return { 8, 8 };
+		case C16:
+		case C16S:
+		case Z16:
+		case Z16S:
+			return { 16, 8 };
+		case P8:
+			return { 16, 16 };
+		case P4:
+			return { 32, 16 };
+		}
+
+		return { 0, 0 };
+	}
+
+	template<PixelStorageMode psm>
+	constexpr usz PixelStorageTraits<psm>::BlocksPerPage()
+	{
+		const auto extent = BlockExtent();
+
+		return static_cast<usz>(extent.x) * static_cast<usz>(extent.y);
+	}
+
+	template<PixelStorageMode psm>
+	constexpr usz PixelStorageTraits<psm>::PixelsPerBlock()
+	{
+		constexpr auto extent = ColumnExtent();
+
+		return static_cast<usz>(extent.x) * extent.y;
+	}
+
+	template<PixelStorageMode psm>
+	constexpr usz PixelStorageTraits<psm>::PixelsPerPage()
+	{
+		constexpr auto extent = PageExtent();
+
+		return static_cast<usz>(extent.x) * extent.y;
+	}
+
+	template<PixelStorageMode psm>
+	constexpr usz PixelStorageTraits<psm>::ColumnId(const ColumnLookupTableT& table, u32 x, u32 y)
+	{
+		constexpr auto extent = ColumnExtent();
+
+		// wrap along the column extent
+		y = y % extent.y;
+		x = x % extent.x;
+
+		return table[y][x];
+	}
+
+	template<PixelStorageMode psm>
+	constexpr usz PixelStorageTraits<psm>::BlockId(const BlockLookupTableT& table, u32 x, u32 y)
+	{
+		constexpr auto block_extent = BlockExtent();
+		constexpr auto column_extent = ColumnExtent();
+
+		y = (y / column_extent.y) % block_extent.y;
+		x = (x / column_extent.x) % block_extent.x;
+
+		return table[y][x];
+	}
+
+	template<PixelStorageMode psm>
+	constexpr usz PixelStorageTraits<psm>::PageId(u32 base, u32 bw, u32 x, u32 y)
+	{
+		constexpr auto page_extent = PageExtent();
+
+		const u32 base_page = base / BlocksPerPage();
+		const u32 row = (y / page_extent.y) * ((bw * 64) / page_extent.x); // T8 and T4 need a / 2 of bw
+		const u32 col = x / page_extent.x;
+
+		return static_cast<usz>(base_page) + row + col;
+	}
+
+	template<PixelStorageMode psm>
+	constexpr void PixelStorageTraits<psm>::InitPageLookupTable(PageLookupTableT& table, const BlockLookupTableT& block_table, const ColumnLookupTableT& column_table)
+	{
+		constexpr auto page_extent = PageExtent();
+		constexpr auto pixels_per_block = PixelsPerBlock();
+		constexpr auto blocks_per_page = BlocksPerPage();
+
+		for (usz block = 0; block < blocks_per_page; ++block)
+		{
+			for (usz y = 0; y < page_extent.y; ++y)
+			{
+				for (usz x = 0; x < page_extent.x; ++x)
+				{
+					table[block][y][x] = ((block + BlockId(block_table, x, y)) * PixelsPerBlock()) + ColumnId(column_table, x, y);
+				}
+			}
+		}
+	}
+
+	template<PixelStorageMode psm>
+	constexpr u32 PixelStorageTraits<psm>::Address(const PageLookupTableT& table, u32 block, u32 bw, u32 x, u32 y)
+	{
+		constexpr auto block_count = BlocksPerPage();
+		constexpr auto page_extent = PageExtent();
+		constexpr auto pixels_per_page = PixelsPerPage();
+
+		const u32 page = PageId(block, bw, x, y);
+
+		block = block % block_count;
+		y = y % page_extent.y;
+		x = x % page_extent.x;
+
+		return (page * PixelsPerPage()) + table[block][y][x];
+	}
+
+	template<PixelStorageMode psm>
+	constexpr usz PixelStorageTraits<psm>::BitOffset()
+	{
+		switch (psm)
+		{
+		case P8H:
+		case P4HL:
+			return 24;
+		case P4HH:
+			return 28;
+		default:
+			break;
+		}
+
+		return 0;
+	}
+
+	template<PixelStorageMode psm>
+	constexpr void PixelStorageTraits<psm>::Write(const PageLookupTableT& table, u8* data, u32 block, u32 bw, u32 x, u32 y, PackedT value)
+	{
+		const u32 pixel_addr = Address(table, block, bw, x, y);
+		const u32 bits = pixel_addr * UnpackedBitWidth(psm) + BitOffset();
+		const u32 byte_addr = (bits / 8) & (MEMORY_SIZE - sizeof(PackedT));
+		const u32 shift = bits % 8;
+
+		u8* ptr = &data[byte_addr];
+
+		PackedT old;
+		std::memcpy(&old, ptr, sizeof(PackedT));
+
+		switch (psm)
+		{
+		case C32:
+		case Z32:
+		case C16:
+		case C16S:
+		case Z16:
+		case Z16S:
+		case P8:
+		case P8H:
+			std::memcpy(ptr, &value, sizeof(PackedT));
+			break;
+		case C24:
+		case Z24:
+			// RMW
+			value = (old & 0xFF000000) | (value & 0x00FFFFFF);
+			std::memcpy(ptr, &value, sizeof(PackedT));
+			break;
+		case P4:
+		case P4HL:
+		case P4HH:
+			// RMW
+			value = (old &~(0x0F << shift)) | ((value & 0x0F) << shift);
+			std::memcpy(ptr, &value, sizeof(PackedT));
+			break;
+		default:
+			break;
+		}
+	}
+
+	template<PixelStorageMode psm>
+	constexpr auto PixelStorageTraits<psm>::Read(const PageLookupTableT& table, u8* data, u32 block, u32 bw, u32 x, u32 y) -> PackedT
+	{
+		const u32 pixel_addr = Address(table, block, bw, x, y);
+		const u32 bits = pixel_addr * UnpackedBitWidth(psm) + BitOffset();
+		const u32 byte_addr = (bits / 8) & (MEMORY_SIZE - sizeof(PackedT));
+		const u32 shift = bits % 8;
+
+		PackedT v;
+		std::memcpy(&v, &data[byte_addr], sizeof(PackedT));
+
+		switch (psm)
+		{
+		case C32:
+		case Z32:
+		case C16:
+		case C16S:
+		case Z16:
+		case Z16S:
+		case P8:
+		case P8H:
+			return v;
+		case C24:
+		case Z24:
+			return v & 0x00FFFFFF;
+		case P4:
+		case P4HL:
+		case P4HH:
+			return (v >> shift) & 0x0F;
+		default:
+			break;
+		}
+
+		return 0xFFFF00FFu;
+	}
+
+	void InitLookupTables();
+
+	void WriteCT32(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
+	void WriteZ32(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
+
+	void WriteCT24(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
+	void WriteZ24(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
+
+	void WriteCT16(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
+	void WriteCT16S(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
+	void WriteZ16(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
+	void WriteZ16S(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
+
+	void WriteP8(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
+	void WriteP8H(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
+
+	void WriteP4(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
+	void WriteP4HH(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
+	void WriteP4HL(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value);
+
+	u32 ReadCT32(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+	u32 ReadZ32(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+
+	u32 ReadCT24(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+	u32 ReadZ24(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+
+	u32 ReadCT24(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+	u32 ReadZ24(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+
+	u32 ReadCT16(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+	u32 ReadCT16S(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+	u32 ReadZ16(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+	u32 ReadZ16S(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+
+	u32 ReadP8(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+	u32 ReadP8H(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+
+	u32 ReadP4(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+	u32 ReadP4HL(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+	u32 ReadP4HH(u8* data, u32 bp, u32 bw, u32 x, u32 y);
+}

--- a/ps2xRuntime/include/runtime/ps2_gs_rasterizer.h
+++ b/ps2xRuntime/include/runtime/ps2_gs_rasterizer.h
@@ -9,7 +9,7 @@ class GSRasterizer
 {
 public:
     void drawPrimitive(GS *gs);
-    void writePixel(GS *gs, int x, int y, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+    void writePixel(GS *gs, int x, int y, int z, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
     uint32_t sampleTexture(GS *gs, float s, float t, float q, uint16_t u, uint16_t v);
     uint32_t lookupCLUT(GS *gs, uint8_t index, uint32_t cbp, uint8_t cpsm, uint8_t csm, uint8_t csa, uint8_t sourcePsm);
 

--- a/ps2xRuntime/include/runtime/ps2_gs_rasterizer.h
+++ b/ps2xRuntime/include/runtime/ps2_gs_rasterizer.h
@@ -11,9 +11,6 @@ public:
     void drawPrimitive(GS *gs);
     void writePixel(GS *gs, int x, int y, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
     uint32_t sampleTexture(GS *gs, float s, float t, float q, uint16_t u, uint16_t v);
-    uint32_t readTexelPSMCT32(GS *gs, uint32_t tbp0, uint32_t tbw, int texU, int texV);
-    uint32_t readTexelPSMCT16(GS *gs, uint32_t tbp0, uint32_t tbw, int texU, int texV);
-    uint32_t readTexelPSMT4(GS *gs, uint32_t tbp0, uint32_t tbw, int texU, int texV);
     uint32_t lookupCLUT(GS *gs, uint8_t index, uint32_t cbp, uint8_t cpsm, uint8_t csm, uint8_t csa, uint8_t sourcePsm);
 
 private:

--- a/ps2xRuntime/include/types.h
+++ b/ps2xRuntime/include/types.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+
+using usz = size_t;
+using uint = unsigned int;
+using sint = signed int;
+
+using u64 = uint64_t;
+using u32 = uint32_t;
+using u16 = uint16_t;
+using u8 = uint8_t;
+
+constexpr usz operator ""_kb(usz bytes)
+{
+	return bytes * 1024;
+}
+
+constexpr usz operator ""_mb(usz bytes)
+{
+	return bytes * 1024 * 1024;
+}

--- a/ps2xRuntime/include/types.h
+++ b/ps2xRuntime/include/types.h
@@ -5,18 +5,19 @@
 using usz = size_t;
 using uint = unsigned int;
 using sint = signed int;
+using ull = unsigned long long;
 
 using u64 = uint64_t;
 using u32 = uint32_t;
 using u16 = uint16_t;
 using u8 = uint8_t;
 
-constexpr usz operator ""_kb(usz bytes)
+constexpr usz operator ""_kb(ull bytes)
 {
 	return bytes * 1024;
 }
 
-constexpr usz operator ""_mb(usz bytes)
+constexpr usz operator ""_mb(ull bytes)
 {
 	return bytes * 1024 * 1024;
 }

--- a/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
@@ -208,12 +208,9 @@ namespace
         return count;
     }
 
-    bool clearFramebufferRect(uint8_t *vram,
-                              uint32_t vramSize,
-                              const GSContext &ctx,
-                              uint32_t rgba)
+    bool clearFramebufferRect(GS* gs, const GSContext &ctx, uint32_t rgba)
     {
-        if (!vram || vramSize == 0u || ctx.frame.fbw == 0u)
+        if (ctx.frame.fbw == 0u)
         {
             return false;
         }
@@ -224,16 +221,20 @@ namespace
             return false;
         }
 
-        const int x0 = std::max<int>(0, ctx.scissor.x0);
-        const int x1 = std::max<int>(x0, ctx.scissor.x1);
-        const int y0 = std::max<int>(0, ctx.scissor.y0);
-        const int y1 = std::max<int>(y0, ctx.scissor.y1);
-        const uint32_t base = ctx.frame.fbp * 8192u;
+        const u32 x0 = static_cast<u32>(std::max<int>(0, ctx.scissor.x0));
+        const u32 x1 = static_cast<u32>(std::max<int>(x0, ctx.scissor.x1));
+        const u32 y0 = static_cast<u32>(std::max<int>(0, ctx.scissor.y0));
+        const u32 y1 = static_cast<u32>(std::max<int>(y0, ctx.scissor.y1));
 
         uint8_t r = static_cast<uint8_t>(rgba & 0xFFu);
         uint8_t g = static_cast<uint8_t>((rgba >> 8) & 0xFFu);
         uint8_t b = static_cast<uint8_t>((rgba >> 16) & 0xFFu);
         uint8_t a = static_cast<uint8_t>((rgba >> 24) & 0xFFu);
+
+        u32 fbp = GSInternal::framePageBaseToBlock(ctx.frame.fbp);
+        u32 fbw = std::max<u32>(ctx.frame.fbw, 1u);
+        u32 fpsm = ctx.frame.psm;
+
         if ((ctx.fba & 0x1ull) != 0ull && ctx.frame.psm != GS_PSM_CT24)
         {
             a = static_cast<uint8_t>(a | 0x80u);
@@ -246,30 +247,18 @@ namespace
                 (static_cast<uint32_t>(g) << 8) |
                 (static_cast<uint32_t>(b) << 16) |
                 (static_cast<uint32_t>(a) << 24);
-            const uint32_t widthBlocks = (ctx.frame.fbw != 0u) ? ctx.frame.fbw : 1u;
 
             for (int y = y0; y <= y1; ++y)
             {
                 for (int x = x0; x <= x1; ++x)
                 {
-                    const uint32_t off =
-                        GSPSMCT32::addrPSMCT32(GSInternal::framePageBaseToBlock(ctx.frame.fbp),
-                                               widthBlocks,
-                                               static_cast<uint32_t>(x),
-                                               static_cast<uint32_t>(y));
-                    if (off + 4u > vramSize)
-                    {
-                        return true;
-                    }
-
                     uint32_t pixel = srcPixel;
                     if (ctx.frame.fbmsk != 0u)
                     {
-                        uint32_t existing = 0u;
-                        std::memcpy(&existing, vram + off, sizeof(existing));
-                        pixel = (pixel & ~ctx.frame.fbmsk) | (existing & ctx.frame.fbmsk);
+                        const u32 c = gs->ReadVram(fpsm, fbp, fbw, x, y);
+                        pixel = (pixel & ~ctx.frame.fbmsk) | (c & ctx.frame.fbmsk);
                     }
-                    std::memcpy(vram + off, &pixel, sizeof(pixel));
+                    gs->WriteVram(fpsm, fbp, fbw, x, y, pixel);
                 }
             }
             return true;
@@ -286,24 +275,13 @@ namespace
             {
                 for (int x = x0; x <= x1; ++x)
                 {
-                    const uint32_t off = addrPSMCT16Family(basePtr,
-                                                           widthBlocks,
-                                                           ctx.frame.psm,
-                                                           static_cast<uint32_t>(x),
-                                                           static_cast<uint32_t>(y));
-                    if (off + 2u > vramSize)
-                    {
-                        return true;
-                    }
-
                     uint16_t pixel = srcPixel;
                     if (mask != 0u)
                     {
-                        uint16_t existing = 0u;
-                        std::memcpy(&existing, vram + off, sizeof(existing));
-                        pixel = static_cast<uint16_t>((pixel & ~mask) | (existing & mask));
+                        const u16 c = gs->ReadVram(fpsm, fbp, fbw, x, y);
+                        pixel = static_cast<uint16_t>((pixel & ~mask) | (c & mask));
                     }
-                    std::memcpy(vram + off, &pixel, sizeof(pixel));
+                    gs->WriteVram(fpsm, fbp, fbw, x, y, pixel);
                 }
             }
             return true;
@@ -2354,13 +2332,13 @@ void GS::performLocalToHostToBuffer()
 bool GS::clearFramebufferContext(uint32_t contextIndex, uint32_t rgba)
 {
     std::lock_guard<std::recursive_mutex> lock(m_stateMutex);
-    return clearFramebufferRect(m_vram, m_vramSize, m_ctx[(contextIndex != 0u) ? 1 : 0], rgba);
+    return clearFramebufferRect(this, m_ctx[(contextIndex != 0u) ? 1 : 0], rgba);
 }
 
 bool GS::clearActiveFramebuffer(uint32_t rgba)
 {
     std::lock_guard<std::recursive_mutex> lock(m_stateMutex);
-    return clearFramebufferRect(m_vram, m_vramSize, activeContext(), rgba);
+    return clearFramebufferRect(this, activeContext(), rgba);
 }
 
 uint32_t GS::consumeLocalToHostBytes(uint8_t *dst, uint32_t maxBytes)

--- a/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
@@ -1571,7 +1571,7 @@ void GS::writeRegister(uint8_t regAddr, uint64_t value)
         GSVertex &vtx = m_vtxQueue[m_vtxCount % kMaxVerts];
         vtx.x = static_cast<float>(value & 0xFFFF) / 16.0f;
         vtx.y = static_cast<float>((value >> 16) & 0xFFFF) / 16.0f;
-        vtx.z = static_cast<float>((value >> 32) & 0xFFFFFF);
+        vtx.z = static_cast<double>((value >> 32) & 0xFFFFFF);
         vtx.fog = static_cast<uint8_t>((value >> 56) & 0xFF);
         vtx.r = m_curR;
         vtx.g = m_curG;
@@ -1591,7 +1591,7 @@ void GS::writeRegister(uint8_t regAddr, uint64_t value)
         GSVertex &vtx = m_vtxQueue[m_vtxCount % kMaxVerts];
         vtx.x = static_cast<float>(value & 0xFFFF) / 16.0f;
         vtx.y = static_cast<float>((value >> 16) & 0xFFFF) / 16.0f;
-        vtx.z = static_cast<float>((value >> 32) & 0xFFFFFFFF);
+        vtx.z = static_cast<double>((value >> 32) & 0xFFFFFFFF);
         vtx.r = m_curR;
         vtx.g = m_curG;
         vtx.b = m_curB;
@@ -1721,7 +1721,9 @@ void GS::writeRegister(uint8_t regAddr, uint64_t value)
     case GS_REG_ZBUF_2:
     {
         int ci = (regAddr == GS_REG_ZBUF_2) ? 1 : 0;
-        m_ctx[ci].zbuf = value;
+        m_ctx[ci].zbuf.zbp = value & 0xFF;
+        m_ctx[ci].zbuf.psm = ((value >> 24) & 0xF) | 0x30;
+        m_ctx[ci].zbuf.zmask = (value >> 32) & 1;
         break;
     }
     case GS_REG_FBA_1:

--- a/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
@@ -518,7 +518,73 @@ using namespace GSInternal;
 
 GS::GS()
 {
-    GSMem::InitLookupTables();
+    using namespace GSMem;
+
+    InitLookupTables();
+
+    for (usz i = 0; i < 0x3F; ++i)
+    {
+        switch (i)
+        {
+        case GS_PSM_CT32:
+            m_read_vram_funcs[i] = ReadCT32;
+            m_write_vram_funcs[i] = WriteCT32;
+            break;
+        case GS_PSM_CT24:
+            m_read_vram_funcs[i] = ReadCT24;
+            m_write_vram_funcs[i] = WriteCT24;
+            break;
+        case GS_PSM_CT16:
+            m_read_vram_funcs[i] = ReadCT16;
+            m_write_vram_funcs[i] = WriteCT16;
+            break;
+        case GS_PSM_CT16S:
+            m_read_vram_funcs[i] = ReadCT16S;
+            m_write_vram_funcs[i] = WriteCT16S;
+            break;
+        case GS_PSM_T8:
+            m_read_vram_funcs[i] = ReadP8;
+            m_write_vram_funcs[i] = WriteP8;
+            break;
+        case GS_PSM_T8H:
+            m_read_vram_funcs[i] = ReadP8H;
+            m_write_vram_funcs[i] = WriteP8H;
+            break;
+        case GS_PSM_T4:
+            m_read_vram_funcs[i] = ReadP4;
+            m_write_vram_funcs[i] = WriteP4;
+            break;
+        case GS_PSM_T4HH:
+            m_read_vram_funcs[i] = ReadP4HH;
+            m_write_vram_funcs[i] = WriteP4HH;
+            break;
+        case GS_PSM_T4HL:
+            m_read_vram_funcs[i] = ReadP4HL;
+            m_write_vram_funcs[i] = WriteP4HL;
+            break;
+        case GS_PSM_Z32:
+            m_read_vram_funcs[i] = ReadZ32;
+            m_write_vram_funcs[i] = WriteZ32;
+            break;
+        case GS_PSM_Z24:
+            m_read_vram_funcs[i] = ReadZ24;
+            m_write_vram_funcs[i] = WriteZ24;
+            break;
+        case GS_PSM_Z16:
+            m_read_vram_funcs[i] = ReadZ16;
+            m_write_vram_funcs[i] = WriteZ16;
+            break;
+        case GS_PSM_Z16S:
+            m_read_vram_funcs[i] = ReadZ16S;
+            m_write_vram_funcs[i] = WriteZ16S;
+            break;
+        default:
+            m_read_vram_funcs[i] = ReadNull;
+            m_write_vram_funcs[i] = WriteNull;
+            break;
+        }
+    }
+
     reset();
 }
 

--- a/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
@@ -107,42 +107,6 @@ namespace
         return frame.fbw != 0u || dw != 0u || dh != 0u || magh != 0u;
     }
 
-    struct GSTransferTraversal
-    {
-        bool reverseX = false;
-        bool reverseY = false;
-    };
-
-    GSTransferTraversal decodeTransferTraversal(uint8_t dir)
-    {
-        GSTransferTraversal traversal{};
-        switch (dir & 0x3u)
-        {
-        case 1u:
-            traversal.reverseY = true;
-            break;
-        case 2u:
-            traversal.reverseX = true;
-            break;
-        case 3u:
-            traversal.reverseX = true;
-            traversal.reverseY = true;
-            break;
-        default:
-            break;
-        }
-        return traversal;
-    }
-
-    uint32_t transferCoord(uint32_t start, uint32_t extent, uint32_t index, bool reverse)
-    {
-        if (reverse && extent != 0u)
-        {
-            return start + (extent - 1u - index);
-        }
-        return start + index;
-    }
-
     struct GSPmodeState
     {
         bool enableCrt1 = false;
@@ -356,162 +320,6 @@ namespace
     std::atomic<uint32_t> s_debugTexaWriteCount{0};
     std::atomic<uint32_t> s_debugCvFontUploadCount{0};
     std::atomic<uint32_t> s_debugLocalCopyCount{0};
-
-    bool supportsFormatAwareLocalCopy(uint8_t psm)
-    {
-        switch (psm)
-        {
-        case GS_PSM_CT32:
-        case GS_PSM_Z32:
-        case GS_PSM_CT24:
-        case GS_PSM_Z24:
-        case GS_PSM_CT16:
-        case GS_PSM_CT16S:
-        case GS_PSM_Z16:
-        case GS_PSM_Z16S:
-        case GS_PSM_T8:
-        case GS_PSM_T4:
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    uint32_t readTransferPixel(const uint8_t *vram,
-                               uint32_t vramSize,
-                               uint32_t basePtr,
-                               uint8_t widthBlocks,
-                               uint8_t psm,
-                               uint32_t x,
-                               uint32_t y)
-    {
-        const uint32_t width = (widthBlocks != 0u) ? static_cast<uint32_t>(widthBlocks) : 1u;
-        const uint32_t base = basePtr * 256u;
-
-        switch (psm)
-        {
-        case GS_PSM_CT32:
-        case GS_PSM_Z32:
-        {
-            const uint32_t off = GSPSMCT32::addrPSMCT32(basePtr, width, x, y);
-            if (off + 4u > vramSize)
-                return 0u;
-            uint32_t value = 0u;
-            std::memcpy(&value, vram + off, sizeof(value));
-            return value;
-        }
-        case GS_PSM_CT24:
-        case GS_PSM_Z24:
-        {
-            const uint32_t off = GSPSMCT32::addrPSMCT32(basePtr, width, x, y);
-            if (off + 3u > vramSize)
-                return 0u;
-            return static_cast<uint32_t>(vram[off + 0u]) |
-                   (static_cast<uint32_t>(vram[off + 1u]) << 8) |
-                   (static_cast<uint32_t>(vram[off + 2u]) << 16);
-        }
-        case GS_PSM_CT16:
-        case GS_PSM_CT16S:
-        case GS_PSM_Z16:
-        case GS_PSM_Z16S:
-        {
-            const uint32_t off = addrPSMCT16Family(basePtr, width, psm, x, y);
-            if (off + 2u > vramSize)
-                return 0u;
-            uint16_t value = 0u;
-            std::memcpy(&value, vram + off, sizeof(value));
-            return value;
-        }
-        case GS_PSM_T8:
-        {
-            const uint32_t off = GSPSMT8::addrPSMT8(basePtr, width, x, y);
-            return (off < vramSize) ? vram[off] : 0u;
-        }
-        case GS_PSM_T4:
-        {
-            const uint32_t nibbleAddr = GSPSMT4::addrPSMT4(basePtr, width, x, y);
-            const uint32_t byteOff = nibbleAddr >> 1;
-            if (byteOff >= vramSize)
-                return 0u;
-            const int shift = static_cast<int>((nibbleAddr & 1u) << 2);
-            return static_cast<uint32_t>((vram[byteOff] >> shift) & 0x0Fu);
-        }
-        default:
-            return 0u;
-        }
-    }
-
-    void writeTransferPixel(uint8_t *vram,
-                            uint32_t vramSize,
-                            uint32_t basePtr,
-                            uint8_t widthBlocks,
-                            uint8_t psm,
-                            uint32_t x,
-                            uint32_t y,
-                            uint32_t value)
-    {
-        const uint32_t width = (widthBlocks != 0u) ? static_cast<uint32_t>(widthBlocks) : 1u;
-        const uint32_t base = basePtr * 256u;
-
-        switch (psm)
-        {
-        case GS_PSM_CT32:
-        case GS_PSM_Z32:
-        {
-            const uint32_t off = GSPSMCT32::addrPSMCT32(basePtr, width, x, y);
-            if (off + 4u > vramSize)
-                return;
-            std::memcpy(vram + off, &value, sizeof(value));
-            return;
-        }
-        case GS_PSM_CT24:
-        case GS_PSM_Z24:
-        {
-            const uint32_t off = GSPSMCT32::addrPSMCT32(basePtr, width, x, y);
-            if (off + 3u > vramSize)
-                return;
-            vram[off + 0u] = static_cast<uint8_t>(value & 0xFFu);
-            vram[off + 1u] = static_cast<uint8_t>((value >> 8) & 0xFFu);
-            vram[off + 2u] = static_cast<uint8_t>((value >> 16) & 0xFFu);
-            return;
-        }
-        case GS_PSM_CT16:
-        case GS_PSM_CT16S:
-        case GS_PSM_Z16:
-        case GS_PSM_Z16S:
-        {
-            const uint32_t off = addrPSMCT16Family(basePtr, width, psm, x, y);
-            if (off + 2u > vramSize)
-                return;
-            const uint16_t value16 = static_cast<uint16_t>(value & 0xFFFFu);
-            std::memcpy(vram + off, &value16, sizeof(value16));
-            return;
-        }
-        case GS_PSM_T8:
-        {
-            const uint32_t off = GSPSMT8::addrPSMT8(basePtr, width, x, y);
-            if (off < vramSize)
-                vram[off] = static_cast<uint8_t>(value & 0xFFu);
-            return;
-        }
-        case GS_PSM_T4:
-        {
-            const uint32_t nibbleAddr = GSPSMT4::addrPSMT4(basePtr, width, x, y);
-            const uint32_t byteOff = nibbleAddr >> 1;
-            if (byteOff >= vramSize)
-                return;
-            const uint8_t nibble = static_cast<uint8_t>(value & 0x0Fu);
-            uint8_t &dst = vram[byteOff];
-            if ((nibbleAddr & 1u) != 0u)
-                dst = static_cast<uint8_t>((dst & 0x0Fu) | (nibble << 4));
-            else
-                dst = static_cast<uint8_t>((dst & 0xF0u) | nibble);
-            return;
-        }
-        default:
-            return;
-        }
-    }
 }
 
 using namespace GSInternal;
@@ -735,17 +543,23 @@ bool GS::copyFrameToHostRgbaUnlocked(const GSFrameReg &frame,
                 {
                     const uint32_t srcX = sourceOriginX + x;
                     const uint32_t srcY = sourceOriginY + y;
-                    const uint32_t srcOff = GSPSMCT32::addrPSMCT32(basePtr, fbwBlocks, srcX, srcY);
-                    if (srcOff + srcPixelBytes > m_vramSize)
+
+                    const u32 c = ReadVram(frame.psm, basePtr, fbwBlocks, srcX, srcY);
+
+                    const u32 r = c & 0xFF;
+                    const u32 g = (c >> 8) & 0xFF;
+                    const u32 b = (c >> 16) & 0xFF;
+
+                    u32 a = 0xFF;
+                    if (preserveAlpha && frame.psm != GS_PSM_CT24)
                     {
-                        return false;
+                        a = (c >> 24) & 0xFF;
                     }
 
-                    dstRow[x * 4u + 0u] = m_vram[srcOff + 0u];
-                    dstRow[x * 4u + 1u] = m_vram[srcOff + 1u];
-                    dstRow[x * 4u + 2u] = m_vram[srcOff + 2u];
-                    dstRow[x * 4u + 3u] =
-                        (preserveAlpha && frame.psm != GS_PSM_CT24) ? m_vram[srcOff + 3u] : 255u;
+                    dstRow[x * 4u + 0u] = r;
+                    dstRow[x * 4u + 1u] = g;
+                    dstRow[x * 4u + 2u] = b;
+                    dstRow[x * 4u + 3u] = a;
                 }
             }
             return true;
@@ -787,21 +601,16 @@ bool GS::copyFrameToHostRgbaUnlocked(const GSFrameReg &frame,
                 {
                     const uint32_t srcX = sourceOriginX + x;
                     const uint32_t srcY = sourceOriginY + y;
-                    const uint32_t srcOff = addrPSMCT16Family(basePtr, fbwBlocks, frame.psm, srcX, srcY);
-                    if (srcOff + sizeof(uint16_t) > m_vramSize)
-                    {
-                        return false;
-                    }
 
-                    uint16_t pixel = 0u;
-                    std::memcpy(&pixel, m_vram + srcOff, sizeof(pixel));
-                    const uint32_t r = pixel & 31u;
-                    const uint32_t g = (pixel >> 5) & 31u;
-                    const uint32_t b = (pixel >> 10) & 31u;
+                    const u16 c = ReadVram(frame.psm, basePtr, fbwBlocks, srcX, srcY);
+
+                    const uint32_t r = c & 31u;
+                    const uint32_t g = (c >> 5) & 31u;
+                    const uint32_t b = (c >> 10) & 31u;
                     dst[x * 4u + 0u] = static_cast<uint8_t>((r << 3) | (r >> 2));
                     dst[x * 4u + 1u] = static_cast<uint8_t>((g << 3) | (g >> 2));
                     dst[x * 4u + 2u] = static_cast<uint8_t>((b << 3) | (b >> 2));
-                    dst[x * 4u + 3u] = preserveAlpha ? ((pixel & 0x8000u) ? 0x80u : 0x00u) : 255u;
+                    dst[x * 4u + 3u] = preserveAlpha ? ((c & 0x8000u) ? 0x80u : 0x00u) : 255u;
                 }
             }
             return true;

--- a/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
@@ -7,6 +7,7 @@
 #include "ps2_log.h"
 #include "ps2_syscalls.h"
 #include "runtime/ps2_memory.h"
+#include "runtime/ps2_gs_memory.h"
 #include <atomic>
 #include <algorithm>
 #include <cmath>
@@ -517,6 +518,7 @@ using namespace GSInternal;
 
 GS::GS()
 {
+    GSMem::InitLookupTables();
     reset();
 }
 
@@ -551,8 +553,6 @@ void GS::reset()
     m_trxpos = {};
     m_trxreg = {};
     m_trxdir = 3;
-    m_hwregX = 0;
-    m_hwregY = 0;
     m_vtxCount = 0;
     m_vtxIndex = 0;
     m_localToHostBuffer.clear();
@@ -1133,17 +1133,6 @@ void GS::processGIFPacket(const uint8_t *data, uint32_t sizeBytes)
         }
     });
 
-    if (sizeBytes >= 16)
-    {
-        const uint64_t tagLo = loadLE64(data);
-        const uint8_t flg = static_cast<uint8_t>((tagLo >> 58) & 0x3);
-        if (flg == GIF_FMT_PACKED)
-        {
-            m_hwregX = 0;
-            m_hwregY = 0;
-        }
-    }
-
     uint32_t offset = 0;
     while (offset + 16 <= sizeBytes)
     {
@@ -1704,8 +1693,15 @@ void GS::writeRegister(uint8_t regAddr, uint64_t value)
     case GS_REG_TRXDIR:
     {
         m_trxdir = static_cast<uint32_t>(value & 0x3);
-        m_hwregX = 0;
-        m_hwregY = 0;
+
+        // We need the transfer state to survive the call to performLocalTo*Transfer
+        // This is because transfers can be broken into multiple IMAGE tags and we
+        // don't want to start all over again from the initial state
+        // The transfer starts officially when TRXDIR is accessed
+        m_transferState.x = m_trxpos.dsax;
+        m_transferState.y = m_trxpos.dsay;
+        m_transferState.total_pixels = m_trxreg.rrw * m_trxreg.rrh;
+        m_transferState.copied_pixels = 0;
 
         if (m_trxdir == 2 && m_vram)
         {
@@ -2004,189 +2000,394 @@ void GS::vertexKick(bool drawing)
 
 void GS::processImageData(const uint8_t *data, uint32_t sizeBytes)
 {
+    // wrong direction set
     if (m_trxdir != 0 || !m_vram)
+    {
         return;
-
-    uint32_t dbp = m_bitbltbuf.dbp;
-    uint8_t dbw = m_bitbltbuf.dbw;
-    uint8_t dpsm = m_bitbltbuf.dpsm;
-
-    if (dbw == 0)
-        dbw = 1;
-    uint32_t base = dbp * 256u;
-    uint32_t bpp = bitsPerPixel(dpsm);
-    uint32_t stridePixels = static_cast<uint32_t>(dbw) * 64u;
-
-    uint32_t rrw = m_trxreg.rrw;
-    uint32_t rrh = m_trxreg.rrh;
-    uint32_t dsax = m_trxpos.dsax;
-    uint32_t dsay = m_trxpos.dsay;
-
-    if (bpp == 4)
-    {
-        uint32_t widthBlocks = (dbw != 0) ? static_cast<uint32_t>(dbw) : 1u;
-        uint32_t offset = 0;
-
-        // T4 image uploads can be split across multiple GIF IMAGE packets.
-        // Keep advancing from the previous HWREG position instead of restarting at (0, 0).
-        auto writeT4Nibble = [&](uint8_t nibble, uint8_t srcByte, uint32_t srcLo, uint32_t srcHi)
-        {
-            if (m_hwregY >= rrh)
-                return;
-
-            const uint32_t vx = dsax + m_hwregX;
-            const uint32_t vy = dsay + m_hwregY;
-            const uint32_t nibbleAddr = GSPSMT4::addrPSMT4(dbp, widthBlocks, vx, vy);
-            const uint32_t byteOff = nibbleAddr >> 1;
-
-            if (byteOff < m_vramSize)
-            {
-                const int shift = static_cast<int>((nibbleAddr & 1u) << 2);
-                uint8_t &b = m_vram[byteOff];
-                b = static_cast<uint8_t>((b & (0xF0u >> shift)) | ((nibble & 0x0Fu) << shift));
-            }
-            ++m_hwregX;
-            if (m_hwregX >= rrw)
-            {
-                m_hwregX = 0;
-                ++m_hwregY;
-            }
-        };
-
-        while (offset < sizeBytes && m_hwregY < rrh)
-        {
-            const uint8_t srcByte = data[offset++];
-            const uint32_t srcLo = srcByte & 0x0Fu;
-            const uint32_t srcHi = (srcByte >> 4) & 0x0Fu;
-            const uint32_t xBefore = m_hwregX;
-
-            writeT4Nibble(static_cast<uint8_t>(srcLo), srcByte, srcLo, srcHi);
-            if ((xBefore + 1u) < rrw && m_hwregY < rrh)
-            {
-                writeT4Nibble(static_cast<uint8_t>(srcHi), srcByte, srcLo, srcHi);
-            }
-        }
     }
-    else if (dpsm == GS_PSM_T8)
+
+    // no height and width means transfer is invalid
+    if (m_trxreg.rrw == 0 || m_trxreg.rrh == 0)
     {
-        uint32_t offset = 0;
-        while (offset < sizeBytes && m_hwregY < rrh)
+        return;
+    }
+
+    u32 dbp = m_bitbltbuf.dbp;
+    u8 dbw = std::max<u8>(m_bitbltbuf.dbw, 1u);
+    u8 dpsm = m_bitbltbuf.dpsm;
+
+    u32 rrw = m_trxreg.rrw;
+    u32 rrh = m_trxreg.rrh;
+    u32 dsax = m_trxpos.dsax;
+    u32 dsay = m_trxpos.dsay;
+
+    u32 data_offset = 0;
+
+    // remove the format branching from the loops
+    // TODO: fixup copypasta
+    switch (dpsm)
+    {
+    case GS_PSM_CT32:
+        while (data_offset < sizeBytes)
         {
-            uint32_t pixelsLeft = rrw - m_hwregX;
-            uint32_t pixelsToCopy = std::min<uint32_t>(pixelsLeft, sizeBytes - offset);
-            if (pixelsToCopy == 0)
+            u32 c;
+            std::memcpy(&c, &data[data_offset], sizeof(u32));
+
+            GSMem::WriteCT32(m_vram, dbp, dbw, m_transferState.x, m_transferState.y, c);
+
+            m_transferState.x++;
+            m_transferState.copied_pixels++;
+            data_offset += 4;
+
+            if ((m_transferState.copied_pixels % rrw) == 0)
             {
+                m_transferState.x = dsax;
+                m_transferState.y++;
+            }
+
+            if (m_transferState.copied_pixels >= m_transferState.total_pixels)
+            {
+                // deactivate the transfer
+                m_trxdir = 3;
+                m_transferState.total_pixels = 0;
                 break;
             }
-
-            for (uint32_t i = 0; i < pixelsToCopy; ++i)
-            {
-                const uint32_t vx = dsax + m_hwregX + i;
-                const uint32_t vy = dsay + m_hwregY;
-                const uint32_t dst = GSPSMT8::addrPSMT8(dbp, dbw, vx, vy);
-                if (dst < m_vramSize)
-                {
-                    m_vram[dst] = data[offset + i];
-                }
-            }
-
-            offset += pixelsToCopy;
-            m_hwregX += pixelsToCopy;
-            if (m_hwregX >= rrw)
-            {
-                m_hwregX = 0;
-                ++m_hwregY;
-            }
         }
-    }
-    else if (dpsm == GS_PSM_CT24 || dpsm == GS_PSM_Z24)
-    {
-        uint32_t transferBpp = 3;
+        break;
 
-        uint32_t offset = 0;
-        while (offset < sizeBytes && m_hwregY < rrh)
+    case GS_PSM_Z32:
+        while (data_offset < sizeBytes)
         {
-            uint32_t pixelsLeft = rrw - m_hwregX;
-            uint32_t srcBytesLeft = pixelsLeft * transferBpp;
-            uint32_t bytesAvail = sizeBytes - offset;
-            uint32_t pixelsToCopy = pixelsLeft;
-            if (srcBytesLeft > bytesAvail)
-                pixelsToCopy = bytesAvail / transferBpp;
+            u32 c;
+            std::memcpy(&c, &data[data_offset], sizeof(u32));
 
-            if (pixelsToCopy == 0)
+            GSMem::WriteZ32(m_vram, dbp, dbw, m_transferState.x, m_transferState.y, c);
+
+            m_transferState.x++;
+            m_transferState.copied_pixels++;
+            data_offset += 4;
+
+            if ((m_transferState.copied_pixels % rrw) == 0)
+            {
+                m_transferState.x = dsax;
+                m_transferState.y++;
+            }
+
+            if (m_transferState.copied_pixels >= m_transferState.total_pixels)
+            {
+                // deactivate the transfer
+                m_trxdir = 3;
+                m_transferState.total_pixels = 0;
                 break;
-
-            if (pixelsToCopy > 0)
-            {
-                for (uint32_t p = 0; p < pixelsToCopy; ++p)
-                {
-                    const uint32_t vx = dsax + m_hwregX + p;
-                    const uint32_t vy = dsay + m_hwregY;
-                    const uint32_t dstOff = GSPSMCT32::addrPSMCT32(dbp, dbw, vx, vy);
-                    if (dstOff + 4u <= m_vramSize)
-                    {
-                        m_vram[dstOff + 0u] = data[offset + p * 3u + 0u];
-                        m_vram[dstOff + 1u] = data[offset + p * 3u + 1u];
-                        m_vram[dstOff + 2u] = data[offset + p * 3u + 2u];
-                        m_vram[dstOff + 3u] = 0x80u;
-                    }
-                }
-            }
-
-            offset += pixelsToCopy * transferBpp;
-            m_hwregX += pixelsToCopy;
-            if (m_hwregX >= rrw)
-            {
-                m_hwregX = 0;
-                ++m_hwregY;
             }
         }
-    }
-    else
-    {
-        uint32_t bytesPerPixel = bpp / 8u;
-        if (bytesPerPixel == 0)
-            bytesPerPixel = 4;
-        uint32_t strideBytes = stridePixels * bytesPerPixel;
-        uint32_t rowBytes = rrw * bytesPerPixel;
+        break;
 
-        uint32_t offset = 0;
-        while (offset < sizeBytes && m_hwregY < rrh)
+    case GS_PSM_CT24:
+        while (data_offset < sizeBytes)
         {
-            uint32_t dstY = dsay + m_hwregY;
-            uint32_t pixelsLeft = rrw - m_hwregX;
-            uint32_t bytesLeft = pixelsLeft * bytesPerPixel;
-            uint32_t bytesAvail = sizeBytes - offset;
-            if (bytesLeft > bytesAvail)
-                bytesLeft = (bytesAvail / bytesPerPixel) * bytesPerPixel;
+            u32 c;
+            std::memcpy(&c, &data[data_offset], sizeof(u32));
 
-            uint32_t pixelsCopied = bytesLeft / bytesPerPixel;
-            if ((dpsm == GS_PSM_CT32 || dpsm == GS_PSM_Z32) && pixelsCopied > 0)
+            GSMem::WriteCT24(m_vram, dbp, dbw, m_transferState.x, m_transferState.y, c);
+
+            m_transferState.x++;
+            m_transferState.copied_pixels++;
+            data_offset += 3;
+
+            if ((m_transferState.copied_pixels % rrw) == 0)
             {
-                for (uint32_t p = 0; p < pixelsCopied; ++p)
-                {
-                    const uint32_t vx = dsax + m_hwregX + p;
-                    const uint32_t vy = dstY;
-                    const uint32_t dstOff = GSPSMCT32::addrPSMCT32(dbp, dbw, vx, vy);
-                    if (dstOff + 4u <= m_vramSize)
-                        std::memcpy(m_vram + dstOff, data + offset + p * 4u, 4u);
-                }
-            }
-            else
-            {
-                uint32_t dstOff = base + dstY * strideBytes + (dsax + m_hwregX) * bytesPerPixel;
-                if (dstOff + bytesLeft <= m_vramSize && bytesLeft > 0)
-                    std::memcpy(m_vram + dstOff, data + offset, bytesLeft);
+                m_transferState.x = dsax;
+                m_transferState.y++;
             }
 
-            offset += bytesLeft;
-            m_hwregX += pixelsCopied;
-            if (m_hwregX >= rrw)
+            if (m_transferState.copied_pixels >= m_transferState.total_pixels)
             {
-                m_hwregX = 0;
-                ++m_hwregY;
+                // deactivate the transfer
+                m_trxdir = 3;
+                m_transferState.total_pixels = 0;
+                break;
             }
         }
+        break;
+
+    case GS_PSM_Z24:
+        while (data_offset < sizeBytes)
+        {
+            u32 c;
+            std::memcpy(&c, &data[data_offset], sizeof(u32));
+
+            GSMem::WriteZ24(m_vram, dbp, dbw, m_transferState.x, m_transferState.y, c);
+
+            m_transferState.x++;
+            m_transferState.copied_pixels++;
+            data_offset += 3;
+
+            if ((m_transferState.copied_pixels % rrw) == 0)
+            {
+                m_transferState.x = dsax;
+                m_transferState.y++;
+            }
+
+            if (m_transferState.copied_pixels >= m_transferState.total_pixels)
+            {
+                // deactivate the transfer
+                m_trxdir = 3;
+                m_transferState.total_pixels = 0;
+                break;
+            }
+        }
+        break;
+
+    case GS_PSM_CT16:
+        while (data_offset < sizeBytes)
+        {
+            u16 c;
+            std::memcpy(&c, &data[data_offset], sizeof(u16));
+
+            GSMem::WriteCT16(m_vram, dbp, dbw, m_transferState.x, m_transferState.y, c);
+
+            m_transferState.x++;
+            m_transferState.copied_pixels++;
+            data_offset += 2;
+
+            if ((m_transferState.copied_pixels % rrw) == 0)
+            {
+                m_transferState.x = dsax;
+                m_transferState.y++;
+            }
+
+            if (m_transferState.copied_pixels >= m_transferState.total_pixels)
+            {
+                // deactivate the transfer
+                m_trxdir = 3;
+                m_transferState.total_pixels = 0;
+                break;
+            }
+        }
+        break;
+
+    case GS_PSM_Z16:
+        while (data_offset < sizeBytes)
+        {
+            u16 c;
+            std::memcpy(&c, &data[data_offset], sizeof(u16));
+
+            GSMem::WriteZ16(m_vram, dbp, dbw, m_transferState.x, m_transferState.y, c);
+
+            m_transferState.x++;
+            m_transferState.copied_pixels++;
+            data_offset += 2;
+
+            if ((m_transferState.copied_pixels % rrw) == 0)
+            {
+                m_transferState.x = dsax;
+                m_transferState.y++;
+            }
+
+            if (m_transferState.copied_pixels >= m_transferState.total_pixels)
+            {
+                // deactivate the transfer
+                m_trxdir = 3;
+                m_transferState.total_pixels = 0;
+                break;
+            }
+        }
+        break;
+
+    case GS_PSM_CT16S:
+        while (data_offset < sizeBytes)
+        {
+            u16 c;
+            std::memcpy(&c, &data[data_offset], sizeof(u16));
+
+            GSMem::WriteCT16S(m_vram, dbp, dbw, m_transferState.x, m_transferState.y, c);
+
+            m_transferState.x++;
+            m_transferState.copied_pixels++;
+            data_offset += 2;
+
+            if ((m_transferState.copied_pixels % rrw) == 0)
+            {
+                m_transferState.x = dsax;
+                m_transferState.y++;
+            }
+
+            if (m_transferState.copied_pixels >= m_transferState.total_pixels)
+            {
+                // deactivate the transfer
+                m_trxdir = 3;
+                m_transferState.total_pixels = 0;
+                break;
+            }
+        }
+        break;
+
+    case GS_PSM_Z16S:
+        while (data_offset < sizeBytes)
+        {
+            u16 c;
+            std::memcpy(&c, &data[data_offset], sizeof(u16));
+
+            GSMem::WriteZ16S(m_vram, dbp, dbw, m_transferState.x, m_transferState.y, c);
+
+            m_transferState.x++;
+            m_transferState.copied_pixels++;
+            data_offset += 2;
+
+            if ((m_transferState.copied_pixels % rrw) == 0)
+            {
+                m_transferState.x = dsax;
+                m_transferState.y++;
+            }
+
+            if (m_transferState.copied_pixels >= m_transferState.total_pixels)
+            {
+                // deactivate the transfer
+                m_trxdir = 3;
+                m_transferState.total_pixels = 0;
+                break;
+            }
+        }
+        break;
+
+    case GS_PSM_T8:
+        while (data_offset < sizeBytes)
+        {
+            u8 c = data[data_offset];
+
+            GSMem::WriteP8(m_vram, dbp, dbw, m_transferState.x, m_transferState.y, c);
+
+            m_transferState.x++;
+            m_transferState.copied_pixels++;
+            data_offset += 1;
+
+            if ((m_transferState.copied_pixels % rrw) == 0)
+            {
+                m_transferState.x = dsax;
+                m_transferState.y++;
+            }
+
+            if (m_transferState.copied_pixels >= m_transferState.total_pixels)
+            {
+                // deactivate the transfer
+                m_trxdir = 3;
+                m_transferState.total_pixels = 0;
+                break;
+            }
+        }
+        break;
+
+    case GS_PSM_T8H:
+        while (data_offset < sizeBytes)
+        {
+            u8 c = data[data_offset];
+
+            GSMem::WriteP8H(m_vram, dbp, dbw, m_transferState.x, m_transferState.y, c);
+
+            m_transferState.x++;
+            m_transferState.copied_pixels++;
+            data_offset += 1;
+
+            if ((m_transferState.copied_pixels % rrw) == 0)
+            {
+                m_transferState.x = dsax;
+                m_transferState.y++;
+            }
+
+            if (m_transferState.copied_pixels >= m_transferState.total_pixels)
+            {
+                // deactivate the transfer
+                m_trxdir = 3;
+                m_transferState.total_pixels = 0;
+                break;
+            }
+        }
+        break;
+    case GS_PSM_T4:
+        while (data_offset < sizeBytes)
+        {
+            u8 c0 = data[data_offset] & 0xF;
+            u8 c1 = (data[data_offset] >> 4) & 0xF;
+
+            GSMem::WriteP4(m_vram, dbp, dbw, m_transferState.x, m_transferState.y, c0);
+            GSMem::WriteP4(m_vram, dbp, dbw, m_transferState.x + 1, m_transferState.y, c1);
+
+            m_transferState.x += 2;
+            m_transferState.copied_pixels += 2;
+            data_offset += 1;
+
+            if ((m_transferState.copied_pixels % rrw) == 0)
+            {
+                m_transferState.x = dsax;
+                m_transferState.y++;
+            }
+
+            if (m_transferState.copied_pixels >= m_transferState.total_pixels)
+            {
+                // deactivate the transfer
+                m_trxdir = 3;
+                m_transferState.total_pixels = 0;
+                break;
+            }
+        }
+        break;
+    case GS_PSM_T4HL:
+        while (data_offset < sizeBytes)
+        {
+            u8 c0 = data[data_offset] & 0xF;
+            u8 c1 = (data[data_offset] >> 4) & 0xF;
+
+            GSMem::WriteP4HL(m_vram, dbp, dbw, m_transferState.x, m_transferState.y, c0);
+            GSMem::WriteP4HL(m_vram, dbp, dbw, m_transferState.x + 1, m_transferState.y, c1);
+
+            m_transferState.x += 2;
+            m_transferState.copied_pixels += 2;
+            data_offset += 1;
+
+            if ((m_transferState.copied_pixels % rrw) == 0)
+            {
+                m_transferState.x = dsax;
+                m_transferState.y++;
+            }
+
+            if (m_transferState.copied_pixels >= m_transferState.total_pixels)
+            {
+                // deactivate the transfer
+                m_trxdir = 3;
+                m_transferState.total_pixels = 0;
+                break;
+            }
+        }
+        break;
+    case GS_PSM_T4HH:
+        while (data_offset < sizeBytes)
+        {
+            u8 c0 = data[data_offset] & 0xF;
+            u8 c1 = (data[data_offset] >> 4) & 0xF;
+
+            GSMem::WriteP4HH(m_vram, dbp, dbw, m_transferState.x, m_transferState.y, c0);
+            GSMem::WriteP4HH(m_vram, dbp, dbw, m_transferState.x + 1, m_transferState.y, c1);
+
+            m_transferState.x += 2;
+            m_transferState.copied_pixels += 2;
+            data_offset += 1;
+
+            if ((m_transferState.copied_pixels % rrw) == 0)
+            {
+                m_transferState.x = dsax;
+                m_transferState.y++;
+            }
+
+            if (m_transferState.copied_pixels >= m_transferState.total_pixels)
+            {
+                // deactivate the transfer
+                m_trxdir = 3;
+                m_transferState.total_pixels = 0;
+                break;
+            }
+        }
+        break;
     }
 }
 

--- a/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
@@ -2288,118 +2288,66 @@ void GS::performLocalToHostToBuffer()
 {
     m_localToHostBuffer.clear();
     m_localToHostReadPos = 0;
+
     if (!m_vram)
         return;
 
     uint32_t sbp = m_bitbltbuf.sbp;
-    uint8_t sbw = m_bitbltbuf.sbw;
+    uint8_t sbw = std::max<u8>(m_bitbltbuf.sbw, 1u);
     uint8_t spsm = m_bitbltbuf.spsm;
-
-    if (sbw == 0)
-        sbw = 1;
-    uint32_t base = sbp * 256u;
-    uint32_t bpp = bitsPerPixel(spsm);
-    uint32_t stridePixels = static_cast<uint32_t>(sbw) * 64u;
-
     uint32_t rrw = m_trxreg.rrw;
     uint32_t rrh = m_trxreg.rrh;
     uint32_t ssax = m_trxpos.ssax;
     uint32_t ssay = m_trxpos.ssay;
 
-    if (bpp == 4)
-    {
-        uint32_t rowBytes = (rrw + 1u) / 2u;
-        if (rowBytes == 0)
-            rowBytes = 1;
-        m_localToHostBuffer.reserve(rowBytes * rrh);
-        uint32_t widthBlocks = static_cast<uint32_t>(sbw);
-        for (uint32_t y = 0; y < rrh; ++y)
-        {
-            for (uint32_t x = 0; x < rrw; ++x)
-            {
-                uint32_t vx = ssax + x;
-                uint32_t vy = ssay + y;
-                uint32_t nibbleAddr = GSPSMT4::addrPSMT4(sbp, widthBlocks, vx, vy);
-                uint32_t byteOff = nibbleAddr >> 1;
-                uint8_t nibble = 0;
-                if (byteOff < m_vramSize)
-                {
-                    int shift = static_cast<int>((nibbleAddr & 1u) << 2);
-                    nibble = static_cast<uint8_t>((m_vram[byteOff] >> shift) & 0x0Fu);
-                }
-                if (x & 1u)
-                    m_localToHostBuffer.back() = static_cast<uint8_t>((m_localToHostBuffer.back() & 0x0Fu) | (nibble << 4));
-                else
-                    m_localToHostBuffer.push_back(nibble);
-            }
-        }
-    }
-    else if (spsm == GS_PSM_T8)
-    {
-        m_localToHostBuffer.reserve(rrw * rrh);
-        for (uint32_t y = 0; y < rrh; ++y)
-        {
-            for (uint32_t x = 0; x < rrw; ++x)
-            {
-                const uint32_t src = GSPSMT8::addrPSMT8(sbp, sbw, ssax + x, ssay + y);
-                m_localToHostBuffer.push_back((src < m_vramSize) ? m_vram[src] : 0u);
-            }
-        }
-    }
-    else if (spsm == GS_PSM_CT24 || spsm == GS_PSM_Z24)
-    {
-        uint32_t transferBpp = 3;
-        m_localToHostBuffer.reserve(rrw * rrh * transferBpp);
+    u32 bpp = GSMem::BitsPerPixel(static_cast<GSMem::PixelStorageMode>(spsm));
 
-        for (uint32_t y = 0; y < rrh; ++y)
-        {
-            for (uint32_t x = 0; x < rrw; ++x)
-            {
-                uint32_t srcOff = GSPSMCT32::addrPSMCT32(sbp, sbw, ssax + x, ssay + y);
-                if (srcOff + 4 <= m_vramSize)
-                {
-                    m_localToHostBuffer.push_back(m_vram[srcOff + 0]);
-                    m_localToHostBuffer.push_back(m_vram[srcOff + 1]);
-                    m_localToHostBuffer.push_back(m_vram[srcOff + 2]);
-                }
-            }
-        }
-    }
-    else
-    {
-        uint32_t bytesPerPixel = bpp / 8u;
-        if (bytesPerPixel == 0)
-            bytesPerPixel = 4;
-        uint32_t strideBytes = stridePixels * bytesPerPixel;
-        uint32_t rowBytes = rrw * bytesPerPixel;
-        m_localToHostBuffer.reserve(rowBytes * rrh);
+    u32 pixel_total = rrw * rrh;
+    u32 bytes_total = (pixel_total * bpp) / 8;
 
-        for (uint32_t y = 0; y < rrh; ++y)
+    m_localToHostBuffer.reserve(bytes_total);
+
+    u32 pixel_count = 0;
+    while (pixel_count < pixel_total)
+    {
+        const u32 x = pixel_count % rrw;
+        const u32 y = pixel_count / rrw;
+
+        const u32 v = ReadVram(spsm, sbp, sbw, x + ssax, y + ssay);
+
+        switch (bpp)
         {
-            if (spsm == GS_PSM_CT32 || spsm == GS_PSM_Z32)
-            {
-                for (uint32_t x = 0; x < rrw; ++x)
-                {
-                    const uint32_t srcOff = GSPSMCT32::addrPSMCT32(sbp, sbw, ssax + x, ssay + y);
-                    if (srcOff + 4u <= m_vramSize)
-                    {
-                        m_localToHostBuffer.push_back(m_vram[srcOff + 0u]);
-                        m_localToHostBuffer.push_back(m_vram[srcOff + 1u]);
-                        m_localToHostBuffer.push_back(m_vram[srcOff + 2u]);
-                        m_localToHostBuffer.push_back(m_vram[srcOff + 3u]);
-                    }
-                }
-            }
-            else
-            {
-                uint32_t srcOff = base + (ssay + y) * strideBytes + ssax * bytesPerPixel;
-                if (srcOff + rowBytes <= m_vramSize)
-                {
-                    for (uint32_t i = 0; i < rowBytes; ++i)
-                        m_localToHostBuffer.push_back(m_vram[srcOff + i]);
-                }
-            }
+        case 32:
+            m_localToHostBuffer.push_back(v & 0xFF);
+            m_localToHostBuffer.push_back((v >> 8) & 0xFF);
+            m_localToHostBuffer.push_back((v >> 16) & 0xFF);
+            m_localToHostBuffer.push_back((v >> 24) & 0xFF);
+            break;
+        case 24:
+            m_localToHostBuffer.push_back(v & 0xFF);
+            m_localToHostBuffer.push_back((v >> 8) & 0xFF);
+            m_localToHostBuffer.push_back((v >> 16) & 0xFF);
+            break;
+        case 16:
+            m_localToHostBuffer.push_back(v & 0xFF);
+            m_localToHostBuffer.push_back((v >> 16) & 0xFF);
+            break;
+        case 8:
+            m_localToHostBuffer.push_back(v);
+            break;
+        case 4:
+        {
+            const u32 v2 = ReadVram(spsm, sbp, sbw, x + ssax + 1, y + ssay);
+
+            m_localToHostBuffer.push_back(v | ((v2 & 0xF) << 4));
+            pixel_count++;
+            break;
         }
+        default:
+            break;
+        }
+
+        pixel_count++;
     }
 }
 

--- a/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
@@ -1883,107 +1883,123 @@ void GS::performLocalToLocalTransfer()
     if (!m_vram)
         return;
 
-    uint32_t sbp = m_bitbltbuf.sbp;
-    uint8_t sbw = m_bitbltbuf.sbw;
-    uint8_t spsm = m_bitbltbuf.spsm;
-    uint32_t dbp = m_bitbltbuf.dbp;
-    uint8_t dbw = m_bitbltbuf.dbw;
-    uint8_t dpsm = m_bitbltbuf.dpsm;
+    const u32 sbp = m_bitbltbuf.sbp;
+    const u8 sbw = m_bitbltbuf.sbw;
+    const u8 spsm = m_bitbltbuf.spsm;
+    const u32 dbp = m_bitbltbuf.dbp;
+    const u8 dbw = m_bitbltbuf.dbw;
+    const u8 dpsm = m_bitbltbuf.dpsm;
+    const u32 rrw = m_trxreg.rrw;
+    const u32 rrh = m_trxreg.rrh;
+    const u32 ssax = m_trxpos.ssax;
+    const u32 ssay = m_trxpos.ssay;
+    const u32 dsax = m_trxpos.dsax;
+    const u32 dsay = m_trxpos.dsay;
+    const u32 dir = m_trxpos.dir;
 
-    if (sbw == 0)
-        sbw = 1;
-    if (dbw == 0)
-        dbw = 1;
+    const u32 total_pixels = rrw * rrh;
 
-    const uint32_t rrw = m_trxreg.rrw;
-    const uint32_t rrh = m_trxreg.rrh;
-    const uint32_t ssax = m_trxpos.ssax;
-    const uint32_t ssay = m_trxpos.ssay;
-    const uint32_t dsax = m_trxpos.dsax;
-    const uint32_t dsay = m_trxpos.dsay;
-    const GSTransferTraversal traversal = decodeTransferTraversal(m_trxpos.dir);
-    const bool formatAware = (spsm == dpsm) && supportsFormatAwareLocalCopy(spsm);
-
-    if (rrw == 0u || rrh == 0u)
+    if (total_pixels == 0)
     {
+        m_trxdir = 3;
         return;
     }
 
-    PS2_IF_AGRESSIVE_LOGS({
-        if ((spsm == GS_PSM_T4 || dpsm == GS_PSM_T4) &&
-            s_debugLocalCopyCount.fetch_add(1u, std::memory_order_relaxed) < 96u)
-        {
-            RUNTIME_LOG("[gs:l2l] sbp=" << sbp
-                                        << " dbp=" << dbp
-                                        << " sbw=" << static_cast<uint32_t>(sbw)
-                                        << " dbw=" << static_cast<uint32_t>(dbw)
-                                        << " spsm=0x" << std::hex << static_cast<uint32_t>(spsm)
-                                        << " dpsm=0x" << static_cast<uint32_t>(dpsm) << std::dec
-                                        << " ss=(" << ssax << "," << ssay << ")"
-                                        << " ds=(" << dsax << "," << dsay << ")"
-                                        << " rr=(" << rrw << "," << rrh << ")"
-                                        << " dir=" << static_cast<uint32_t>(m_trxpos.dir)
-                                        << " formatAware=" << (formatAware ? 1 : 0) << std::endl);
-        }
-    });
-
-    if (formatAware)
+    // TODO: clean this up / optimize
+    switch (dir)
     {
-        for (uint32_t row = 0; row < rrh; ++row)
+    case 0: // left -> right top -> bottom
+    {
+        u32 pixel_count = 0;
+        while (pixel_count < total_pixels)
         {
-            const uint32_t srcY = transferCoord(ssay, rrh, row, traversal.reverseY);
-            const uint32_t dstY = transferCoord(dsay, rrh, row, traversal.reverseY);
-            for (uint32_t col = 0; col < rrw; ++col)
-            {
-                const uint32_t srcX = transferCoord(ssax, rrw, col, traversal.reverseX);
-                const uint32_t dstX = transferCoord(dsax, rrw, col, traversal.reverseX);
-                const uint32_t pixel =
-                    readTransferPixel(m_vram, m_vramSize, sbp, sbw, spsm, srcX, srcY);
-                writeTransferPixel(m_vram, m_vramSize, dbp, dbw, dpsm, dstX, dstY, pixel);
-            }
+            const u32 x = pixel_count % rrw;
+            const u32 y = pixel_count / rrw;
+
+            const u32 sx = x + ssax;
+            const u32 sy = y + ssay;
+            const u32 dx = x + dsax;
+            const u32 dy = y + dsay;
+
+            WriteVram(dpsm, dbp, dbw, dx, dy, ReadVram(spsm, sbp, sbw, sx, sy));
+
+            pixel_count++;
         }
     }
-    else
+    break;
+
+
+    // left -> right
+    // bottom -> top (invert y)
+    case 1:
     {
-        const uint32_t srcBase = sbp * 256u;
-        const uint32_t dstBase = dbp * 256u;
-        uint32_t srcBpp = bitsPerPixel(spsm) / 8u;
-        uint32_t dstBpp = bitsPerPixel(dpsm) / 8u;
-        if (srcBpp == 0)
-            srcBpp = 4;
-        if (dstBpp == 0)
-            dstBpp = 4;
-        const uint32_t srcStride = static_cast<uint32_t>(sbw) * 64u * srcBpp;
-        const uint32_t dstStride = static_cast<uint32_t>(dbw) * 64u * dstBpp;
-        const uint32_t copyBpp = (srcBpp < dstBpp) ? srcBpp : dstBpp;
-
-        uint8_t pixelBytes[4] = {};
-        for (uint32_t row = 0; row < rrh; ++row)
+        u32 pixel_count = 0;
+        while (pixel_count < total_pixels)
         {
-            const uint32_t srcY = transferCoord(ssay, rrh, row, traversal.reverseY);
-            const uint32_t dstY = transferCoord(dsay, rrh, row, traversal.reverseY);
-            for (uint32_t col = 0; col < rrw; ++col)
-            {
-                const uint32_t srcX = transferCoord(ssax, rrw, col, traversal.reverseX);
-                const uint32_t dstX = transferCoord(dsax, rrw, col, traversal.reverseX);
-                const uint32_t srcOff = srcBase + srcY * srcStride + srcX * srcBpp;
-                const uint32_t dstOff = dstBase + dstY * dstStride + dstX * dstBpp;
-                if (srcOff + copyBpp > m_vramSize || dstOff + copyBpp > m_vramSize)
-                {
-                    continue;
-                }
+            const u32 x = pixel_count % rrw;
+            const u32 y = rrh - (pixel_count / rrw) - 1;
 
-                std::memcpy(pixelBytes, m_vram + srcOff, copyBpp);
-                std::memcpy(m_vram + dstOff, pixelBytes, copyBpp);
-            }
+            const u32 sx = x + ssax;
+            const u32 sy = y + ssay;
+            const u32 dx = x + dsax;
+            const u32 dy = y + dsay;
+
+            WriteVram(dpsm, dbp, dbw, dx, dy, ReadVram(spsm, sbp, sbw, sx, sy));
+
+            pixel_count++;
         }
     }
+    break;
 
-    if (sbp == 0u && (dbp == 0u || dbp == 0x20u) && rrw >= 640u && rrh >= 512u)
+    // right -> left (invert x)
+    // top -> bottom
+    case 2:
     {
-        m_lastDisplayBaseBytes = (dbp == 0x20u) ? 8192u : 0u;
-        snapshotVRAM();
+        u32 pixel_count = 0;
+        while (pixel_count < total_pixels)
+        {
+            const u32 x = rrw - (pixel_count % rrw) - 1;
+            const u32 y = pixel_count / rrw;
+
+            const u32 sx = x + ssax;
+            const u32 sy = y + ssay;
+            const u32 dx = x + dsax;
+            const u32 dy = y + dsay;
+
+            WriteVram(dpsm, dbp, dbw, dx, dy, ReadVram(spsm, sbp, sbw, sx, sy));
+
+            pixel_count++;
+        }
     }
+    break;
+
+    // right to left (invert x)
+    // bottom to top (invert y)
+    case 3:
+    {
+        u32 pixel_count = 0;
+        while (pixel_count < total_pixels)
+        {
+            const u32 x = rrw - (pixel_count % rrw) - 1;
+            const u32 y = rrh - (pixel_count / rrw) - 1;
+
+            const u32 sx = x + ssax;
+            const u32 sy = y + ssay;
+            const u32 dx = x + dsax;
+            const u32 dy = y + dsay;
+
+            WriteVram(dpsm, dbp, dbw, dx, dy, ReadVram(spsm, sbp, sbw, sx, sy));
+
+            pixel_count++;
+        }
+    }
+    break;
+
+    default:
+        break;
+    }
+
+    m_trxdir = 3;
 }
 
 void GS::vertexKick(bool drawing)

--- a/ps2xRuntime/src/lib/ps2_gs_memory.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_memory.cpp
@@ -287,6 +287,10 @@ namespace GSMem
         PixelStorageTraits<P4HH>::Write(PageTableC32, data, bp, bw, x, y, value);
     }
 
+    void WriteNull(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value)
+    {
+    }
+
     u32 ReadCT32(u8* data, u32 bp, u32 bw, u32 x, u32 y)
     {
         return PixelStorageTraits<C32>::Read(PageTableC32, data, bp, bw, x, y);
@@ -350,6 +354,11 @@ namespace GSMem
     u32 ReadP4HH(u8* data, u32 bp, u32 bw, u32 x, u32 y)
     {
         return PixelStorageTraits<P4HH>::Read(PageTableC32, data, bp, bw, x, y);
+    }
+
+    u32 ReadNull(u8* data, u32 bp, u32 bw, u32 x, u32 y)
+    {
+        return 0;
     }
 }
 

--- a/ps2xRuntime/src/lib/ps2_gs_memory.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_memory.cpp
@@ -1,0 +1,356 @@
+#include <array>
+
+#include "runtime/ps2_gs_memory.h"
+
+namespace GSMem
+{
+    using enum PixelStorageMode;
+
+    using C32Traits  = PixelStorageTraits<C32>;
+    using Z32Traits  = PixelStorageTraits<Z32>;
+    using C16Traits  = PixelStorageTraits<C16>;
+    using C16STraits = PixelStorageTraits<C16S>;
+    using Z16Traits  = PixelStorageTraits<Z16>;
+    using Z16STraits = PixelStorageTraits<Z16S>;
+    using P8Traits   = PixelStorageTraits<P8>;
+    using P4Traits   = PixelStorageTraits<P4>;
+
+    using C32PageLookupTable    = C32Traits::PageLookupTableT;
+    using C32BlockLookupTableT  = C32Traits::BlockLookupTableT;
+    using Z32PageLookupTableT = Z32Traits::PageLookupTableT;
+    using Z32BlockLookupTableT = Z32Traits::BlockLookupTableT;
+
+    // column table is shared
+    using C32ColumnLookupTableT = C32Traits::ColumnLookupTableT;
+
+    using C16PageLookupTable   = C16Traits::PageLookupTableT;
+    using C16BlockLookupTable  = C16Traits::BlockLookupTableT;
+    using Z16PageLookupTable   = Z16Traits::PageLookupTableT;
+    using Z16BlockLookupTable  = Z16Traits::BlockLookupTableT;
+
+    using C16SPageLookupTable  = C16STraits::PageLookupTableT;
+    using C16SBlockLookupTable = C16STraits::BlockLookupTableT;
+    using Z16SPageLookupTable  = Z16STraits::PageLookupTableT;
+    using Z16SBlockLookupTable = Z16STraits::BlockLookupTableT;
+
+    // column table is shared
+    using C16ColumnLookupTable = C16Traits::ColumnLookupTableT;
+
+    using P8PageLookupTable   = P8Traits::PageLookupTableT;
+    using P8BlockLookupTable  = P8Traits::BlockLookupTableT;
+    using P8ColumnLookupTable = P8Traits::ColumnLookupTableT;
+
+    using P4PageLookupTable   = P4Traits::PageLookupTableT;
+    using P4BlockLookupTable  = P4Traits::BlockLookupTableT;
+    using P4ColumnLookupTable = P4Traits::ColumnLookupTableT;
+
+    static constexpr C32BlockLookupTableT BlockTableC32
+    {{
+        {  0,  1,  4,  5, 16, 17, 20, 21 },
+        {  2,  3,  6,  7, 18, 19, 22, 23 },
+        {  8,  9, 12, 13, 24, 25, 28, 29 },
+        { 10, 11, 14, 15, 26, 27, 30, 31 }
+    }};
+
+    static constexpr Z32BlockLookupTableT BlockTableZ32
+    {{
+        { 24, 25, 28, 29,  8,  9, 12, 13 },
+        { 26, 27, 30, 31, 10, 11, 14, 15 },
+        { 16, 17, 20, 21,  0,  1,  4,  5 },
+        { 18, 19, 22, 23,  2,  3,  6,  7 }
+    }};
+
+    static constexpr C16BlockLookupTable BlockTableC16
+    {{
+        {  0,  2,  8, 10 },
+        {  1,  3,  9, 11 },
+        {  4,  6, 12, 14 },
+        {  5,  7, 13, 15 },
+        { 16, 18, 24, 26 },
+        { 17, 19, 25, 27 },
+        { 20, 22, 28, 30 },
+        { 21, 23, 29, 31 }
+    }};
+
+    static constexpr C16SBlockLookupTable BlockTableC16S
+    {{
+        {  0,  2, 16, 18 },
+        {  1,  3, 17, 19 },
+        {  8, 10, 24, 26 },
+        {  9, 11, 25, 27 },
+        {  4,  6, 20, 22 },
+        {  5,  7, 21, 23 },
+        { 12, 14, 28, 30 },
+        { 13, 15, 29, 31 }
+    }};
+
+    static constexpr Z16BlockLookupTable BlockTableZ16
+    {{
+        { 24, 26, 16, 18 },
+        { 25, 27, 17, 19 },
+        { 28, 30, 20, 22 },
+        { 29, 31, 21, 23 },
+        {  8, 10,  0,  2 },
+        {  9, 11,  1,  3 },
+        { 12, 14,  4,  6 },
+        { 13, 15,  5,  7 }
+    }};
+
+    static constexpr Z16SBlockLookupTable BlockTableZ16S
+    {{
+        { 24, 26,  8, 10 },
+        { 25, 27,  9, 11 },
+        { 16, 18,  0,  2 },
+        { 17, 19,  1,  3 },
+        { 28, 30, 12, 14 },
+        { 29, 31, 13, 15 },
+        { 20, 22,  4,  6 },
+        { 21, 23,  5,  7 }
+    }};
+
+    static constexpr P8BlockLookupTable BlockTableP8
+    {{
+        {  0,  1,  4,  5, 16, 17, 20, 21},
+        {  2,  3,  6,  7, 18, 19, 22, 23},
+        {  8,  9, 12, 13, 24, 25, 28, 29},
+        { 10, 11, 14, 15, 26, 27, 30, 31}
+    }};
+
+    static constexpr P4BlockLookupTable BlockTableP4
+    {{
+        {  0,  2,  8, 10 },
+        {  1,  3,  9, 11 },
+        {  4,  6, 12, 14 },
+        {  5,  7, 13, 15 },
+        { 16, 18, 24, 26 },
+        { 17, 19, 25, 27 },
+        { 20, 22, 28, 30 },
+        { 21, 23, 29, 31 }
+    }};
+
+    // column layout is shared between c32 and z32
+    static constexpr C32ColumnLookupTableT ColumnTable32
+    {{
+        {  0,  1,  4,  5,  8,  9, 12, 13 },
+        {  2,  3,  6,  7, 10, 11, 14, 15 },
+        { 16, 17, 20, 21, 24, 25, 28, 29 },
+        { 18, 19, 22, 23, 26, 27, 30, 31 },
+        { 32, 33, 36, 37, 40, 41, 44, 45 },
+        { 34, 35, 38, 39, 42, 43, 46, 47 },
+        { 48, 49, 52, 53, 56, 57, 60, 61 },
+        { 50, 51, 54, 55, 58, 59, 62, 63 },
+    }};
+
+    static constexpr C16ColumnLookupTable ColumnTable16
+    {{
+        {   0,   2,   8,  10,  16,  18,  24,  26,   1,   3,   9,  11,  17,  19,  25,  27 },
+        {   4,   6,  12,  14,  20,  22,  28,  30,   5,   7,  13,  15,  21,  23,  29,  31 },
+        {  32,  34,  40,  42,  48,  50,  56,  58,  33,  35,  41,  43,  49,  51,  57,  59 },
+        {  36,  38,  44,  46,  52,  54,  60,  62,  37,  39,  45,  47,  53,  55,  61,  63 },
+        {  64,  66,  72,  74,  80,  82,  88,  90,  65,  67,  73,  75,  81,  83,  89,  91 },
+        {  68,  70,  76,  78,  84,  86,  92,  94,  69,  71,  77,  79,  85,  87,  93,  95 },
+        {  96,  98, 104, 106, 112, 114, 120, 122,  97,  99, 105, 107, 113, 115, 121, 123 },
+        { 100, 102, 108, 110, 116, 118, 124, 126, 101, 103, 109, 111, 117, 119, 125, 127 }
+    }};
+
+    static constexpr P8ColumnLookupTable ColumnTable8
+    {{
+        {   0,   4,  16,  20,  32,  36,  48,  52,   2,   6,  18,  22,  34,  38,  50,  54 },
+        {   8,  12,  24,  28,  40,  44,  56,  60,  10,  14,  26,  30,  42,  46,  58,  62 },
+        {  33,  37,  49,  53,   1,   5,  17,  21,  35,  39,  51,  55,   3,   7,  19,  23 },
+        {  41,  45,  57,  61,   9,  13,  25,  29,  43,  47,  59,  63,  11,  15,  27,  31 },
+        {  96, 100, 112, 116,  64,  68,  80,  84,  98, 102, 114, 118,  66,  70,  82,  86 },
+        { 104, 108, 120, 124,  72,  76,  88,  92, 106, 110, 122, 126,  74,  78,  90,  94 },
+        {  65,  69,  81,  85,  97, 101, 113, 117,  67,  71,  83,  87,  99, 103, 115, 119 },
+        {  73,  77,  89,  93, 105, 109, 121, 125,  75,  79,  91,  95, 107, 111, 123, 127 },
+        { 128, 132, 144, 148, 160, 164, 176, 180, 130, 134, 146, 150, 162, 166, 178, 182 },
+        { 136, 140, 152, 156, 168, 172, 184, 188, 138, 142, 154, 158, 170, 174, 186, 190 },
+        { 161, 165, 177, 181, 129, 133, 145, 149, 163, 167, 179, 183, 131, 135, 147, 151 },
+        { 169, 173, 185, 189, 137, 141, 153, 157, 171, 175, 187, 191, 139, 143, 155, 159 },
+        { 224, 228, 240, 244, 192, 196, 208, 212, 226, 230, 242, 246, 194, 198, 210, 214 },
+        { 232, 236, 248, 252, 200, 204, 216, 220, 234, 238, 250, 254, 202, 206, 218, 222 },
+        { 193, 197, 209, 213, 225, 229, 241, 245, 195, 199, 211, 215, 227, 231, 243, 247 },
+        { 201, 205, 217, 221, 233, 237, 249, 253, 203, 207, 219, 223, 235, 239, 251, 255 }
+    }};
+
+    static constexpr P4ColumnLookupTable ColumnTable4
+    {{
+        {   0,   8,  32,  40,  64,  72,  96, 104,   2,  10,  34,  42,  66,  74,  98, 106,   4,  12,  36,  44,  68,  76, 100, 108,   6,  14,  38,  46,  70,  78, 102, 110 },
+        {  16,  24,  48,  56,  80,  88, 112, 120,  18,  26,  50,  58,  82,  90, 114, 122,  20,  28,  52,  60,  84,  92, 116, 124,  22,  30,  54,  62,  86,  94, 118, 126 },
+        {  65,  73,  97, 105,   1,   9,  33,  41,  67,  75,  99, 107,   3,  11,  35,  43,  69,  77, 101, 109,   5,  13,  37,  45,  71,  79, 103, 111,   7,  15,  39,  47 },
+        {  81,  89, 113, 121,  17,  25,  49,  57,  83,  91, 115, 123,  19,  27,  51,  59,  85,  93, 117, 125,  21,  29,  53,  61,  87,  95, 119, 127,  23,  31,  55,  63 },
+        { 192, 200, 224, 232, 128, 136, 160, 168, 194, 202, 226, 234, 130, 138, 162, 170, 196, 204, 228, 236, 132, 140, 164, 172, 198, 206, 230, 238, 134, 142, 166, 174 },
+        { 208, 216, 240, 248, 144, 152, 176, 184, 210, 218, 242, 250, 146, 154, 178, 186, 212, 220, 244, 252, 148, 156, 180, 188, 214, 222, 246, 254, 150, 158, 182, 190 },
+        { 129, 137, 161, 169, 193, 201, 225, 233, 131, 139, 163, 171, 195, 203, 227, 235, 133, 141, 165, 173, 197, 205, 229, 237, 135, 143, 167, 175, 199, 207, 231, 239 },
+        { 145, 153, 177, 185, 209, 217, 241, 249, 147, 155, 179, 187, 211, 219, 243, 251, 149, 157, 181, 189, 213, 221, 245, 253, 151, 159, 183, 191, 215, 223, 247, 255 },
+        { 256, 264, 288, 296, 320, 328, 352, 360, 258, 266, 290, 298, 322, 330, 354, 362, 260, 268, 292, 300, 324, 332, 356, 364, 262, 270, 294, 302, 326, 334, 358, 366 },
+        { 272, 280, 304, 312, 336, 344, 368, 376, 274, 282, 306, 314, 338, 346, 370, 378, 276, 284, 308, 316, 340, 348, 372, 380, 278, 286, 310, 318, 342, 350, 374, 382 },
+        { 321, 329, 353, 361, 257, 265, 289, 297, 323, 331, 355, 363, 259, 267, 291, 299, 325, 333, 357, 365, 261, 269, 293, 301, 327, 335, 359, 367, 263, 271, 295, 303 },
+        { 337, 345, 369, 377, 273, 281, 305, 313, 339, 347, 371, 379, 275, 283, 307, 315, 341, 349, 373, 381, 277, 285, 309, 317, 343, 351, 375, 383, 279, 287, 311, 319 },
+        { 448, 456, 480, 488, 384, 392, 416, 424, 450, 458, 482, 490, 386, 394, 418, 426, 452, 460, 484, 492, 388, 396, 420, 428, 454, 462, 486, 494, 390, 398, 422, 430 },
+        { 464, 472, 496, 504, 400, 408, 432, 440, 466, 474, 498, 506, 402, 410, 434, 442, 468, 476, 500, 508, 404, 412, 436, 444, 470, 478, 502, 510, 406, 414, 438, 446 },
+        { 385, 393, 417, 425, 449, 457, 481, 489, 387, 395, 419, 427, 451, 459, 483, 491, 389, 397, 421, 429, 453, 461, 485, 493, 391, 399, 423, 431, 455, 463, 487, 495 },
+        { 401, 409, 433, 441, 465, 473, 497, 505, 403, 411, 435, 443, 467, 475, 499, 507, 405, 413, 437, 445, 469, 477, 501, 509, 407, 415, 439, 447, 471, 479, 503, 511 },
+    }};
+
+    // this is going to be massive (an entire page of addess lookups)
+    static C32PageLookupTable  PageTableC32{ };
+    static Z32PageLookupTableT PageTableZ32{ };
+    static C16PageLookupTable  PageTableC16{ };
+    static C16SPageLookupTable PageTableC16S{ };
+    static Z16PageLookupTable  PageTableZ16{ };
+    static Z16SPageLookupTable PageTableZ16S{ };
+    static P8PageLookupTable   PageTableP8{ };
+    static P4PageLookupTable   PageTableP4{ };
+
+    void InitLookupTables()
+    {
+        // 32 bit
+        PixelStorageTraits<C32>::InitPageLookupTable(PageTableC32, BlockTableC32, ColumnTable32);
+        PixelStorageTraits<Z32>::InitPageLookupTable(PageTableZ32, BlockTableZ32, ColumnTable32);
+
+        // 16 bit
+        PixelStorageTraits<C16>::InitPageLookupTable(PageTableC16, BlockTableC16, ColumnTable16);
+        PixelStorageTraits<C16S>::InitPageLookupTable(PageTableC16S, BlockTableC16S, ColumnTable16);
+        PixelStorageTraits<Z16>::InitPageLookupTable(PageTableZ16, BlockTableZ16, ColumnTable16);
+        PixelStorageTraits<Z16S>::InitPageLookupTable(PageTableZ16S, BlockTableZ16S, ColumnTable16);
+
+        // 8 bit
+        PixelStorageTraits<P8>::InitPageLookupTable(PageTableP8, BlockTableP8, ColumnTable8);
+
+        // 4 bit
+        PixelStorageTraits<P4>::InitPageLookupTable(PageTableP4, BlockTableP4, ColumnTable4);
+    }
+
+    void WriteCT32(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value)
+    {
+        PixelStorageTraits<C32>::Write(PageTableC32, data, bp, bw, x, y, value);
+    }
+
+    void WriteCT24(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value)
+    {
+        PixelStorageTraits<C24>::Write(PageTableC32, data, bp, bw, x, y, value);
+    }
+
+    void WriteZ32(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value)
+    {
+        PixelStorageTraits<Z32>::Write(PageTableZ32, data, bp, bw, x, y, value);
+    }
+
+    void WriteZ24(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value)
+    {
+        PixelStorageTraits<Z24>::Write(PageTableZ32, data, bp, bw, x, y, value);
+    }
+
+    void WriteCT16(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value)
+    {
+        PixelStorageTraits<C16>::Write(PageTableC16, data, bp, bw, x, y, value);
+    }
+
+    void WriteCT16S(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value)
+    {
+        PixelStorageTraits<C16S>::Write(PageTableC16S, data, bp, bw, x, y, value);
+    }
+
+    void WriteZ16(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value)
+    {
+        PixelStorageTraits<Z16>::Write(PageTableZ16, data, bp, bw, x, y, value);
+    }
+
+    void WriteZ16S(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value)
+    {
+        PixelStorageTraits<Z16S>::Write(PageTableZ16S, data, bp, bw, x, y, value);
+    }
+
+    void WriteP8(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value)
+    {
+        PixelStorageTraits<P8>::Write(PageTableP8, data, bp, bw, x, y, value);
+    }
+
+    void WriteP8H(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value)
+    {
+        PixelStorageTraits<P8H>::Write(PageTableC32, data, bp, bw, x, y, value);
+    }
+
+    void WriteP4(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value)
+    {
+        PixelStorageTraits<P4>::Write(PageTableP4, data, bp, bw, x, y, value);
+    }
+
+    void WriteP4HL(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value)
+    {
+        PixelStorageTraits<P4HL>::Write(PageTableC32, data, bp, bw, x, y, value);
+    }
+
+    void WriteP4HH(u8* data, u32 bp, u32 bw, u32 x, u32 y, u32 value)
+    {
+        PixelStorageTraits<P4HH>::Write(PageTableC32, data, bp, bw, x, y, value);
+    }
+
+    u32 ReadCT32(u8* data, u32 bp, u32 bw, u32 x, u32 y)
+    {
+        return PixelStorageTraits<C32>::Read(PageTableC32, data, bp, bw, x, y);
+    }
+
+    u32 ReadZ32(u8* data, u32 bp, u32 bw, u32 x, u32 y)
+    {
+        return PixelStorageTraits<Z32>::Read(PageTableZ32, data, bp, bw, x, y);
+    }
+
+    u32 ReadCT24(u8* data, u32 bp, u32 bw, u32 x, u32 y)
+    {
+        return PixelStorageTraits<C24>::Read(PageTableC32, data, bp, bw, x, y);
+    }
+
+    u32 ReadZ24(u8* data, u32 bp, u32 bw, u32 x, u32 y)
+    {
+        return PixelStorageTraits<Z24>::Read(PageTableZ32, data, bp, bw, x, y);
+    }
+
+    u32 ReadCT16(u8* data, u32 bp, u32 bw, u32 x, u32 y)
+    {
+        return PixelStorageTraits<C16>::Read(PageTableC16, data, bp, bw, x, y);
+    }
+
+    u32 ReadCT16S(u8* data, u32 bp, u32 bw, u32 x, u32 y)
+    {
+        return PixelStorageTraits<C16S>::Read(PageTableC16S, data, bp, bw, x, y);
+    }
+
+    u32 ReadZ16(u8* data, u32 bp, u32 bw, u32 x, u32 y)
+    {
+        return PixelStorageTraits<Z16>::Read(PageTableZ16, data, bp, bw, x, y);
+    }
+
+    u32 ReadZ16S(u8* data, u32 bp, u32 bw, u32 x, u32 y)
+    {
+        return PixelStorageTraits<Z16S>::Read(PageTableZ16S, data, bp, bw, x, y);
+    }
+
+    u32 ReadP8(u8* data, u32 bp, u32 bw, u32 x, u32 y)
+    {
+        return PixelStorageTraits<P8>::Read(PageTableP8, data, bp, bw, x, y);
+    }
+
+    u32 ReadP8H(u8* data, u32 bp, u32 bw, u32 x, u32 y)
+    {
+        return PixelStorageTraits<P8H>::Read(PageTableC32, data, bp, bw, x, y);
+    }
+
+    u32 ReadP4(u8* data, u32 bp, u32 bw, u32 x, u32 y)
+    {
+        return PixelStorageTraits<P4>::Read(PageTableP4, data, bp, bw, x, y);
+    }
+
+    u32 ReadP4HL(u8* data, u32 bp, u32 bw, u32 x, u32 y)
+    {
+        return PixelStorageTraits<P4HL>::Read(PageTableC32, data, bp, bw, x, y);
+    }
+
+    u32 ReadP4HH(u8* data, u32 bp, u32 bw, u32 x, u32 y)
+    {
+        return PixelStorageTraits<P4HH>::Read(PageTableC32, data, bp, bw, x, y);
+    }
+}
+
+

--- a/ps2xRuntime/src/lib/ps2_gs_rasterizer.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_rasterizer.cpp
@@ -5,6 +5,7 @@
 #include "runtime/ps2_gs_psmct32.h"
 #include "runtime/ps2_gs_psmt4.h"
 #include "runtime/ps2_gs_psmt8.h"
+#include "runtime/ps2_gs_memory.h"
 #include "ps2_log.h"
 #include <atomic>
 #include <algorithm>
@@ -212,19 +213,30 @@ namespace
         return (index & 0xE7u) | ((index & 0x08u) << 1u) | ((index & 0x10u) >> 1u);
     }
 
+    // TODO: clut cache
     uint32_t resolveClutIndex(uint8_t index, uint8_t csm, uint8_t csa, uint8_t sourcePsm)
     {
         uint32_t clutIndex = static_cast<uint32_t>(index);
 
-        if (sourcePsm == GS_PSM_T4)
+        switch (sourcePsm)
+        {
+        case GS_PSM_T4:
+        case GS_PSM_T4HH:
+        case GS_PSM_T4HL:
         {
             clutIndex = (static_cast<uint32_t>(csa) << 4u) | (clutIndex & 0x0Fu);
+
             if (csm == 0u)
                 clutIndex = swizzleClutIndexCSM1(clutIndex);
         }
-        else if (sourcePsm == GS_PSM_T8 && csm == 0u)
-        {
-            clutIndex = swizzleClutIndexCSM1(clutIndex);
+        break;
+        case GS_PSM_T8:
+        case GS_PSM_T8H:
+            if (csm == 0)
+                clutIndex = swizzleClutIndexCSM1(clutIndex);
+            break;
+        default:
+            break;
         }
 
         return clutIndex;
@@ -605,24 +617,19 @@ uint32_t GSRasterizer::lookupCLUT(GS *gs,
     const uint32_t clutX = static_cast<uint32_t>(gs->m_texclut.cou) + (clutIndex & 0x0Fu);
     const uint32_t clutY = static_cast<uint32_t>(gs->m_texclut.cov) + (clutIndex >> 4);
 
-    if (cpsm == GS_PSM_CT32 || cpsm == GS_PSM_CT24)
-    {
-        const uint32_t off = GSPSMCT32::addrPSMCT32(cbp, clutWidth, clutX, clutY);
-        if (off + 4 > gs->m_vramSize)
-            return 0xFFFF00FFu;
-        uint32_t color;
-        std::memcpy(&color, gs->m_vram + off, 4);
-        return applyTexa(gs->m_texa, cpsm, color);
-    }
 
-    if (cpsm == GS_PSM_CT16 || cpsm == GS_PSM_CT16S)
+    switch (cpsm)
     {
-        uint32_t off = addrPSMCT16Family(cbp, clutWidth, cpsm, clutX, clutY);
-        if (off + 2 > gs->m_vramSize)
-            return 0xFFFF00FFu;
-        uint16_t c16;
-        std::memcpy(&c16, gs->m_vram + off, 2);
-        return applyTexa(gs->m_texa, cpsm, decodePSMCT16(c16));
+    case GS_PSM_CT32:
+        return applyTexa(gs->m_texa, cpsm, GSMem::ReadCT32(gs->m_vram, cbp, clutWidth, clutX, clutY));
+    case GS_PSM_CT24:
+        return applyTexa(gs->m_texa, cpsm, GSMem::ReadCT24(gs->m_vram, cbp, clutWidth, clutX, clutY));
+    case GS_PSM_CT16:
+        return applyTexa(gs->m_texa, cpsm, GSMem::ReadCT16(gs->m_vram, cbp, clutWidth, clutX, clutY));
+    case GS_PSM_CT16S:
+        return applyTexa(gs->m_texa, cpsm, GSMem::ReadCT16S(gs->m_vram, cbp, clutWidth, clutX, clutY));
+    default:
+        break;
     }
 
     return 0xFFFF00FFu;
@@ -654,27 +661,34 @@ uint32_t GSRasterizer::sampleTexture(GS *gs, float s, float t, float q, uint16_t
         sampleU = clampInt(sampleU, 0, texW - 1);
         sampleV = clampInt(sampleV, 0, texH - 1);
 
-        if (tex.psm == GS_PSM_CT32 || tex.psm == GS_PSM_CT24)
-            return applyTexa(gs->m_texa, tex.psm, readTexelPSMCT32(gs, tex.tbp0, tex.tbw, sampleU, sampleV));
-
-        if (tex.psm == GS_PSM_CT16 || tex.psm == GS_PSM_CT16S)
-            return applyTexa(gs->m_texa, tex.psm, readTexelPSMCT16(gs, tex.tbp0, tex.tbw, sampleU, sampleV));
-
-        if (tex.psm == GS_PSM_T4)
+        switch (tex.psm)
         {
-            uint32_t idx = readTexelPSMT4(gs, tex.tbp0, tex.tbw, sampleU, sampleV);
-            return lookupCLUT(gs, static_cast<uint8_t>(idx), tex.cbp, tex.cpsm, tex.csm, tex.csa, tex.psm);
-        }
-
-        if (tex.psm == GS_PSM_T8)
-        {
-            if (tex.tbw == 0)
-                return 0xFFFF00FFu;
-            uint32_t off = GSPSMT8::addrPSMT8(tex.tbp0, tex.tbw, static_cast<uint32_t>(sampleU), static_cast<uint32_t>(sampleV));
-            if (off >= gs->m_vramSize)
-                return 0xFFFF00FFu;
-            uint8_t idx = gs->m_vram[off];
-            return lookupCLUT(gs, idx, tex.cbp, tex.cpsm, tex.csm, tex.csa, tex.psm);
+        case GS_PSM_CT32:
+            return applyTexa(gs->m_texa, tex.psm, GSMem::ReadCT32(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV));
+        case GS_PSM_Z32:
+            return applyTexa(gs->m_texa, tex.psm, GSMem::ReadZ32(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV));
+        case GS_PSM_CT24:
+            return applyTexa(gs->m_texa, tex.psm, GSMem::ReadCT24(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV));
+        case GS_PSM_Z24:
+            return applyTexa(gs->m_texa, tex.psm, GSMem::ReadZ24(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV));
+        case GS_PSM_CT16:
+            return applyTexa(gs->m_texa, tex.psm, decodePSMCT16(GSMem::ReadCT16(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
+        case GS_PSM_CT16S:
+            return applyTexa(gs->m_texa, tex.psm, decodePSMCT16(GSMem::ReadCT16S(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
+        case GS_PSM_Z16:
+            return applyTexa(gs->m_texa, tex.psm, decodePSMCT16(GSMem::ReadZ16(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
+        case GS_PSM_Z16S:
+            return applyTexa(gs->m_texa, tex.psm, decodePSMCT16(GSMem::ReadZ16S(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
+        case GS_PSM_T8:
+            return lookupCLUT(gs, GSMem::ReadP8(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV), tex.cbp, tex.cpsm, tex.csm, tex.csa, tex.psm);
+        case GS_PSM_T8H:
+            return lookupCLUT(gs, GSMem::ReadP8H(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV), tex.cbp, tex.cpsm, tex.csm, tex.csa, tex.psm);
+        case GS_PSM_T4:
+            return lookupCLUT(gs, GSMem::ReadP4(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV), tex.cbp, tex.cpsm, tex.csm, tex.csa, tex.psm);
+        case GS_PSM_T4HL:
+            return lookupCLUT(gs, GSMem::ReadP4HL(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV), tex.cbp, tex.cpsm, tex.csm, tex.csa, tex.psm);
+        case GS_PSM_T4HH:
+            return lookupCLUT(gs, GSMem::ReadP4HH(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV), tex.cbp, tex.cpsm, tex.csm, tex.csa, tex.psm);
         }
 
         return 0xFFFF00FFu;

--- a/ps2xRuntime/src/lib/ps2_gs_rasterizer.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_rasterizer.cpp
@@ -25,13 +25,29 @@ namespace
         return (std::fabs(q) > 1.0e-8f) ? q : 1.0f;
     }
 
-    uint32_t decodePSMCT16(uint16_t pixel)
+    u16 Rgba8888ToRgba5551(u32 c)
     {
-        const uint32_t r = ((pixel >> 0) & 0x1Fu) << 3;
-        const uint32_t g = ((pixel >> 5) & 0x1Fu) << 3;
-        const uint32_t b = ((pixel >> 10) & 0x1Fu) << 3;
-        const uint32_t a = (pixel & 0x8000u) ? 0x80u : 0u;
-        return r | (g << 8) | (b << 16) | (a << 24);
+        uint32_t r = ((c >> 0)  & 0xFF) >> 3;
+        uint32_t g = ((c >> 8)  & 0xFF) >> 3;
+        uint32_t b = ((c >> 16) & 0xFF) >> 3;
+        uint32_t a = ((c >> 24) & 0xFF) >> 7;
+
+        return (r | (g << 5) | (b << 10) | (a << 15));
+    }
+
+    u32 Rgba5551ToRgba8888(u16 c)
+    {
+        u32 r = ((c >> 0)  & 0x1F) << 3;
+        u32 g = ((c >> 5)  & 0x1F) << 3;
+        u32 b = ((c >> 10) & 0x1F) << 3;
+        u32 a = ((c >> 15) & 0x01) << 7;
+
+        return (r | (g << 8) | (b << 16) | (a << 24));
+    }
+
+    u32 pack32(u8 r, u8 g, u8 b, u8 a)
+    {
+        return static_cast<u32>(r) | (g << 8) | (b << 16) | (a << 24);
     }
 
     uint32_t applyTexa(const GSTexaReg &texa, uint8_t psm, uint32_t texel)
@@ -62,14 +78,6 @@ namespace
         }
 
         return (texel & 0x00FFFFFFu) | (static_cast<uint32_t>(a) << 24);
-    }
-
-    uint16_t encodePSMCT16(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-    {
-        return static_cast<uint16_t>(((r >> 3) & 0x1Fu) |
-                                     (((g >> 3) & 0x1Fu) << 5) |
-                                     (((b >> 3) & 0x1Fu) << 10) |
-                                     ((a >= 0x40u) ? 0x8000u : 0u));
     }
 
     uint32_t addrPSMCT16Family(uint32_t basePtr, uint32_t width, uint8_t psm, uint32_t x, uint32_t y)
@@ -402,95 +410,72 @@ void GSRasterizer::drawPrimitive(GS *gs)
 void GSRasterizer::writePixel(GS *gs, int x, int y, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
     const auto &ctx = gs->activeContext();
+
     if (x < ctx.scissor.x0 || x > ctx.scissor.x1 ||
         y < ctx.scissor.y0 || y > ctx.scissor.y1)
         return;
 
     const AlphaTestResult alphaTest = classifyAlphaTest(ctx.test, a);
+
     if (!alphaTest.writeFramebuffer)
         return;
 
-    const uint32_t widthBlocks = (ctx.frame.fbw != 0u) ? ctx.frame.fbw : 1u;
-    const uint32_t bytesPerPixel =
-        (ctx.frame.psm == GS_PSM_CT16 || ctx.frame.psm == GS_PSM_CT16S) ? 2u : 4u;
+    u8* vram = gs->m_vram;
 
-    uint32_t off = 0u;
-    if (ctx.frame.psm == GS_PSM_CT32 || ctx.frame.psm == GS_PSM_CT24)
+    const u32 fbp  = GSInternal::framePageBaseToBlock(ctx.frame.fbp);
+    const u32 fbw  = std::max<u32>(ctx.frame.fbw, 1u);
+    const u32 fpsm = ctx.frame.psm;
+    const u32 fmsk = ctx.frame.fbmsk;
+
+    const bool alphaBlendEnabled = gs->m_prim.abe;
+    const bool destinationAlpha  = alphaTest.preserveDestinationAlpha;
+
+    // small optimization, avoid reading the framebuffer for simple draws
+    // TODO: only one address lookup for rmw
+    const bool frmw = (ctx.frame.fbmsk != 0) || alphaBlendEnabled || destinationAlpha;
+
+    u32 fbrgba = 0;
+    if (frmw)
     {
-        off = GSPSMCT32::addrPSMCT32(GSInternal::framePageBaseToBlock(ctx.frame.fbp),
-                                     widthBlocks,
-                                     static_cast<uint32_t>(x),
-                                     static_cast<uint32_t>(y));
-    }
-    else
-    {
-        off = addrPSMCT16Family(GSInternal::framePageBaseToBlock(ctx.frame.fbp),
-                                widthBlocks,
-                                ctx.frame.psm,
-                                static_cast<uint32_t>(x),
-                                static_cast<uint32_t>(y));
-    }
-
-    if (off + bytesPerPixel > gs->m_vramSize)
-        return;
-
-    PS2_IF_AGRESSIVE_LOGS({
-        const uint32_t pixelIndex = s_debugPixelCount.fetch_add(1, std::memory_order_relaxed);
-        if (pixelIndex < 32u)
+        switch (fpsm)
         {
-            std::cout << "[gs:pixel] idx=" << pixelIndex
-                      << " xy=(" << x << "," << y << ")"
-                      << " rgba=(" << static_cast<uint32_t>(r) << ","
-                      << static_cast<uint32_t>(g) << ","
-                      << static_cast<uint32_t>(b) << ","
-                      << static_cast<uint32_t>(a) << ")"
-                      << " fbp=" << ctx.frame.fbp
-                      << " fbw=" << ctx.frame.fbw
-                      << " psm=0x" << std::hex << static_cast<uint32_t>(ctx.frame.psm) << std::dec
-                      << " off=0x" << std::hex << off << std::dec
-                      << std::endl;
+        case GS_PSM_CT32:
+            fbrgba = GSMem::ReadCT32(vram, fbp, fbw, x, y);
+            break;
+        case GS_PSM_Z32:
+            fbrgba = GSMem::ReadZ32(vram, fbp, fbw, x, y);
+            break;
+        case GS_PSM_CT24:
+            fbrgba = GSMem::ReadCT24(vram, fbp, fbw, x, y);
+            break;
+        case GS_PSM_Z24:
+            fbrgba = GSMem::ReadZ24(vram, fbp, fbw, x, y);
+            break;
+        case GS_PSM_CT16:
+            fbrgba = Rgba5551ToRgba8888(GSMem::ReadCT16(vram, fbp, fbw, x, y));
+            break;
+        case GS_PSM_CT16S:
+            fbrgba = Rgba5551ToRgba8888(GSMem::ReadCT16S(vram, fbp, fbw, x, y));
+            break;
+        case GS_PSM_Z16:
+            fbrgba = Rgba5551ToRgba8888(GSMem::ReadZ16(vram, fbp, fbw, x, y));
+            break;
+        case GS_PSM_Z16S:
+            fbrgba = Rgba5551ToRgba8888(GSMem::ReadZ16S(vram, fbp, fbw, x, y));
+            break;
         }
-    });
+    }
 
-    PS2_IF_AGRESSIVE_LOGS({
-        if (ctx.frame.fbp == 150u &&
-            s_debugFbp150PixelCount.fetch_add(1u, std::memory_order_relaxed) < 32u)
-        {
-            std::cout << "[gs:fbp150-pixel]"
-                      << " xy=(" << x << "," << y << ")"
-                      << " rgba=(" << static_cast<uint32_t>(r) << ","
-                      << static_cast<uint32_t>(g) << ","
-                      << static_cast<uint32_t>(b) << ","
-                      << static_cast<uint32_t>(a) << ")"
-                      << " scissor=(" << ctx.scissor.x0
-                      << "," << ctx.scissor.y0
-                      << ")-(" << ctx.scissor.x1
-                      << "," << ctx.scissor.y1 << ")"
-                      << " off=0x" << std::hex << off << std::dec << std::endl;
-        }
-    });
-
-    const uint8_t srcR = r;
-    const uint8_t srcG = g;
-    const uint8_t srcB = b;
+    const u8 srcR = r;
+    const u8 srcG = g;
+    const u8 srcB = b;
 
     if (gs->m_prim.abe)
     {
-        uint32_t existing = 0u;
-        if (bytesPerPixel == 2u)
-        {
-            uint16_t packed = 0u;
-            std::memcpy(&packed, gs->m_vram + off, 2);
-            existing = decodePSMCT16(packed);
-        }
-        else
-        {
-            std::memcpy(&existing, gs->m_vram + off, 4);
-        }
-        uint8_t dr = existing & 0xFF;
-        uint8_t dg = (existing >> 8) & 0xFF;
-        uint8_t db = (existing >> 16) & 0xFF;
-        uint8_t da = (existing >> 24) & 0xFF;
+        uint8_t dr = fbrgba & 0xFF;
+        uint8_t dg = (fbrgba >> 8) & 0xFF;
+        uint8_t db = (fbrgba >> 16) & 0xFF;
+        uint8_t da = (fbrgba >> 24) & 0xFF;
 
         // PABE disables alpha blending when the source alpha MSB is clear.
         if (!(gs->m_pabe && (a & 0x80u) == 0u))
@@ -533,75 +518,45 @@ void GSRasterizer::writePixel(GS *gs, int x, int y, uint8_t r, uint8_t g, uint8_
         a = static_cast<uint8_t>(a | 0x80u);
     }
 
-    if (bytesPerPixel == 2u)
-    {
-        uint16_t pixel = encodePSMCT16(r, g, b, a);
-        if ((mask & 0xFFFFu) != 0u)
-        {
-            uint16_t existing = 0u;
-            std::memcpy(&existing, gs->m_vram + off, 2);
-            pixel = static_cast<uint16_t>((pixel & ~mask) | (existing & mask));
-        }
-        std::memcpy(gs->m_vram + off, &pixel, 2);
-        return;
-    }
-
-    uint32_t pixel = static_cast<uint32_t>(r) | (static_cast<uint32_t>(g) << 8) | (static_cast<uint32_t>(b) << 16) | (static_cast<uint32_t>(a) << 24);
+    u32 pixel = pack32(r, g, b, a);
 
     if (mask != 0)
     {
-        uint32_t existing;
-        std::memcpy(&existing, gs->m_vram + off, 4);
-        pixel = (pixel & ~mask) | (existing & mask);
+        pixel = (pixel & ~mask) | (fbrgba & mask);
     }
 
     if (alphaTest.preserveDestinationAlpha)
     {
-        uint32_t existing = 0u;
-        std::memcpy(&existing, gs->m_vram + off, 4);
-        pixel = (pixel & 0x00FFFFFFu) | (existing & 0xFF000000u);
+        pixel = (pixel & 0x00FFFFFFu) | (fbrgba & 0xFF000000u);
     }
 
-    std::memcpy(gs->m_vram + off, &pixel, 4);
-}
-
-uint32_t GSRasterizer::readTexelPSMCT32(GS *gs, uint32_t tbp0, uint32_t tbw, int texU, int texV)
-{
-    if (tbw == 0)
-        tbw = 1;
-    uint32_t off = GSPSMCT32::addrPSMCT32(tbp0, tbw, static_cast<uint32_t>(texU), static_cast<uint32_t>(texV));
-    if (off + 4 > gs->m_vramSize)
-        return 0xFFFF00FFu;
-    uint32_t texel;
-    std::memcpy(&texel, gs->m_vram + off, 4);
-    return texel;
-}
-
-uint32_t GSRasterizer::readTexelPSMCT16(GS *gs, uint32_t tbp0, uint32_t tbw, int texU, int texV)
-{
-    if (tbw == 0)
-        tbw = 1;
-    const uint8_t psm = gs->activeContext().tex0.psm;
-    uint32_t off = addrPSMCT16Family(tbp0, tbw, psm, static_cast<uint32_t>(texU), static_cast<uint32_t>(texV));
-    if (off + 2 > gs->m_vramSize)
-        return 0xFFFF00FFu;
-    uint16_t texel;
-    std::memcpy(&texel, gs->m_vram + off, 2);
-    return decodePSMCT16(texel);
-}
-
-uint32_t GSRasterizer::readTexelPSMT4(GS *gs, uint32_t tbp0, uint32_t tbw, int texU, int texV)
-{
-    if (tbw == 0)
-        tbw = 1;
-    uint32_t nibbleAddr = GSPSMT4::addrPSMT4(tbp0, tbw, static_cast<uint32_t>(texU), static_cast<uint32_t>(texV));
-    uint32_t byteOff = nibbleAddr >> 1;
-    if (byteOff >= gs->m_vramSize)
-        return 0;
-    uint8_t packed = gs->m_vram[byteOff];
-    uint32_t shift = (nibbleAddr & 1u) << 2;
-    uint32_t idx = (packed >> shift) & 0xFu;
-    return idx;
+    switch (fpsm)
+    {
+    case GS_PSM_CT32:
+        GSMem::WriteCT32(vram, fbp, fbw, x, y, pixel);
+        break;
+    case GS_PSM_Z32:
+        GSMem::WriteZ32(vram, fbp, fbw, x, y, pixel);
+        break;
+    case GS_PSM_CT24:
+        GSMem::WriteCT24(vram, fbp, fbw, x, y, pixel);
+        break;
+    case GS_PSM_Z24:
+        GSMem::WriteZ24(vram, fbp, fbw, x, y, pixel);
+        break;
+    case GS_PSM_CT16:
+        GSMem::WriteCT16(vram, fbp, fbw, x, y, Rgba8888ToRgba5551(pixel));
+        break;
+    case GS_PSM_CT16S:
+        GSMem::WriteCT16S(vram, fbp, fbw, x, y, Rgba8888ToRgba5551(pixel));
+        break;
+    case GS_PSM_Z16:
+        GSMem::WriteZ16(vram, fbp, fbw, x, y, Rgba8888ToRgba5551(pixel));
+        break;
+    case GS_PSM_Z16S:
+        GSMem::WriteZ16S(vram, fbp, fbw, x, y, Rgba8888ToRgba5551(pixel));
+        break;
+    }
 }
 
 uint32_t GSRasterizer::lookupCLUT(GS *gs,
@@ -672,13 +627,13 @@ uint32_t GSRasterizer::sampleTexture(GS *gs, float s, float t, float q, uint16_t
         case GS_PSM_Z24:
             return applyTexa(gs->m_texa, tex.psm, GSMem::ReadZ24(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV));
         case GS_PSM_CT16:
-            return applyTexa(gs->m_texa, tex.psm, decodePSMCT16(GSMem::ReadCT16(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
+            return applyTexa(gs->m_texa, tex.psm, Rgba5551ToRgba8888(GSMem::ReadCT16(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
         case GS_PSM_CT16S:
-            return applyTexa(gs->m_texa, tex.psm, decodePSMCT16(GSMem::ReadCT16S(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
+            return applyTexa(gs->m_texa, tex.psm, Rgba5551ToRgba8888(GSMem::ReadCT16S(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
         case GS_PSM_Z16:
-            return applyTexa(gs->m_texa, tex.psm, decodePSMCT16(GSMem::ReadZ16(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
+            return applyTexa(gs->m_texa, tex.psm, Rgba5551ToRgba8888(GSMem::ReadZ16(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
         case GS_PSM_Z16S:
-            return applyTexa(gs->m_texa, tex.psm, decodePSMCT16(GSMem::ReadZ16S(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
+            return applyTexa(gs->m_texa, tex.psm, Rgba5551ToRgba8888(GSMem::ReadZ16S(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
         case GS_PSM_T8:
             return lookupCLUT(gs, GSMem::ReadP8(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV), tex.cbp, tex.cpsm, tex.csm, tex.csa, tex.psm);
         case GS_PSM_T8H:

--- a/ps2xRuntime/src/lib/ps2_gs_rasterizer.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_rasterizer.cpp
@@ -399,7 +399,7 @@ void GSRasterizer::drawPrimitive(GS *gs)
         const auto &ctx = gs->activeContext();
         int px = static_cast<int>(v.x) - (ctx.xyoffset.ofx >> 4);
         int py = static_cast<int>(v.y) - (ctx.xyoffset.ofy >> 4);
-        writePixel(gs, px, py, v.r, v.g, v.b, v.a);
+        writePixel(gs, px, py, static_cast<u32>(v.z), v.r, v.g, v.b, v.a);
         break;
     }
     default:
@@ -407,7 +407,7 @@ void GSRasterizer::drawPrimitive(GS *gs)
     }
 }
 
-void GSRasterizer::writePixel(GS *gs, int x, int y, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+void GSRasterizer::writePixel(GS *gs, int x, int y, int z, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
     const auto &ctx = gs->activeContext();
 
@@ -426,6 +426,8 @@ void GSRasterizer::writePixel(GS *gs, int x, int y, uint8_t r, uint8_t g, uint8_
     const u32 fbw  = std::max<u32>(ctx.frame.fbw, 1u);
     const u32 fpsm = ctx.frame.psm;
     const u32 fmsk = ctx.frame.fbmsk;
+    const u32 zbp = GSInternal::framePageBaseToBlock(ctx.zbuf.zbp);
+    const u32 zpsm = ctx.zbuf.psm;
 
     const bool alphaBlendEnabled = gs->m_prim.abe;
     const bool destinationAlpha  = alphaTest.preserveDestinationAlpha;
@@ -443,6 +445,31 @@ void GSRasterizer::writePixel(GS *gs, int x, int y, uint8_t r, uint8_t g, uint8_
         {
             fbrgba = Rgba5551ToRgba8888(fbrgba);
         }
+    }
+
+    uint ztest_method = (ctx.test >> 17) & 3;
+
+
+    bool zpass = false;
+    switch (ztest_method)
+    {
+    case 0:
+        zpass = false;
+        break;
+    case 1:
+        zpass = true;
+        break;
+    case 2:
+        zpass = z >= gs->ReadVram(zpsm, zbp, fbw, x, y);
+        break;
+    case 3:
+        zpass = z > gs->ReadVram(zpsm, zbp, fbw, x, y);
+        break;
+    }
+
+    if (!zpass)
+    {
+        return;
     }
 
     const u8 srcR = r;
@@ -489,7 +516,9 @@ void GSRasterizer::writePixel(GS *gs, int x, int y, uint8_t r, uint8_t g, uint8_
         }
     }
 
-    uint32_t mask = ctx.frame.fbmsk;
+    u32 fbmask = ctx.frame.fbmsk;
+    bool zmask = ctx.zbuf.zmask;
+
     if (!alphaTest.preserveDestinationAlpha &&
         (ctx.fba & 0x1ull) != 0ull &&
         ctx.frame.psm != GS_PSM_CT24)
@@ -499,9 +528,9 @@ void GSRasterizer::writePixel(GS *gs, int x, int y, uint8_t r, uint8_t g, uint8_
 
     u32 pixel = pack32(r, g, b, a);
 
-    if (mask != 0)
+    if (fbmask != 0)
     {
-        pixel = (pixel & ~mask) | (fbrgba & mask);
+        pixel = (pixel & ~fbmask) | (fbrgba & fbmask);
     }
 
     if (alphaTest.preserveDestinationAlpha)
@@ -516,6 +545,11 @@ void GSRasterizer::writePixel(GS *gs, int x, int y, uint8_t r, uint8_t g, uint8_
     }
 
     gs->WriteVram(fpsm, fbp, fbw, x, y, pixel);
+
+    if (!zmask)
+    {
+        gs->WriteVram(zpsm, zbp, fbw, x, y, z);
+    }
 }
 
 uint32_t GSRasterizer::lookupCLUT(GS *gs,
@@ -659,6 +693,7 @@ void GSRasterizer::drawSprite(GS *gs)
     int y0 = static_cast<int>(v0.y) - ofy;
     int x1 = static_cast<int>(v1.x) - ofx;
     int y1 = static_cast<int>(v1.y) - ofy;
+    u32 z1 = static_cast<u32>(v1.z);
 
     if (x0 > x1)
         std::swap(x0, x1);
@@ -774,7 +809,7 @@ void GSRasterizer::drawSprite(GS *gs)
                 uint8_t ta = static_cast<uint8_t>((texel >> 24) & 0xFF);
 
                 const TextureCombineResult color = combineTexture(tex, r, g, b, a, tr, tg, tb, ta);
-                writePixel(gs, x, y, color.r, color.g, color.b, color.a);
+                writePixel(gs, x, y, z1, color.r, color.g, color.b, color.a);
             }
         }
     }
@@ -782,7 +817,7 @@ void GSRasterizer::drawSprite(GS *gs)
     {
         for (int y = drawY0; y <= drawY1; ++y)
             for (int x = drawX0; x <= drawX1; ++x)
-                writePixel(gs, x, y, r, g, b, a);
+                writePixel(gs, x, y, z1, r, g, b, a);
     }
 }
 
@@ -834,6 +869,8 @@ void GSRasterizer::drawTriangle(GS *gs)
 
             if (w0 < -kEdgeEpsilon || w1 < -kEdgeEpsilon || w2 < -kEdgeEpsilon)
                 continue;
+
+            double z = v0.z * w0 + v1.z * w1 + v2.z * w2;
 
             uint8_t r, g, b, a;
             if (gs->m_prim.iip)
@@ -898,7 +935,7 @@ void GSRasterizer::drawTriangle(GS *gs)
                 a = color.a;
             }
 
-            writePixel(gs, x, y, r, g, b, a);
+            writePixel(gs, x, y, static_cast<u32>(z), r, g, b, a);
         }
     }
 }
@@ -947,7 +984,9 @@ void GSRasterizer::drawLine(GS *gs)
             a = v1.a;
         }
 
-        writePixel(gs, x0, y0, r, g, b, a);
+        double z = (v0.z + (v1.z - v0.z) * t);
+
+        writePixel(gs, x0, y0, static_cast<u32>(z), r, g, b, a);
 
         if (x0 == x1 && y0 == y1)
             break;

--- a/ps2xRuntime/src/lib/ps2_gs_rasterizer.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_rasterizer.cpp
@@ -437,32 +437,11 @@ void GSRasterizer::writePixel(GS *gs, int x, int y, uint8_t r, uint8_t g, uint8_
     u32 fbrgba = 0;
     if (frmw)
     {
-        switch (fpsm)
+        fbrgba = gs->ReadVram(fpsm, fbp, fbw, x, y);
+
+        if (bitsPerPixel(fpsm) == 16)
         {
-        case GS_PSM_CT32:
-            fbrgba = GSMem::ReadCT32(vram, fbp, fbw, x, y);
-            break;
-        case GS_PSM_Z32:
-            fbrgba = GSMem::ReadZ32(vram, fbp, fbw, x, y);
-            break;
-        case GS_PSM_CT24:
-            fbrgba = GSMem::ReadCT24(vram, fbp, fbw, x, y);
-            break;
-        case GS_PSM_Z24:
-            fbrgba = GSMem::ReadZ24(vram, fbp, fbw, x, y);
-            break;
-        case GS_PSM_CT16:
-            fbrgba = Rgba5551ToRgba8888(GSMem::ReadCT16(vram, fbp, fbw, x, y));
-            break;
-        case GS_PSM_CT16S:
-            fbrgba = Rgba5551ToRgba8888(GSMem::ReadCT16S(vram, fbp, fbw, x, y));
-            break;
-        case GS_PSM_Z16:
-            fbrgba = Rgba5551ToRgba8888(GSMem::ReadZ16(vram, fbp, fbw, x, y));
-            break;
-        case GS_PSM_Z16S:
-            fbrgba = Rgba5551ToRgba8888(GSMem::ReadZ16S(vram, fbp, fbw, x, y));
-            break;
+            fbrgba = Rgba5551ToRgba8888(fbrgba);
         }
     }
 
@@ -529,34 +508,14 @@ void GSRasterizer::writePixel(GS *gs, int x, int y, uint8_t r, uint8_t g, uint8_
     {
         pixel = (pixel & 0x00FFFFFFu) | (fbrgba & 0xFF000000u);
     }
-
-    switch (fpsm)
+    
+    // format conversion
+    if (bitsPerPixel(fpsm) == 16)
     {
-    case GS_PSM_CT32:
-        GSMem::WriteCT32(vram, fbp, fbw, x, y, pixel);
-        break;
-    case GS_PSM_Z32:
-        GSMem::WriteZ32(vram, fbp, fbw, x, y, pixel);
-        break;
-    case GS_PSM_CT24:
-        GSMem::WriteCT24(vram, fbp, fbw, x, y, pixel);
-        break;
-    case GS_PSM_Z24:
-        GSMem::WriteZ24(vram, fbp, fbw, x, y, pixel);
-        break;
-    case GS_PSM_CT16:
-        GSMem::WriteCT16(vram, fbp, fbw, x, y, Rgba8888ToRgba5551(pixel));
-        break;
-    case GS_PSM_CT16S:
-        GSMem::WriteCT16S(vram, fbp, fbw, x, y, Rgba8888ToRgba5551(pixel));
-        break;
-    case GS_PSM_Z16:
-        GSMem::WriteZ16(vram, fbp, fbw, x, y, Rgba8888ToRgba5551(pixel));
-        break;
-    case GS_PSM_Z16S:
-        GSMem::WriteZ16S(vram, fbp, fbw, x, y, Rgba8888ToRgba5551(pixel));
-        break;
+        pixel = Rgba8888ToRgba5551(pixel);
     }
+
+    gs->WriteVram(fpsm, fbp, fbw, x, y, pixel);
 }
 
 uint32_t GSRasterizer::lookupCLUT(GS *gs,
@@ -616,34 +575,26 @@ uint32_t GSRasterizer::sampleTexture(GS *gs, float s, float t, float q, uint16_t
         sampleU = clampInt(sampleU, 0, texW - 1);
         sampleV = clampInt(sampleV, 0, texH - 1);
 
+        u32 out = gs->ReadVram(tex.psm, tex.tbp0, tex.tbw, sampleU, sampleV);
+
         switch (tex.psm)
         {
         case GS_PSM_CT32:
-            return applyTexa(gs->m_texa, tex.psm, GSMem::ReadCT32(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV));
         case GS_PSM_Z32:
-            return applyTexa(gs->m_texa, tex.psm, GSMem::ReadZ32(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV));
         case GS_PSM_CT24:
-            return applyTexa(gs->m_texa, tex.psm, GSMem::ReadCT24(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV));
         case GS_PSM_Z24:
-            return applyTexa(gs->m_texa, tex.psm, GSMem::ReadZ24(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV));
+            return applyTexa(gs->m_texa, tex.psm, out);
         case GS_PSM_CT16:
-            return applyTexa(gs->m_texa, tex.psm, Rgba5551ToRgba8888(GSMem::ReadCT16(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
         case GS_PSM_CT16S:
-            return applyTexa(gs->m_texa, tex.psm, Rgba5551ToRgba8888(GSMem::ReadCT16S(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
         case GS_PSM_Z16:
-            return applyTexa(gs->m_texa, tex.psm, Rgba5551ToRgba8888(GSMem::ReadZ16(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
         case GS_PSM_Z16S:
-            return applyTexa(gs->m_texa, tex.psm, Rgba5551ToRgba8888(GSMem::ReadZ16S(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV)));
+            return applyTexa(gs->m_texa, tex.psm, Rgba5551ToRgba8888(out));
         case GS_PSM_T8:
-            return lookupCLUT(gs, GSMem::ReadP8(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV), tex.cbp, tex.cpsm, tex.csm, tex.csa, tex.psm);
         case GS_PSM_T8H:
-            return lookupCLUT(gs, GSMem::ReadP8H(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV), tex.cbp, tex.cpsm, tex.csm, tex.csa, tex.psm);
         case GS_PSM_T4:
-            return lookupCLUT(gs, GSMem::ReadP4(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV), tex.cbp, tex.cpsm, tex.csm, tex.csa, tex.psm);
         case GS_PSM_T4HL:
-            return lookupCLUT(gs, GSMem::ReadP4HL(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV), tex.cbp, tex.cpsm, tex.csm, tex.csa, tex.psm);
         case GS_PSM_T4HH:
-            return lookupCLUT(gs, GSMem::ReadP4HH(gs->m_vram, tex.tbp0, tex.tbw, sampleU, sampleV), tex.cbp, tex.cpsm, tex.csm, tex.csa, tex.psm);
+            return lookupCLUT(gs, static_cast<u8>(out), tex.cbp, tex.cpsm, tex.csm, tex.csa, tex.psm);
         }
 
         return 0xFFFF00FFu;

--- a/ps2xTest/src/ps2_gs_tests.cpp
+++ b/ps2xTest/src/ps2_gs_tests.cpp
@@ -619,6 +619,7 @@ void register_ps2_gs_tests()
             gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
 
             gs.writeRegister(GS_REG_FRAME_1, (1ull << 16)); // FBW=1, PSMCT32, FBP=0
+            gs.writeRegister(GS_REG_ZBUF_1, (1ull << 32));
             gs.writeRegister(GS_REG_SCISSOR_1, 0ull);
             gs.writeRegister(GS_REG_ALPHA_1, 0x6000000064ull);
             gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
@@ -668,8 +669,9 @@ void register_ps2_gs_tests()
             gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
 
             gs.writeRegister(GS_REG_FRAME_1, (1ull << 16));
+            gs.writeRegister(GS_REG_ZBUF_1, (1ull) << 32);
             gs.writeRegister(GS_REG_SCISSOR_1, 0ull);
-            gs.writeRegister(GS_REG_TEST_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
 
             gs.writeRegister(GS_REG_PRIM, static_cast<uint64_t>(GS_PRIM_POINT));
             gs.writeRegister(GS_REG_FBA_1, 0ull);
@@ -704,6 +706,7 @@ void register_ps2_gs_tests()
                 (0ull << 0) |
                 (1ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf1 = (1ull << 32);
             constexpr uint64_t kScissor1 =
                 (0ull << 0) |
                 (1ull << 16) |
@@ -713,6 +716,7 @@ void register_ps2_gs_tests()
                 (150ull << 0) |
                 (1ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf2 = (1ull << 32);
             constexpr uint64_t kScissor2 = 0ull;
             constexpr uint64_t kTex0_2 =
                 (0ull << 0) |
@@ -737,17 +741,19 @@ void register_ps2_gs_tests()
                 (16ull << 16);
 
             gs.writeRegister(GS_REG_FRAME_1, kFrame1);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf1);
             gs.writeRegister(GS_REG_SCISSOR_1, kScissor1);
             gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
-            gs.writeRegister(GS_REG_TEST_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
             gs.writeRegister(GS_REG_PRIM, kPointPrim);
             gs.writeRegister(GS_REG_RGBAQ, kSourceColor);
             gs.writeRegister(GS_REG_XYZ2, kPointXyz);
 
             gs.writeRegister(GS_REG_FRAME_2, kFrame2);
+            gs.writeRegister(GS_REG_ZBUF_2, kZbuf2);
             gs.writeRegister(GS_REG_SCISSOR_2, kScissor2);
             gs.writeRegister(GS_REG_XYOFFSET_2, 0ull);
-            gs.writeRegister(GS_REG_TEST_2, 0ull);
+            gs.writeRegister(GS_REG_TEST_2, 0x30000ull);
             gs.writeRegister(GS_REG_TEX0_2, kTex0_2);
             gs.writeRegister(GS_REG_PRIM, kCopyPrim);
             gs.writeRegister(GS_REG_RGBAQ, 0x80808080ull);
@@ -772,6 +778,7 @@ void register_ps2_gs_tests()
                 (150ull << 0) |
                 (1ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
             constexpr uint64_t kScissor =
                 (0ull << 0) |
                 (3ull << 16) |
@@ -812,9 +819,10 @@ void register_ps2_gs_tests()
             }
 
             gs.writeRegister(GS_REG_FRAME_1, kFrame);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
             gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
             gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
-            gs.writeRegister(GS_REG_TEST_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
             gs.writeRegister(GS_REG_ALPHA_1, 0ull);
             gs.writeRegister(GS_REG_TEX0_1, kTex0);
             gs.writeRegister(GS_REG_TEX1_1, 0ull);
@@ -944,6 +952,7 @@ void register_ps2_gs_tests()
                 150ull |
                 (10ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf2 = (1ull << 32);
             constexpr uint64_t kScissor2 =
                 (0ull << 0) |
                 (639ull << 16) |
@@ -983,6 +992,7 @@ void register_ps2_gs_tests()
                 ((8ull + (480ull * 16ull)) << 16);
 
             gs.writeRegister(GS_REG_FRAME_2, kFrame2);
+            gs.writeRegister(GS_REG_ZBUF_2, kZbuf2);
             gs.writeRegister(GS_REG_SCISSOR_2, kScissor2);
             gs.writeRegister(GS_REG_XYOFFSET_2, kXYOffset2);
             gs.writeRegister(GS_REG_ALPHA_2, kAlpha2);
@@ -1131,6 +1141,7 @@ void register_ps2_gs_tests()
                 150ull |
                 (10ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf2 = (static_cast<uint64_t>(1) << 32);
             constexpr uint64_t kScissor2 =
                 (0ull << 0) |
                 (639ull << 16) |
@@ -1170,6 +1181,7 @@ void register_ps2_gs_tests()
                 ((8ull + (480ull * 16ull)) << 16);
 
             gs.writeRegister(GS_REG_FRAME_2, kFrame2);
+            gs.writeRegister(GS_REG_ZBUF_2, kZbuf2);
             gs.writeRegister(GS_REG_SCISSOR_2, kScissor2);
             gs.writeRegister(GS_REG_XYOFFSET_2, kXYOffset2);
             gs.writeRegister(GS_REG_ALPHA_2, kAlpha2);
@@ -1601,6 +1613,7 @@ void register_ps2_gs_tests()
                 (0ull << 0) |
                 (1ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
             constexpr uint64_t kScissor =
                 (0ull << 0) |
                 (4ull << 16) |
@@ -1659,9 +1672,10 @@ void register_ps2_gs_tests()
                 std::memcpy(vram.data() + clutOff, &sample.color, sizeof(sample.color));
 
                 gs.writeRegister(GS_REG_FRAME_1, kFrame);
+                gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
                 gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
                 gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
-                gs.writeRegister(GS_REG_TEST_1, 0ull);
+                gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
                 gs.writeRegister(GS_REG_ALPHA_1, 0ull);
                 gs.writeRegister(GS_REG_TEX0_1, kTex0);
                 gs.writeRegister(GS_REG_TEX1_1, 0ull);
@@ -2271,6 +2285,7 @@ void register_ps2_gs_tests()
                 (0ull << 0) |
                 (1ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
             constexpr uint64_t kTex0 =
                 (static_cast<uint64_t>(kTexTbp) << 0) |
                 (1ull << 14) |
@@ -2300,9 +2315,10 @@ void register_ps2_gs_tests()
             std::memcpy(vram.data() + expectedClutOff, &kExpectedColor, sizeof(kExpectedColor));
 
             gs.writeRegister(GS_REG_FRAME_1, kFrameReg);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
             gs.writeRegister(GS_REG_SCISSOR_1, 0ull);
             gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
-            gs.writeRegister(GS_REG_TEST_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
             gs.writeRegister(GS_REG_ALPHA_1, 0ull);
             gs.writeRegister(GS_REG_TEX0_1, kTex0);
             gs.writeRegister(GS_REG_PRIM, kPrim);
@@ -2330,6 +2346,7 @@ void register_ps2_gs_tests()
                 (0ull << 0) |
                 (1ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
             constexpr uint64_t kTex0 =
                 (static_cast<uint64_t>(kTexTbp) << 0) |
                 (1ull << 14) |
@@ -2380,9 +2397,10 @@ void register_ps2_gs_tests()
             gs.processGIFPacket(packet.data(), static_cast<uint32_t>(packet.size()));
 
             gs.writeRegister(GS_REG_FRAME_1, kFrameReg);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
             gs.writeRegister(GS_REG_SCISSOR_1, 0ull);
             gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
-            gs.writeRegister(GS_REG_TEST_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
             gs.writeRegister(GS_REG_ALPHA_1, 0ull);
             gs.writeRegister(GS_REG_TEX0_1, kTex0);
             gs.writeRegister(GS_REG_PRIM, kPrim);
@@ -2411,6 +2429,7 @@ void register_ps2_gs_tests()
                 (0ull << 0) |
                 (1ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
             constexpr uint64_t kTex0 =
                 (static_cast<uint64_t>(kTexTbp) << 0) |
                 (1ull << 14) |
@@ -2443,9 +2462,10 @@ void register_ps2_gs_tests()
             std::memcpy(vram.data() + expectedClutOff, &kExpectedColor, sizeof(kExpectedColor));
 
             gs.writeRegister(GS_REG_FRAME_1, kFrameReg);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
             gs.writeRegister(GS_REG_SCISSOR_1, 0ull);
             gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
-            gs.writeRegister(GS_REG_TEST_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
             gs.writeRegister(GS_REG_ALPHA_1, 0ull);
             gs.writeRegister(GS_REG_TEX0_1, kTex0);
             gs.writeRegister(GS_REG_TEX2_1, kTex2);
@@ -2474,6 +2494,7 @@ void register_ps2_gs_tests()
                 (0ull << 0) |
                 (1ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
             constexpr uint64_t kTex0 =
                 (static_cast<uint64_t>(kTexTbp) << 0) |
                 (1ull << 14) |
@@ -2505,9 +2526,10 @@ void register_ps2_gs_tests()
             std::memcpy(vram.data() + expectedClutOff, &kExpectedColor, sizeof(kExpectedColor));
 
             gs.writeRegister(GS_REG_FRAME_1, kFrameReg);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
             gs.writeRegister(GS_REG_SCISSOR_1, 0ull);
             gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
-            gs.writeRegister(GS_REG_TEST_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
             gs.writeRegister(GS_REG_ALPHA_1, 0ull);
             gs.writeRegister(GS_REG_TEX0_1, kTex0);
             gs.writeRegister(GS_REG_TEXCLUT, kTexClut);
@@ -2535,6 +2557,7 @@ void register_ps2_gs_tests()
                 (0ull << 0) |
                 (1ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
             constexpr uint64_t kScissor =
                 (0ull << 0) |
                 (1ull << 16) |
@@ -2572,9 +2595,10 @@ void register_ps2_gs_tests()
             vram[blackOff + 3u] = 0x00u;
 
             gs.writeRegister(GS_REG_FRAME_1, kFrameReg);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
             gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
             gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
-            gs.writeRegister(GS_REG_TEST_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
             gs.writeRegister(GS_REG_ALPHA_1, 0ull);
             gs.writeRegister(GS_REG_TEX0_1, kTex0);
             gs.writeRegister(GS_REG_TEXA, kTexa);
@@ -2610,6 +2634,7 @@ void register_ps2_gs_tests()
                 (0ull << 0) |
                 (1ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
             constexpr uint64_t kScissor =
                 (0ull << 0) |
                 (0ull << 16) |
@@ -2642,9 +2667,10 @@ void register_ps2_gs_tests()
             std::memcpy(vram.data() + texOff, &kTexturePixel, sizeof(kTexturePixel));
 
             gs.writeRegister(GS_REG_FRAME_1, kFrameReg);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
             gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
             gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
-            gs.writeRegister(GS_REG_TEST_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
             gs.writeRegister(GS_REG_ALPHA_1, 0ull);
             gs.writeRegister(GS_REG_TEX0_1, kTex0);
             gs.writeRegister(GS_REG_PRIM, kPrim);
@@ -2670,6 +2696,7 @@ void register_ps2_gs_tests()
                 (0ull << 0) |
                 (1ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
             constexpr uint64_t kScissor =
                 (0ull << 0) |
                 (0ull << 16) |
@@ -2702,9 +2729,10 @@ void register_ps2_gs_tests()
             std::memcpy(vram.data() + texOff, &kTexturePixel, sizeof(kTexturePixel));
 
             gs.writeRegister(GS_REG_FRAME_1, kFrameReg);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
             gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
             gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
-            gs.writeRegister(GS_REG_TEST_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
             gs.writeRegister(GS_REG_ALPHA_1, 0ull);
             gs.writeRegister(GS_REG_TEX0_1, kTex0);
             gs.writeRegister(GS_REG_PRIM, kPrim);
@@ -2730,6 +2758,7 @@ void register_ps2_gs_tests()
                 (0ull << 0) |
                 (1ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
             constexpr uint64_t kScissor =
                 (0ull << 0) |
                 (0ull << 16) |
@@ -2762,9 +2791,10 @@ void register_ps2_gs_tests()
             std::memcpy(vram.data() + texOff, &kTexturePixel, sizeof(kTexturePixel));
 
             gs.writeRegister(GS_REG_FRAME_1, kFrameReg);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
             gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
             gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
-            gs.writeRegister(GS_REG_TEST_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
             gs.writeRegister(GS_REG_ALPHA_1, 0ull);
             gs.writeRegister(GS_REG_TEX0_1, kTex0);
             gs.writeRegister(GS_REG_PRIM, kPrim);
@@ -2793,6 +2823,7 @@ void register_ps2_gs_tests()
                     (0ull << 0) |
                     (1ull << 16) |
                     (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+                constexpr uint64_t kZbuf = (1ull << 32);
                 constexpr uint64_t kScissor =
                     (0ull << 0) |
                     (4ull << 16) |
@@ -2835,9 +2866,10 @@ void register_ps2_gs_tests()
                 };
 
                 gs.writeRegister(GS_REG_FRAME_1, kFrame);
+                gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
                 gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
                 gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
-                gs.writeRegister(GS_REG_TEST_1, 0ull);
+                gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
                 gs.writeRegister(GS_REG_ALPHA_1, 0ull);
                 gs.writeRegister(GS_REG_TEX0_1, kTex0);
                 gs.writeRegister(GS_REG_TEX1_1, tex1Reg);
@@ -2881,6 +2913,7 @@ void register_ps2_gs_tests()
                 (0ull << 0) |
                 (1ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
             constexpr uint64_t kScissor =
                 (0ull << 0) |
                 (0ull << 16) |
@@ -2890,7 +2923,8 @@ void register_ps2_gs_tests()
                 1ull |                  // ATE
                 (5ull << 1) |          // ATST = GEQUAL
                 (0x80ull << 4) |       // AREF
-                (1ull << 12);          // AFAIL = FB_ONLY
+                (1ull << 12) |          // AFAIL = FB_ONLY
+                (1ull << 17);          // ZTST = ALWAYS
             constexpr uint64_t kPrim =
                 static_cast<uint64_t>(GS_PRIM_POINT);
             constexpr uint64_t kRgbaq =
@@ -2901,6 +2935,7 @@ void register_ps2_gs_tests()
                 (0x3F800000ull << 32); // q = 1.0f
 
             gs.writeRegister(GS_REG_FRAME_1, kFrame);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
             gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
             gs.writeRegister(GS_REG_TEST_1, kTest);
             gs.writeRegister(GS_REG_PRIM, kPrim);
@@ -2923,16 +2958,18 @@ void register_ps2_gs_tests()
                 (0ull << 0) |
                 (1ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
             constexpr uint64_t kScissor =
                 (0ull << 0) |
                 (0ull << 16) |
                 (0ull << 32) |
                 (0ull << 48);
             constexpr uint64_t kTest =
-                1ull |                  // ATE
-                (5ull << 1) |          // ATST = GEQUAL
-                (0x80ull << 4) |       // AREF
-                (3ull << 12);          // AFAIL = RGB_ONLY
+                1ull |                // ATE
+                (5ull << 1) |         // ATST = GEQUAL
+                (0x80ull << 4) |      // AREF
+                (3ull << 12) |        // AFAIL = RGB_ONLY
+                (1ull << 17);         // ZTST = ALWAYS
             constexpr uint64_t kPrim =
                 static_cast<uint64_t>(GS_PRIM_POINT);
             constexpr uint64_t kRgbaq =
@@ -2946,6 +2983,7 @@ void register_ps2_gs_tests()
             std::memcpy(vram.data(), &kExisting, sizeof(kExisting));
 
             gs.writeRegister(GS_REG_FRAME_1, kFrame);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
             gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
             gs.writeRegister(GS_REG_TEST_1, kTest);
             gs.writeRegister(GS_REG_PRIM, kPrim);
@@ -2968,6 +3006,7 @@ void register_ps2_gs_tests()
                 (0ull << 0) |
                 (1ull << 16) |
                 (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
             constexpr uint64_t kScissor =
                 (0ull << 0) |
                 (31ull << 16) |
@@ -2988,9 +3027,10 @@ void register_ps2_gs_tests()
             };
 
             gs.writeRegister(GS_REG_FRAME_1, kFrame);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
             gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
             gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
-            gs.writeRegister(GS_REG_TEST_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
             gs.writeRegister(GS_REG_PRIM, kPrim);
             gs.writeRegister(GS_REG_RGBAQ, kRgbaq);
             gs.writeRegister(GS_REG_XYZF2, makeXyzf(102u, 102u));

--- a/ps2xTest/src/ps2_runtime_expansion_tests.cpp
+++ b/ps2xTest/src/ps2_runtime_expansion_tests.cpp
@@ -772,7 +772,12 @@ void register_ps2_runtime_expansion_tests()
                 (1ull << 16) |  // FBW
                 (0ull << 24) |  // PSM CT32
                 (0ull << 32);   // FBMSK
+
+            const uint64_t zbuf1 = (1ull << 32);
+
             gs.writeRegister(GS_REG_FRAME_1, frame1);
+            gs.writeRegister(GS_REG_ZBUF_1, zbuf1);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
 
             // XYOFFSET=1,1 pixels (16.4 fixed point).
             const uint64_t xyoffset = (16ull) | (16ull << 32);
@@ -827,9 +832,12 @@ void register_ps2_runtime_expansion_tests()
                 (1ull << 16) |  // FBW
                 (0ull << 24) |  // PSM CT32
                 (0ull << 32);   // FBMSK
+            const uint64_t zbuf1 = (1ull << 32);
             gs.writeRegister(GS_REG_FRAME_1, frame1);
+            gs.writeRegister(GS_REG_ZBUF_1, zbuf1);
             gs.writeRegister(GS_REG_SCISSOR_1, (0ull) | (4ull << 16) | (0ull << 32) | (4ull << 48));
             gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
 
             const uint32_t pxOff = frameOffsetBytes(1u, 1u, 1u);
             vram[pxOff + 0u] = 40u;


### PR DESCRIPTION
This PR reimplements a lot of the swizzling for gs memory.
Additionally, it provides some speed improvements by reducing a lot of the swizzling math to a lookup. Note that you need to compile with optimization to see this performance increase.

There is additionally a small `types.h` header I hope to work into the rest of the runtime at some point

**New texture formats:**
P8H
P4HL
P4HH
Z32
Z16
Z24
Z16S

**Improved over the previous code:**
CT16
CT16S

**Other improvements**:
GS memory wrapping (memory wraps at 4mb)

Test program: https://github.com/tealalchemist/gstests/tree/main/texture
Tested against emulator

output before this PR (provided by ranj, 24 bit is actually a bug I need to correct in the test program later)
<img width="655" height="496" alt="image" src="https://github.com/user-attachments/assets/5fc11c02-b70e-462b-9fc9-85677c4ecf0c" />

output with this PR:
<img width="639" height="479" alt="image" src="https://github.com/user-attachments/assets/d124bf77-fb3a-4b7a-abc5-d3cc9e92e9e9" />

Emulator comparison:
<img width="629" height="446" alt="image" src="https://github.com/user-attachments/assets/e5657177-31d4-49f2-8eb0-4d5f27b21dea" />

The emulator is a modified version of DobieStation (used because it's pretty accurate and I find it easier to read than PCSX2)

**TODO:**
The clut on the GS is cached, this can be implemented to our benefit to reduce the clut swizzling calculations
Some of the code is repetitive. I hope to rework some of the transfer code to a generic `Unpack` function
There is currently no depth handling
Local to local and local to host transfer rework
Remove old swizzling code
Various other smaller improvements I think need to be made

Thank you to ranj for the help with getting the test program working properly