### PR TITLE
fix(runtime): stop double-counting nloop in sceGifPkRefLoadImage A+D header GIFtag

### DIFF
--- a/ps2xRuntime/src/lib/Kernel/Stubs/GS.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Stubs/GS.cpp
@@ -504,7 +504,10 @@ namespace ps2_stubs
                             sizeof(words));
             writePacketBuilderCurrent(rdram, runtime, stateAddr, packetAddr + 16u);
 
-            const uint64_t giftag[2] = {makeGiftagAplusD(4u), 0xEULL};
+            // Seed an open A+D tag (nloop=0, EOP clear): closePacketGifTag adds the true
+            // appended qword count, so a pre-set nloop would double-count. Open variant
+            // (not makeGiftagAplusD) because that always sets EOP on this chained tag.
+            const uint64_t giftag[2] = {makeGiftagAplusDOpen(0u), 0xEULL};
             uint32_t currentAddr = packetAddr + 16u;
             writeGuestBytes(rdram, runtime, currentAddr, reinterpret_cast<const uint8_t *>(giftag), sizeof(giftag));
             writePacketBuilderCurrent(rdram, runtime, stateAddr, currentAddr + 16u);

--- a/ps2xRuntime/src/lib/Kernel/Stubs/Helpers/Support.h
+++ b/ps2xRuntime/src/lib/Kernel/Stubs/Helpers/Support.h
@@ -1673,6 +1673,14 @@ namespace
                (static_cast<uint64_t>(1u) << 60);
     }
 
+    // Like makeGiftagAplusD but leaves EOP (bit 15) clear, for a chained/open
+    // A+D tag whose nloop is finalized later by closePacketGifTag.
+    static uint64_t makeGiftagAplusDOpen(uint32_t nloop)
+    {
+        return (static_cast<uint64_t>(nloop & 0x7FFFu) << 0) |
+               (static_cast<uint64_t>(1u) << 60);
+    }
+
     static uint32_t readStackU32(uint8_t *rdram, R5900Context *ctx, uint32_t offset)
     {
         uint32_t sp = getRegU32(ctx, 29);

--- a/ps2xTest/src/ps2_gs_tests.cpp
+++ b/ps2xTest/src/ps2_gs_tests.cpp
@@ -3175,6 +3175,87 @@ void register_ps2_gs_tests()
             }
         });
 
