### PR TITLE
runtime: fix run-token ⇄ guest-mutex lock-order deadlock in blocking syscalls (WaitSema et al.)

### DIFF
--- a/ps2xRuntime/include/ps2_runtime.h
+++ b/ps2xRuntime/include/ps2_runtime.h
@@ -469,11 +469,10 @@ public:
     class GuestExecutionReleaseScope
     {
     public:
-        explicit GuestExecutionReleaseScope(PS2Runtime *runtime) noexcept;
         // Owns the caller's guest-object unique_lock; the destructor unlocks it before
         // reacquiring the run-token, so a blocking syscall never parks for the run-token
         // while holding a guest-object mutex. The referenced lock must outlive this scope.
-        GuestExecutionReleaseScope(PS2Runtime *runtime, std::unique_lock<std::mutex> &lock) noexcept;
+        explicit GuestExecutionReleaseScope(PS2Runtime *runtime, std::unique_lock<std::mutex> &lock) noexcept;
         ~GuestExecutionReleaseScope();
 
         GuestExecutionReleaseScope(const GuestExecutionReleaseScope &) = delete;

--- a/ps2xRuntime/include/ps2_runtime.h
+++ b/ps2xRuntime/include/ps2_runtime.h
@@ -470,6 +470,10 @@ public:
     {
     public:
         explicit GuestExecutionReleaseScope(PS2Runtime *runtime) noexcept;
+        // Owns the caller's guest-object unique_lock; the destructor unlocks it before
+        // reacquiring the run-token, so a blocking syscall never parks for the run-token
+        // while holding a guest-object mutex. The referenced lock must outlive this scope.
+        GuestExecutionReleaseScope(PS2Runtime *runtime, std::unique_lock<std::mutex> &lock) noexcept;
         ~GuestExecutionReleaseScope();
 
         GuestExecutionReleaseScope(const GuestExecutionReleaseScope &) = delete;
@@ -478,6 +482,7 @@ public:
     private:
         PS2Runtime *m_runtime = nullptr;
         uint32_t m_depth = 0u;
+        std::unique_lock<std::mutex> *m_lock = nullptr;
     };
 
     void registerFunction(uint32_t address, RecompiledFunction func);

--- a/ps2xRuntime/src/lib/Kernel/Syscalls/Helpers/Runtime.h
+++ b/ps2xRuntime/src/lib/Kernel/Syscalls/Helpers/Runtime.h
@@ -29,10 +29,11 @@ static void waitWhileSuspended(const std::shared_ptr<ThreadInfo> &info, PS2Runti
         info->waitType = TSW_NONE;
         info->waitId = 0;
         {
-            PS2Runtime::GuestExecutionReleaseScope releaseGuestExecution(runtime);
+            PS2Runtime::GuestExecutionReleaseScope releaseGuestExecution(runtime, lock);
             info->cv.wait(lock, [&]()
                           { return info->suspendCount == 0 || info->terminated.load(); });
         }
+        lock.lock(); // release scope dropped info->m; re-take it for the post-wait bookkeeping.
         if (info->terminated.load())
         {
             throw ThreadExitException();

--- a/ps2xRuntime/src/lib/Kernel/Syscalls/Interrupt.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Syscalls/Interrupt.cpp
@@ -397,10 +397,11 @@ namespace ps2_syscalls
         std::unique_lock<std::mutex> lock(g_vsync_flag_mutex);
         uint64_t current = g_vsync_tick_counter;
         {
-            PS2Runtime::GuestExecutionReleaseScope releaseGuestExecution(runtime);
+            PS2Runtime::GuestExecutionReleaseScope releaseGuestExecution(runtime, lock);
             g_vsync_cv.wait(lock, [current, runtime]()
                             { return g_vsync_tick_counter > current || (runtime != nullptr && runtime->isStopRequested()); });
         }
+        lock.lock(); // release scope dropped the vsync mutex; re-take it to read the counter.
         return g_vsync_tick_counter;
     }
 

--- a/ps2xRuntime/src/lib/Kernel/Syscalls/Sync.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Syscalls/Sync.cpp
@@ -313,7 +313,7 @@ namespace ps2_syscalls
 
             sema->waiters++;
             {
-                PS2Runtime::GuestExecutionReleaseScope releaseGuestExecution(runtime);
+                PS2Runtime::GuestExecutionReleaseScope releaseGuestExecution(runtime, lock);
                 sema->cv.wait(lock, [&]()
                               {
                                   bool forced = info ? info->forceRelease.load() : false;
@@ -321,6 +321,7 @@ namespace ps2_syscalls
                                   return sema->count > 0 || sema->deleted || forced || terminated; //
                               });
             }
+            lock.lock(); // release scope dropped sema->m; re-take it for the post-wait bookkeeping.
             sema->waiters--;
             if (sema->deleted)
             {
@@ -636,9 +637,10 @@ namespace ps2_syscalls
 
             info->waiters++;
             {
-                PS2Runtime::GuestExecutionReleaseScope releaseGuestExecution(runtime);
+                PS2Runtime::GuestExecutionReleaseScope releaseGuestExecution(runtime, lock);
                 info->cv.wait(lock, satisfied);
             }
+            lock.lock(); // release scope dropped info->m; re-take it for the post-wait bookkeeping.
             info->waiters--;
 
             if (tInfo)

--- a/ps2xRuntime/src/lib/Kernel/Syscalls/Thread.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Syscalls/Thread.cpp
@@ -604,10 +604,10 @@ namespace ps2_syscalls
             // Block until the target thread actually finishes unwinding and becomes dormant
             std::unique_lock<std::mutex> lock(info->m);
             {
-                PS2Runtime::GuestExecutionReleaseScope releaseGuestExecution(runtime);
+                PS2Runtime::GuestExecutionReleaseScope releaseGuestExecution(runtime, lock);
                 info->cv.wait(lock, [&]()
                               { return !info->started && info->status == THS_DORMANT; });
-            }
+            } // nothing after needs info->m, so it stays released (no re-lock).
         }
 
         setReturnS32(ctx, KE_OK);
@@ -642,10 +642,11 @@ namespace ps2_syscalls
         {
             std::unique_lock<std::mutex> lock(info->m);
             {
-                PS2Runtime::GuestExecutionReleaseScope releaseGuestExecution(runtime);
+                PS2Runtime::GuestExecutionReleaseScope releaseGuestExecution(runtime, lock);
                 info->cv.wait(lock, [&]()
                               { return info->suspendCount == 0 || info->terminated.load(); });
             }
+            lock.lock(); // release scope dropped info->m; re-take it for the post-wait bookkeeping.
             if (info->terminated.load())
             {
                 throw ThreadExitException();
@@ -788,10 +789,11 @@ namespace ps2_syscalls
             info->forceRelease = false;
 
             {
-                PS2Runtime::GuestExecutionReleaseScope releaseGuestExecution(runtime);
+                PS2Runtime::GuestExecutionReleaseScope releaseGuestExecution(runtime, lock);
                 info->cv.wait(lock, [&]()
                               { return info->wakeupCount > 0 || info->forceRelease.load() || info->terminated.load(); });
             }
+            lock.lock(); // release scope dropped info->m; re-take it for the post-wait bookkeeping.
 
             if (info->terminated.load())
             {

--- a/ps2xRuntime/src/lib/ps2_runtime.cpp
+++ b/ps2xRuntime/src/lib/ps2_runtime.cpp
@@ -412,8 +412,24 @@ PS2Runtime::GuestExecutionReleaseScope::GuestExecutionReleaseScope(PS2Runtime *r
     }
 }
 
+PS2Runtime::GuestExecutionReleaseScope::GuestExecutionReleaseScope(PS2Runtime *runtime,
+                                                                   std::unique_lock<std::mutex> &lock) noexcept
+    : m_runtime(runtime), m_lock(&lock)
+{
+    if (m_runtime)
+    {
+        m_depth = m_runtime->releaseGuestExecution();
+    }
+}
+
 PS2Runtime::GuestExecutionReleaseScope::~GuestExecutionReleaseScope()
 {
+    // Drop the guest-object mutex before reacquiring the run-token, so a thread parked for
+    // the run-token never holds a mutex a run-token holder might lock (which would deadlock).
+    if (m_lock && m_lock->owns_lock())
+    {
+        m_lock->unlock();
+    }
     if (m_runtime && m_depth != 0u)
     {
         m_runtime->reacquireGuestExecution(m_depth);

--- a/ps2xRuntime/src/lib/ps2_runtime.cpp
+++ b/ps2xRuntime/src/lib/ps2_runtime.cpp
@@ -403,15 +403,6 @@ PS2Runtime::GuestExecutionScope::~GuestExecutionScope()
     }
 }
 
-PS2Runtime::GuestExecutionReleaseScope::GuestExecutionReleaseScope(PS2Runtime *runtime) noexcept
-    : m_runtime(runtime)
-{
-    if (m_runtime)
-    {
-        m_depth = m_runtime->releaseGuestExecution();
-    }
-}
-
 PS2Runtime::GuestExecutionReleaseScope::GuestExecutionReleaseScope(PS2Runtime *runtime,
                                                                    std::unique_lock<std::mutex> &lock) noexcept
     : m_runtime(runtime), m_lock(&lock)


### PR DESCRIPTION
## Problem
The cooperative run-token scheduler can deadlock. Every blocking syscall holds a guest object's
std::mutex across the `GuestExecutionReleaseScope` destructor, whose `reacquireGuestExecution()`
blocks reacquiring the run-token (`m_guestExecutionMutex`). So a thread waiting for the run-token
holds a guest-object mutex; any run-token holder that then locks the same mutex (e.g.
`SignalSema`/`PollSema` on the same sema) blocks — and neither thread can make progress, so the whole
cooperative scheduler freezes.

Concretely in `WaitSema`: the woken thread returns from `sema->cv.wait()` holding `sema->m`, then
`~GuestExecutionReleaseScope` parks for the run-token with `sema->m` still held; a token holder
calling `SignalSema`/`PollSema` on that sema blocks on `sema->m`. The two form a cycle:

| Thread | Holds | Waits for |
|---|---|---|
| Waiter (in `WaitSema`) | `sema->m` | run-token (in `~GuestExecutionReleaseScope`) |
| Token holder (in `SignalSema`/`PollSema`) | run-token | `sema->m` |

The lock order is run-token → object-mutex at syscall entry, but object-mutex → run-token at the
wait-reacquire — an inversion. (The run-token is a `std::recursive_mutex`, but recursion only
prevents *same-thread* re-entry; this is a *two-thread* cycle.) We confirmed it downstream with
`eu-stack` on a wedged process: one thread in the run-token reacquire holding `sema->m`, another in
`PollSema`'s `std::mutex::lock` on the same sema.

## Affected sites (all fixed)
- `WaitSema`, `WaitEventFlag` — `Kernel/Syscalls/Sync.cpp`
- `SleepThread`, `SuspendThread`, `TerminateThread` (wait for target to unwind) — `Kernel/Syscalls/Thread.cpp`
- `waitWhileSuspended` helper — `Kernel/Syscalls/Helpers/Runtime.h`
- `WaitForNextVSyncTick` — `Kernel/Syscalls/Interrupt.cpp`

## Fix
Add a `GuestExecutionReleaseScope` overload that owns the caller's `std::unique_lock` and unlocks it
in the destructor **before** reacquiring the run-token, centralising the invariant "never reacquire
the run-token while holding a guest-object mutex." After the fix the only lock order anywhere is
run-token → object-mutex. Each site passes its lock and re-locks afterward (run-token held) for
post-wait bookkeeping. No change to guest-visible count/waiter/event-flag/thread-state or
wakeup-election semantics — it only narrows a host-lock hold window, so it cannot change which waiter
wakes or the election order.

We chose to centralise the unlock in the destructor rather than drop the mutex by hand at each of the
sites: it makes the invariant impossible to get wrong at a future call site and keeps each site to a
one-line change. (A small follow-up commit then removes the now-unused release-only constructor.)

## How we ran into this
We hit this building a static recompilation of **Dragon Quest VIII: Journey of the Cursed King** on
top of PS2Recomp. DQ8 leans hard on semaphore handshakes between its guest threads, and the port
would wedge at random points during boot and early gameplay — no crash, no log, just a frozen
scheduler with every guest thread stuck READY-but-never-run.

Because it was nondeterministic (roughly a third of launches hung, in a different spot each time) it
smelled like a lock-ordering race rather than a logic bug. An `eu-stack` dump of a hung process
confirmed the exact cycle above: one guest thread parked in the run-token reacquire while still
holding `sema->m`, and another thread spinning in `PollSema`'s `std::mutex::lock` on that same
semaphore. Neither could ever make progress.

With the fix in place the title went from booting maybe half the time to **24 consecutive clean runs**
to the title screen. (Those figures are anecdotal downstream evidence from one title, not a
benchmark.) Since the bug is in the shared scheduler rather than anything DQ8-specific, it should help
any title that relies on semaphore handshakes between guest threads — which is most of them.

## Testing
Builds the `ps2_runtime` library cleanly locally (GCC). Behaviour is otherwise preserved — the
`cv.wait` predicates and all guest-state writes are untouched, so no semaphore/event-flag/thread-state
semantics change. No automated regression test is included here: a deterministic unit test can't
reproduce this (it needs the `SignalSema`/`PollSema`-vs-`WaitSema` timing race); a stress-loop test is
the right vehicle and can follow separately. 

## Longer term (out of scope for this PR)
This inversion is a class, not a single site. It's eliminated structurally by an ultramodern-style
scheduler (as in N64ModernRuntime): a strict signal-and-park baton with no guest-object mutexes,
where external events (IRQ/VSync/alarms/IOP/SIF) are injected through a lock-free queue drained at
syscall boundaries. That's a much larger change and is noted here only as the eventual direction;
this PR is the minimal, behaviour-preserving fix for the existing scheduler.
