### PR TITLE
[runtime] fixup rasterizer

### DIFF
--- a/ps2xRuntime/src/lib/ps2_gs_rasterizer.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_rasterizer.cpp
@@ -573,9 +573,9 @@ uint32_t GSRasterizer::lookupCLUT(GS *gs,
     case GS_PSM_CT24:
         return applyTexa(gs->m_texa, cpsm, GSMem::ReadCT24(gs->m_vram, cbp, clutWidth, clutX, clutY));
     case GS_PSM_CT16:
-        return applyTexa(gs->m_texa, cpsm, GSMem::ReadCT16(gs->m_vram, cbp, clutWidth, clutX, clutY));
+        return applyTexa(gs->m_texa, cpsm, Rgba5551ToRgba8888(GSMem::ReadCT16(gs->m_vram, cbp, clutWidth, clutX, clutY)));
     case GS_PSM_CT16S:
-        return applyTexa(gs->m_texa, cpsm, GSMem::ReadCT16S(gs->m_vram, cbp, clutWidth, clutX, clutY));
+        return applyTexa(gs->m_texa, cpsm, Rgba5551ToRgba8888(GSMem::ReadCT16S(gs->m_vram, cbp, clutWidth, clutX, clutY)));
     default:
         break;
     }
@@ -935,7 +935,7 @@ void GSRasterizer::drawTriangle(GS *gs)
                 a = color.a;
             }
 
-            writePixel(gs, x, y, static_cast<u32>(z), r, g, b, a);
+            writePixel(gs, x, y, static_cast<u32>(z + 0.5), r, g, b, a);
         }
     }
 }


### PR DESCRIPTION
For now, I round depth up in the triangle rasterizer for Code Veronica instead of truncate
Game expects FFFE for fade draw, but we sometimes produce FFFD for flat depth on triangles which fails the depth test
Stippling in z is still an issue

Small additional oversight is fixed for clut color lookup for 16 bit

Longer-term, triangle rasterization fixes in my rasterizer rework part 2 PR to fix stippling and other errors