### PR TITLE
GS PRIM must honor PRMODECONT (attribute-bit clobber)

### DIFF
--- a/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
@@ -1572,15 +1572,22 @@ void GS::writeRegister(uint8_t regAddr, uint64_t value)
     {
     case GS_REG_PRIM:
     {
+        // GS User's Manual PRMODECONT (AC) semantics: TYPE (bits 0-2) always
+        // comes from PRIM, but the attribute bits (bits 3-10) come from PRIM
+        // only when PRMODECONT=1; when PRMODECONT=0 they are held from the last
+        // PRMODE write (mirrors the gate already present in case GS_REG_PRMODE).
         m_prim.type = static_cast<GSPrimType>(value & 0x7);
-        m_prim.iip = ((value >> 3) & 1) != 0;
-        m_prim.tme = ((value >> 4) & 1) != 0;
-        m_prim.fge = ((value >> 5) & 1) != 0;
-        m_prim.abe = ((value >> 6) & 1) != 0;
-        m_prim.aa1 = ((value >> 7) & 1) != 0;
-        m_prim.fst = ((value >> 8) & 1) != 0;
-        m_prim.ctxt = ((value >> 9) & 1) != 0;
-        m_prim.fix = ((value >> 10) & 1) != 0;
+        if (m_prmodecont)
+        {
+            m_prim.iip  = ((value >> 3) & 1) != 0;
+            m_prim.tme  = ((value >> 4) & 1) != 0;
+            m_prim.fge  = ((value >> 5) & 1) != 0;
+            m_prim.abe  = ((value >> 6) & 1) != 0;
+            m_prim.aa1  = ((value >> 7) & 1) != 0;
+            m_prim.fst  = ((value >> 8) & 1) != 0;
+            m_prim.ctxt = ((value >> 9) & 1) != 0;
+            m_prim.fix  = ((value >> 10) & 1) != 0;
+        }
         m_vtxCount = 0;
         m_vtxIndex = 0;
         break;

--- a/ps2xTest/src/ps2_gs_tests.cpp
+++ b/ps2xTest/src/ps2_gs_tests.cpp
@@ -771,6 +771,90 @@ void register_ps2_gs_tests()
                      "CT32 primitives should land in the same local-memory layout that later CT32 texture sampling expects");
         });
 
