### PR TITLE
Controllers should open in digital mode, not analog

### DIFF
--- a/ps2xRuntime/src/lib/Kernel/Stubs/Pad.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Stubs/Pad.cpp
@@ -45,7 +45,7 @@ namespace ps2_stubs
         struct PadPortState
         {
             bool open = false;
-            bool analogMode = true;
+            bool analogMode = false;  // real pads power up DIGITAL (CURID=4, mode 0x41)
             bool pressureEnabled = false;
             bool lastUsedOverride = false;
             bool lastUsedBackend = false;
@@ -216,7 +216,7 @@ namespace ps2_stubs
         void initializePadPortLocked(PadPortState &portState, uint32_t dmaAddr)
         {
             portState.open = true;
-            portState.analogMode = true;
+            portState.analogMode = false;  // real pads open DIGITAL
             portState.pressureEnabled = false;
             portState.buttonMask = 0xFFFFu;
             portState.dmaAddr = dmaAddr;
@@ -610,7 +610,7 @@ namespace ps2_stubs
         }
 
         portState->open = true;
-        portState->analogMode = true;
+        portState->analogMode = false;     // real pads open DIGITAL
         portState->pressureEnabled = false;
         portState->buttonMask = 0xFFFFu;
         portState->dmaAddr = dmaAddr;

--- a/ps2xTest/src/pad_input_tests.cpp
+++ b/ps2xTest/src/pad_input_tests.cpp
@@ -258,7 +258,7 @@ void register_pad_input_tests()
             setRegU32(ctx, 6, 1);
             setRegU32(ctx, 7, 0);
             ps2_stubs::scePadInfoMode(rdram.data(), &ctx, nullptr);
-            t.Equals(static_cast<uint32_t>(getRegU32(&ctx, 2)), static_cast<uint32_t>(7), "scePadInfoMode CURID should return DualShock");
+            t.Equals(static_cast<uint32_t>(getRegU32(&ctx, 2)), static_cast<uint32_t>(4), "scePadInfoMode CURID should return digital at open");
 
             setRegU32(ctx, 4, 0u);
             setRegU32(ctx, 5, 0u);
@@ -299,6 +299,57 @@ void register_pad_input_tests()
             setRegU32(ctx, 7, 0u);
             ps2_stubs::scePadInfoMode(rdram.data(), &ctx, nullptr);
             t.Equals(static_cast<uint32_t>(getRegU32(&ctx, 2)), static_cast<uint32_t>(7), "mode table entry should return DualShock in analog mode");
+
+            closePadPort(ctx, rdram);
+        });
+
+        tc.Run("pads open in digital mode and switch to analog on scePadSetMainMode", [](TestCase &t)
+               {
+            std::vector<uint8_t> rdram(PS2_RAM_SIZE, 0);
+            R5900Context ctx;
+
+            ps2_stubs::scePadInit(rdram.data(), &ctx, nullptr);
+            openPadPort(ctx, rdram);
+
+            setRegU32(ctx, 4, 0u);
+            setRegU32(ctx, 5, 0u);
+            ps2_stubs::scePadGetState(rdram.data(), &ctx, nullptr);
+            t.Equals(static_cast<uint32_t>(getRegU32(&ctx, 2)), static_cast<uint32_t>(6), "freshly opened port should report STABLE");
+
+            setRegU32(ctx, 4, 0u);
+            setRegU32(ctx, 5, 0u);
+            setRegU32(ctx, 6, 1);
+            setRegU32(ctx, 7, 0);
+            ps2_stubs::scePadInfoMode(rdram.data(), &ctx, nullptr);
+            t.Equals(static_cast<uint32_t>(getRegU32(&ctx, 2)), static_cast<uint32_t>(4), "scePadInfoMode CURID should return digital at open");
+
+            runPadRead(ctx, rdram);
+            const uint8_t *data = rdram.data() + kPadDataAddr;
+            t.Equals(data[1], static_cast<uint8_t>(0x41), "mode byte should be 0x41 (digital) at open");
+
+            setRegU32(ctx, 4, 0u);
+            setRegU32(ctx, 5, 0u);
+            setRegU32(ctx, 6, 1);
+            setRegU32(ctx, 7, 3);
+            ps2_stubs::scePadSetMainMode(rdram.data(), &ctx, nullptr);
+            t.Equals(static_cast<uint32_t>(getRegU32(&ctx, 2)), static_cast<uint32_t>(1), "scePadSetMainMode should succeed switching to analog");
+
+            setRegU32(ctx, 4, 0u);
+            setRegU32(ctx, 5, 0u);
+            setRegU32(ctx, 6, 1);
+            setRegU32(ctx, 7, 0);
+            ps2_stubs::scePadInfoMode(rdram.data(), &ctx, nullptr);
+            t.Equals(static_cast<uint32_t>(getRegU32(&ctx, 2)), static_cast<uint32_t>(7), "scePadInfoMode CURID should return analog after SetMainMode");
+
+            // scePadSetMainMode queues a one-shot EXECCMD transient state; pump scePadGetState
+            // once so the port settles back to STABLE before reading, mirroring the existing
+            // "pad command state reports EXECCMD once before returning STABLE" test.
+            setRegU32(ctx, 4, 0u);
+            setRegU32(ctx, 5, 0u);
+            ps2_stubs::scePadGetState(rdram.data(), &ctx, nullptr);
+
+            runPadRead(ctx, rdram);
+            t.Equals(data[1], static_cast<uint8_t>(0x73), "mode byte should be 0x73 (analog) after SetMainMode");
 
             closePadPort(ctx, rdram);
         });


