### PR TITLE
fix(recomp): advance ctx->pc on fallthrough functions with no terminating branch

### DIFF
--- a/ps2xRecomp/src/lib/function_emitter.cpp
+++ b/ps2xRecomp/src/lib/function_emitter.cpp
@@ -226,13 +226,7 @@ namespace ps2recomp
             }
         }
 
-        // If the function's last instruction is not a branch/jump (no delay
-        // slot), execution "falls off the end" without ctx->pc ever being
-        // updated past that instruction's own address (every non-branch
-        // instruction sets ctx->pc to its own address, not the next one).
-        // dispatchLoop would then call this exact function again forever.
-        // Advance ctx->pc to the function's end so dispatchLoop's next
-        // lookup resumes at the following function instead of spinning.
+        // Fallthrough with no terminating branch: advance ctx->pc past the function so dispatchLoop doesn't re-call it forever.
         if (!instructions.empty() && !lastInstructionWasControlFlow)
         {
             ss << "    ctx->pc = 0x" << std::hex << function.end << "u;\n"

--- a/ps2xRecomp/src/lib/function_emitter.cpp
+++ b/ps2xRecomp/src/lib/function_emitter.cpp
@@ -103,9 +103,12 @@ namespace ps2recomp
            << std::dec;
         ss << "\n";
 
+        bool lastInstructionWasControlFlow = false;
+
         for (size_t i = 0; i < instructions.size(); ++i)
         {
             const Instruction &inst = instructions[i];
+            lastInstructionWasControlFlow = inst.hasDelaySlot;
 
             if (internalTargets.contains(inst.address))
             {
@@ -221,6 +224,19 @@ namespace ps2recomp
 
                 throw;
             }
+        }
+
+        // If the function's last instruction is not a branch/jump (no delay
+        // slot), execution "falls off the end" without ctx->pc ever being
+        // updated past that instruction's own address (every non-branch
+        // instruction sets ctx->pc to its own address, not the next one).
+        // dispatchLoop would then call this exact function again forever.
+        // Advance ctx->pc to the function's end so dispatchLoop's next
+        // lookup resumes at the following function instead of spinning.
+        if (!instructions.empty() && !lastInstructionWasControlFlow)
+        {
+            ss << "    ctx->pc = 0x" << std::hex << function.end << "u;\n"
+               << std::dec;
         }
 
         ss << "}\n";


### PR DESCRIPTION
## Summary
- `FunctionEmitter::emit` only advances `ctx->pc` per-instruction (overwritten each iteration) or via `handleBranchDelaySlots` when the last instruction is a branch/jump.
- A function whose last instruction is **not** a branch (e.g. a single no-op-style instruction with no terminator) leaves `ctx->pc` stuck at its own address forever after returning.
- `dispatchLoop` then re-reads `ctx->pc`, looks up the same function, and calls it again — indefinitely. No crash, no exception, just a silent infinite loop with zero forward progress.

## Repro
Found while debugging a "silent boot hang" in a downstream game (SDBZ, `SLUS_214.42`). The ELF entry point `0x100008` gets emitted as a standalone one-instruction function (`padduw $at, $zero, $zero`, no branch), and `dispatchLoop` spins on `pc=0x100008` forever — confirmed live via debugger, watching `ctx->pc` stay constant across repeated dispatch iterations.

## Fix
Track whether the last instruction processed in the loop had a delay slot (i.e. was a branch/jump). If the function's last instruction isn't one, emit an unconditional `ctx->pc = 0x<function.end>u;` before closing the function body, so `dispatchLoop`'s next lookup resumes at the following function instead of spinning on the same one.

## Test plan
- [x] Applied cleanly on top of upstream `main`
- [x] Confirmed via live debugger session that the affected function (`sub_00100008_0x100008`) previously left `ctx->pc` unchanged after returning
- [ ] Would appreciate a maintainer/CI build+regression pass, since I don't have a local build environment set up against this exact upstream checkout