+        tc.Run("sceGifPkRefLoadImage seeds A+D GIFtag nloop once (no double-count)", [](TestCase &t)
+        {
+            std::vector<uint8_t> rdram(PS2_RAM_SIZE, 0u);
+            PS2Runtime runtime;
+            R5900Context ctx{};
+
+            constexpr uint32_t stateAddr = 0x1000u;
+            constexpr uint32_t baseAddr = 0x2000u;
+            constexpr uint32_t spAddr = 0x8000u;
+
+            setRegU32(ctx, 4, stateAddr);
+            setRegU32(ctx, 5, baseAddr);
+            ps2_stubs::sceGifPkInit(rdram.data(), &ctx, &runtime);
+
+            setRegU32(ctx, 29, spAddr);
+            const uint32_t width = 16u;
+            const uint32_t height = 1u;
+            std::memcpy(rdram.data() + spAddr, &width, sizeof(width));
+            std::memcpy(rdram.data() + spAddr + 8u, &height, sizeof(height));
+
+            const uint32_t dbp = 0x3fc0u;
+            const uint32_t dpsm = 0u;
+            const uint32_t dbw = 1u;
+            const uint32_t dataAddr = 0u;
+            const uint32_t dsax = 0u;
+            const uint32_t dsay = 0u;
+
+            setRegU32(ctx, 4, stateAddr);
+            setRegU32(ctx, 5, dbp);
+            setRegU32(ctx, 6, dpsm);
+            setRegU32(ctx, 7, dbw);
+            setRegU32(ctx, 8, dataAddr);
+            setRegU32(ctx, 9, 0u); // qwcRemaining: setup only, no image body
+            setRegU32(ctx, 10, dsax);
+            setRegU32(ctx, 11, dsay);
+            ps2_stubs::sceGifPkRefLoadImage(rdram.data(), &ctx, &runtime);
+
+            uint64_t tagLo = 0u;
+            uint64_t tagHi = 0u;
+            std::memcpy(&tagLo, rdram.data() + baseAddr + 16u, sizeof(tagLo));
+            std::memcpy(&tagHi, rdram.data() + baseAddr + 24u, sizeof(tagHi));
+            t.Equals(tagLo, static_cast<uint64_t>(0x1000000000000004ULL),
+                      "header GIFtag lo must be nloop=4 nreg=1 A+D eop=0 (double-count would give ...0008)");
+            t.Equals(tagHi, static_cast<uint64_t>(0xEULL),
+                      "header GIFtag hi must be A+D register descriptor 0xE");
+
+            uint64_t reg1Desc = 0u;
+            uint64_t reg2Desc = 0u;
+            uint64_t reg3Desc = 0u;
+            uint64_t reg4Desc = 0u;
+            std::memcpy(&reg1Desc, rdram.data() + baseAddr + 32u + 0u * 16u + 8u, sizeof(reg1Desc));
+            std::memcpy(&reg2Desc, rdram.data() + baseAddr + 32u + 1u * 16u + 8u, sizeof(reg2Desc));
+            std::memcpy(&reg3Desc, rdram.data() + baseAddr + 32u + 2u * 16u + 8u, sizeof(reg3Desc));
+            std::memcpy(&reg4Desc, rdram.data() + baseAddr + 32u + 3u * 16u + 8u, sizeof(reg4Desc));
+            t.Equals(reg1Desc, static_cast<uint64_t>(0x50ULL), "first register qword should be BITBLTBUF (0x50)");
+            t.Equals(reg2Desc, static_cast<uint64_t>(0x51ULL), "second register qword should be TRXPOS (0x51)");
+            t.Equals(reg3Desc, static_cast<uint64_t>(0x52ULL), "third register qword should be TRXREG (0x52)");
+            t.Equals(reg4Desc, static_cast<uint64_t>(0x53ULL), "fourth register qword should be TRXDIR (0x53)");
+
+            uint64_t reg1Payload = 0u;
+            uint64_t reg2Payload = 0u;
+            uint64_t reg3Payload = 0u;
+            uint64_t reg4Payload = 0u;
+            std::memcpy(&reg1Payload, rdram.data() + baseAddr + 32u + 0u * 16u + 0u, sizeof(reg1Payload));
+            std::memcpy(&reg2Payload, rdram.data() + baseAddr + 32u + 1u * 16u + 0u, sizeof(reg2Payload));
+            std::memcpy(&reg3Payload, rdram.data() + baseAddr + 32u + 2u * 16u + 0u, sizeof(reg3Payload));
+            std::memcpy(&reg4Payload, rdram.data() + baseAddr + 32u + 3u * 16u + 0u, sizeof(reg4Payload));
+            // BITBLTBUF: dbp=0x3fc0 (bits 32-45), dbw=1 (bits 48-53), dpsm=0 (bits 56-61).
+            t.Equals(reg1Payload, static_cast<uint64_t>(0x00013FC000000000ULL),
+                      "BITBLTBUF payload must encode dbp=0x3fc0, dbw=1, dpsm=0");
+            // TRXPOS: dsax=0, dsay=0.
+            t.Equals(reg2Payload, static_cast<uint64_t>(0x0ULL),
+                      "TRXPOS payload must encode dsax=0, dsay=0");
+            // TRXREG: width=16 (bits 0-31), height=1 (bits 32-63).
+            t.Equals(reg3Payload, static_cast<uint64_t>(0x0000000100000010ULL),
+                      "TRXREG payload must encode width=16, height=1");
+            // TRXDIR: host-to-local transfer, dir=0.
+            t.Equals(reg4Payload, static_cast<uint64_t>(0x0ULL),
+                      "TRXDIR payload must encode dir=0 (host-to-local)");
+        });
+
         tc.Run("sceGsResetGraph frees its temporary GIF packet", [](TestCase &t)
         {
             PS2Runtime runtime;


### PR DESCRIPTION
## Summary

`sceGifPkRefLoadImage` seeds its A+D GIFtag nloop, then double-counts it.

`sceGifPkRefLoadImage` (`ps2xRuntime/src/lib/Kernel/Stubs/GS.cpp`) builds a GS load-image setup packet: an A+D header GIFtag followed by four A+D register qwords (BITBLTBUF/TRXPOS/TRXREG/TRXDIR). It seeded the header tag with `makeGiftagAplusD(4u)` (nloop pre-set to 4), then called `closePacketGifTag`, which computes the appended qword count (4) from the write-cursor delta and **adds** it to the tag's existing nloop — finalizing `nloop=8` for a 4-register tag. Downstream GIF parsing then consumed the following IMAGE tag and its first payload qwords as bogus A+D data, starving/corrupting the CLUT or texture upload that follows the setup (observed in DQ8: font-glyph CLUT blocks stayed all-zero).

### Change
- Seed the header tag with an **open** A+D tag — `nreg=1`, `nloop=0`, `eop=0` — and let `closePacketGifTag` add the true appended count, finalizing `0x1000000000000004` / hi `0xE`. The seed must **not** carry EOP (bit 15) or a nonzero nloop: this is a chained/open tag whose count is filled in at close time. `makeGiftagAplusD(0u)` can't be used because it always sets EOP.
- The seed is written via a named `makeGiftagAplusDOpen(nloop)` helper in `Support.h` (mirrors `makeGiftagAplusD` but leaves EOP clear), rather than a bare `1ULL << 60` literal, to keep the file's GIFtag-construction convention consistent.
- Behavior-affecting change is one line in `sceGifPkRefLoadImage`; no other call sites touched.

### Sibling audit
All `closePacketGifTag` call sites checked: `sceGifPkCloseGifTag` (line 413) and `sceVif1PkCloseGifTag` (line 1644) close guest-built tags with no seed — correct. All other `makeGiftagAplusD(...)` sites (810, 898, 991, 1091, 1157) build complete fixed packets and never pass them through `closePacketGifTag` — correct. `sceGifPkRefLoadImage` was the single seed-then-close double-count site.

### Regression test
Byte-level test in `ps2xTest/src/ps2_gs_tests.cpp`: drives `sceGifPkRefLoadImage` (setup only, `qwcRemaining=0`) against a scratch packet-builder state, reads back the finalized header GIFtag, and asserts:
- the **full 64-bit** lo word `0x1000000000000004` (pre-fix it reads `0x1000000000008008`: nloop=8 + stray EOP) and hi word `0xE` — this is the assertion that catches the original double-count bug;
- the four A+D register descriptors `0x50..0x53` immediately following the tag;
- the four register **payloads**: BITBLTBUF (`dbp=0x3fc0`, `dbw=1`, `dpsm=0` → `0x00013FC000000000`), TRXPOS (`0`), TRXREG (`width=16`, `height=1` → `0x0000000100000010`), TRXDIR (`0`) — pinning the full setup packet, not just its register selectors.

## Verification
- Full CMake build succeeds; no new warnings.
- `ps2x_tests`: **297 passed, 0 failed**, including the case `sceGifPkRefLoadImage seeds A+D GIFtag nloop once (no double-count)`.
- Test discriminates: pre-fix seed would finalize `0x1000000000008008`, failing the exact-bytes lo-word assertion.