+        tc.Run("GS PRIM honors PRMODECONT for attribute bits", [](TestCase &t)
+        {
+            std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
+            GS gs;
+            gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
+
+            gs.writeRegister(GS_REG_PRMODECONT, 0ull);
+            gs.writeRegister(GS_REG_PRMODE, 0x10ull);
+            gs.writeRegister(GS_REG_PRIM, static_cast<uint64_t>(GS_PRIM_SPRITE));
+            t.IsTrue(gs.getDebugSnapshot().prim.tme,
+                     "PRMODECONT=0: PRIM write must not clobber TME held from PRMODE");
+
+            gs.writeRegister(GS_REG_PRMODECONT, 1ull);
+            gs.writeRegister(GS_REG_PRIM, static_cast<uint64_t>(GS_PRIM_SPRITE));
+            t.IsFalse(gs.getDebugSnapshot().prim.tme,
+                      "PRMODECONT=1: PRIM write attribute bits take effect, TME cleared");
+        });
+
+        tc.Run("GS textured present honors PRMODECONT-held TME", [](TestCase &t)
+        {
+            std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
+            GS gs;
+            gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
+
+            constexpr uint32_t kSrcFbp = 0u;
+            constexpr uint32_t kDstFbp = 10u;
+            constexpr uint32_t kFbw = 1u;
+            constexpr uint32_t kSourceColor = 0x80AABBCCu;
+            constexpr uint32_t kFlatSpriteColor = 0x80112233u;
+
+            constexpr uint64_t kFrame =
+                (static_cast<uint64_t>(kDstFbp) << 0) |
+                (static_cast<uint64_t>(kFbw) << 16) |
+                (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
+            constexpr uint64_t kScissor = 0ull;
+            constexpr uint64_t kTex0 =
+                (static_cast<uint64_t>(kSrcFbp) << 0) |
+                (static_cast<uint64_t>(kFbw) << 14) |
+                (static_cast<uint64_t>(GS_PSM_CT32) << 20) |
+                (0ull << 26) |
+                (0ull << 30) |
+                (1ull << 34) |
+                (1ull << 35);
+            constexpr uint64_t kXyz1 =
+                (static_cast<uint64_t>(1u << 4) << 0) |
+                (static_cast<uint64_t>(1u << 4) << 16);
+            constexpr uint64_t kUv1 =
+                (static_cast<uint64_t>(1u * 16u) << 0) |
+                (static_cast<uint64_t>(1u * 16u) << 16);
+
+            // Seed the source framebuffer directly with a texel that is clearly
+            // distinct from the flat sprite color below.
+            writeReferenceFramePSMCT32Pixel(vram, kSrcFbp, kFbw, 0u, 0u, kSourceColor);
+
+            gs.writeRegister(GS_REG_FRAME_1, kFrame);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
+            gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
+            gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
+            gs.writeRegister(GS_REG_ALPHA_1, 0ull);
+            gs.writeRegister(GS_REG_TEX0_1, kTex0);
+            gs.writeRegister(GS_REG_TEX1_1, 0ull);
+
+            // TME and FST are supplied entirely by PRMODE while PRMODECONT=0;
+            // the PRIM write below carries a bare SPRITE type with all
+            // attribute bits zero, mirroring how a game leaves PRIM's upper
+            // bits untouched between draws once PRMODECONT gating is active.
+            gs.writeRegister(GS_REG_PRMODECONT, 0ull);
+            gs.writeRegister(GS_REG_PRMODE, 0x110ull);
+            gs.writeRegister(GS_REG_PRIM, static_cast<uint64_t>(GS_PRIM_SPRITE));
+            gs.writeRegister(GS_REG_RGBAQ, static_cast<uint64_t>(kFlatSpriteColor));
+            gs.writeRegister(GS_REG_UV, 0ull);
+            gs.writeRegister(GS_REG_XYZ2, 0ull);
+            gs.writeRegister(GS_REG_UV, kUv1);
+            gs.writeRegister(GS_REG_XYZ2, kXyz1);
+
+            const uint32_t dstPixel = readReferenceFramePSMCT32Pixel(vram, kDstFbp, kFbw, 0u, 0u);
+            t.Equals(dstPixel, kSourceColor,
+                     "PRMODECONT=0 sprite copy must sample the source texture (TME held from PRMODE)");
+            t.IsFalse(dstPixel == kFlatSpriteColor,
+                      "PRMODECONT=0 sprite copy must not fall back to the flat RGBAQ color");
+        });
+
         tc.Run("FST sprite 1:1 CT32 copies preserve source texels at the right and bottom edges", [](TestCase &t)
         {
             std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);


### PR DESCRIPTION
## Summary

`GS::writeRegister`'s `case GS_REG_PRIM` unconditionally overwrote all eight PRIM attribute bits (IIP/TME/FGE/ABE/AA1/FST/CTXT/FIX, bits 3-10) on every PRIM write, ignoring `PRMODECONT`. Per GS User's Manual PRMODECONT (AC) semantics, those attributes come from PRIM only when `PRMODECONT=1`; when `PRMODECONT=0` they are held from the last `PRMODE` write, and PRIM changes only the primitive TYPE (bits 0-2).

The `case GS_REG_PRMODE` handler was already correctly gated on `!m_prmodecont`; this change makes the PRIM case symmetric by wrapping its attribute-bit assignments in `if (m_prmodecont)`. `m_prim.type` and the vertex-queue reset remain unconditional.

Real-world impact: the common composite/present pattern `PRMODECONT=0` + `PRMODE(TME=1)` + bare `PRIM=SPRITE` per draw had its TME silently reset to 0 on every draw, so fullscreen textured blits rendered as flat untextured fills (observed as DQ8's present pass to `FRAME.FBP=0x70` showing only a gray clear).

## Changes

- `ps2xRuntime/src/lib/ps2_gs_gpu.cpp`: gate the eight PRIM attribute-bit writes on `m_prmodecont`.
- `ps2xTest/src/ps2_gs_tests.cpp`: two regression tests in the PS2GS suite:
  - **State-level** — `PRMODECONT=0` + `PRMODE(TME)` + bare `PRIM=SPRITE` must leave TME set (observed via `getDebugSnapshot().prim.tme`); then `PRMODECONT=1` + the same PRIM write must clear it.
  - **Render-level** — a sprite copy whose TME|FST come entirely from PRMODE (PRMODECONT=0, PRIM attribute bits 0) must sample its source texture (TEX0 uses DECAL so the result cannot alias the flat RGBAQ color); asserts the destination pixel equals the source texel and not the flat fill.

## Verification

- Full build succeeds (Debug, GCC 16; local-only `-include cstdint` workaround for vendored ELFIO header — not committed).
- Full `ps2x_tests` suite: **298/298 passed**, including both new cases.
- Regression-guard check: with the fix temporarily reverted, exactly the two new tests fail (296/298); restored, back to 298/298.

## Notes / limitations

- The render-level test seeds the source framebuffer via the existing `writeReferenceFramePSMCT32Pixel` test helper instead of drawing an untextured sprite pass — same coverage of the PRIM/PRMODE interaction under test, matching the established style of neighboring GS tests.
- No diagnostics logging was added here; that is out of scope for this change.