### PR DESCRIPTION
## Summary

Real PS2 controllers power up in **DIGITAL** mode (CURID `4`, mode byte `0x41`) and only switch to analog (CURID `7`, `0x73`) when the game calls `scePadSetMainMode(mode=1)`. The three open-time sites in `Pad.cpp` incorrectly initialized `analogMode = true`, so `scePadInfoMode(..., PAD_MODECURID)` and `scePadRead` reported analog from the very first frame. Games that gate logic on the analog transition (e.g. DQ8 `fn_165b20`) saw an impossible state — analog before anyone asked for it.

## Changes

`ps2xRuntime/src/lib/Kernel/Stubs/Pad.cpp` — three open-time `analogMode = true` → `false`:
- `PadPortState` default member (line 48)
- `initializePadPortLocked` (line 219)
- `scePadPortOpen` (line 613)

`scePadSetMainMode` is untouched — it remains the only path into analog mode. The consumer ternaries at lines 248/520 already map `false → DIGITAL`, so no consumer logic changed.

`ps2xTest/src/pad_input_tests.cpp`:
- Fixed one existing assertion in "pad info and mode helpers return consistent values": at-open CURID is now `4` (digital) instead of `7`. (This was the only existing assertion affected — the later CURID checks are preceded by their own `scePadSetMainMode` calls and stay correct.)
- Added a byte-level regression test "pads open in digital mode and switch to analog on scePadSetMainMode": after open asserts `scePadGetState`=STABLE, CURID=`4`, `scePadRead` `data[1]`=`0x41`; after `scePadSetMainMode(mode=1)` asserts CURID=`7` and `data[1]`=`0x73` (pumping one `scePadGetState` to drain the one-shot EXECCMD transient before the read).

## References

This behavior is documented at both the wire-protocol and SDK levels:

- Curious Inventor, Interfacing a PS2 Controller — the DualShock controller boots into digital mode: "Controller defaults to digital mode and only transmits the on/off status of the buttons in the 4th and 5th byte." The second response byte's high nibble is the mode ID (0x4 digital, 0x7 analog), giving the 0x41 / 0x73 mode bytes; switching to analog requires an explicit config command sequence, so the controller never reports analog before the game requests it. https://store.curiousinventor.com/guides/PS2
- PS2SDK libpad.h — the open equivalent of Sony's libpad, defining the type IDs and mode API this code emulates: PAD_TYPE_DIGITAL 0x4 (CURID 4), PAD_TYPE_DUALSHOCK 0x7 (CURID 7), with scePadSetMainMode(mode=1) documented as "Analog/dual shock enabled; mode = 0 -> Digital." https://github.com/ps2dev/ps2sdk/blob/master/ee/rpc/pad/include/libpad.h

Together these confirm that a real PS2 controller powers up in digital mode (CURID 4 / 0x41) and only transitions to analog (CURID 7 / 0x73) when the game explicitly calls scePadSetMainMode(mode=1) — matching the fix in this PR.

## Verification

- Configured and built the `ps2x_tests` target (GCC 16, Release).
- Full test suite: **297 passed, 0 failed**, including the new regression test and the updated existing test.

## Note on an existing test

One pre-existing test, "pad info and mode helpers return consistent values", asserted CURID `7` immediately at open. That assertion was wrong under real controller behavior and is now updated to `4`, as described above; no other existing test was affected.
