### PR TITLE
fix(runtime): finalize packet-builder DMAtag QWC once at close, not on every append

### DIFF
--- a/ps2xRuntime/src/lib/Kernel/Stubs/GS.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Stubs/GS.cpp
@@ -166,6 +166,8 @@ namespace ps2_stubs
             }
 
             writePacketBuilderCurrent(rdram, runtime, stateAddr, currentAddr);
+            // Finalize the pending DMAtag QWC exactly once here; see refreshPacketBuilderPendingCount.
+            refreshPacketBuilderPendingCount(rdram, runtime, stateAddr);
             writeGuestBytes(rdram,
                             runtime,
                             stateAddr + 8u,
@@ -235,6 +237,14 @@ namespace ps2_stubs
                             sizeof(temp));
         }
 
+        // Finalizes the pending block's outer DMAtag QWC exactly once, here at
+        // close. Real hardware's DMAC reads a source-chain tag's QWC from memory
+        // at tag fetch (kick time, after close), not at append time -- and guest
+        // libraries that link their own packet builder terminate a block by
+        // ADDING their qword count onto a zero-seeded QWC field, so setting it
+        // eagerly per append would make that add land on a non-zero value and
+        // double the count. Shared by the sceGifPk* and sceVif1Pk* builder
+        // families, which populate the same outer-DMAtag QWC slot.
         void refreshPacketBuilderPendingCount(uint8_t *rdram, PS2Runtime *runtime, uint32_t stateAddr)
         {
             uint32_t currentAddr = 0u;
@@ -264,10 +274,10 @@ namespace ps2_stubs
             writeGuestU32(rdram, runtime, pendingCountAddr, countWord);
         }
 
+        // Advances the write cursor only; does not touch the QWC (see refreshPacketBuilderPendingCount).
         void writePacketBuilderCurrent(uint8_t *rdram, PS2Runtime *runtime, uint32_t stateAddr, uint32_t currentAddr)
         {
             writeGuestU32(rdram, runtime, stateAddr, currentAddr);
-            refreshPacketBuilderPendingCount(rdram, runtime, stateAddr);
         }
 
         uint32_t reservePacketBuilderWords(uint8_t *rdram, PS2Runtime *runtime, uint32_t stateAddr, uint32_t wordCount)

--- a/ps2xTest/src/ps2_gs_tests.cpp
+++ b/ps2xTest/src/ps2_gs_tests.cpp
@@ -3324,6 +3324,102 @@ void register_ps2_gs_tests()
                       "TRXDIR payload must encode dir=0 (host-to-local)");
         });
 
+        tc.Run("GIF packet-builder appends leave the pending CNT DMAtag QWC untouched until close", [](TestCase &t)
+        {
+            std::vector<uint8_t> rdram(PS2_RAM_SIZE, 0u);
+            PS2Runtime runtime;
+            R5900Context ctx{};
+
+            constexpr uint32_t stateAddr = 0x1000u;
+            constexpr uint32_t baseAddr = 0x2000u;
+
+            setRegU32(ctx, 4, stateAddr);
+            setRegU32(ctx, 5, baseAddr);
+            ps2_stubs::sceGifPkInit(rdram.data(), &ctx, &runtime);
+
+            // Open a CNT DMAtag at baseAddr with a zero-seeded QWC field.
+            setRegU32(ctx, 4, stateAddr);
+            setRegU32(ctx, 5, 0u); // count word
+            setRegU32(ctx, 6, 0u); // extra word
+            setRegU32(ctx, 7, 0u); // tag low; sceGifPkCnt ORs in the CNT id, QWC stays 0
+            ps2_stubs::sceGifPkCnt(rdram.data(), &ctx, &runtime);
+
+            uint32_t pendingCountAddr = 0u;
+            std::memcpy(&pendingCountAddr, rdram.data() + stateAddr + 8u, sizeof(pendingCountAddr));
+            t.Equals(pendingCountAddr, baseAddr,
+                     "sceGifPkCnt should record the pending DMAtag address at stateAddr+8");
+
+            uint32_t seededTagLo = 0u;
+            std::memcpy(&seededTagLo, rdram.data() + baseAddr, sizeof(seededTagLo));
+            t.Equals(seededTagLo & 0xFFFFu, 0u, "CNT DMAtag QWC field must start zero-seeded");
+
+            // Append three A+D register qwords (16 bytes each) onto the open block.
+            for (uint32_t i = 0u; i < 3u; ++i)
+            {
+                setRegU32(ctx, 4, stateAddr);
+                setRegU32(ctx, 5, 0x50u + i); // register descriptor (value irrelevant to QWC)
+                setRegU64(ctx, 6, 0u);        // register payload
+                ps2_stubs::sceGifPkAddGsAD(rdram.data(), &ctx, &runtime);
+            }
+
+            uint32_t currentAddr = 0u;
+            std::memcpy(&currentAddr, rdram.data() + stateAddr, sizeof(currentAddr));
+            t.Equals(currentAddr, baseAddr + 16u + 3u * 16u,
+                     "three A+D appends should advance the write cursor by three quadwords past the DMAtag");
+
+            // The pending DMAtag's QWC must still be ZERO mid-block. Finalizing
+            // the count is the block-close's job (terminatePacketBuilderState, or
+            // a guest's own terminate), not the per-append cursor advance. An
+            // eager per-append refresh would show 3 here and, against a guest
+            // terminate that adds onto this field, double the real count.
+            uint32_t midBlockTagLo = 0u;
+            std::memcpy(&midBlockTagLo, rdram.data() + baseAddr, sizeof(midBlockTagLo));
+            t.Equals(midBlockTagLo, 0x10000000u,
+                     "pending CNT DMAtag must remain id=CNT with QWC=0 mid-block; appends must not patch it");
+        });
+
+        tc.Run("GIF packet-builder finalizes the CNT DMAtag QWC once at close, to the true qword count", [](TestCase &t)
+        {
+            std::vector<uint8_t> rdram(PS2_RAM_SIZE, 0u);
+            PS2Runtime runtime;
+            R5900Context ctx{};
+
+            constexpr uint32_t stateAddr = 0x1000u;
+            constexpr uint32_t baseAddr = 0x2000u;
+
+            setRegU32(ctx, 4, stateAddr);
+            setRegU32(ctx, 5, baseAddr);
+            ps2_stubs::sceGifPkInit(rdram.data(), &ctx, &runtime);
+
+            setRegU32(ctx, 4, stateAddr);
+            setRegU32(ctx, 5, 0u);
+            setRegU32(ctx, 6, 0u);
+            setRegU32(ctx, 7, 0u);
+            ps2_stubs::sceGifPkCnt(rdram.data(), &ctx, &runtime);
+
+            for (uint32_t i = 0u; i < 3u; ++i)
+            {
+                setRegU32(ctx, 4, stateAddr);
+                setRegU32(ctx, 5, 0x50u + i);
+                setRegU64(ctx, 6, 0u);
+                ps2_stubs::sceGifPkAddGsAD(rdram.data(), &ctx, &runtime);
+            }
+
+            // Close the block through our own terminate path.
+            setRegU32(ctx, 4, stateAddr);
+            ps2_stubs::sceGifPkTerminate(rdram.data(), &ctx, &runtime);
+
+            uint32_t finalTagLo = 0u;
+            std::memcpy(&finalTagLo, rdram.data() + baseAddr, sizeof(finalTagLo));
+            t.Equals(finalTagLo, 0x10000003u,
+                     "closing the block must finalize the CNT DMAtag to id=CNT with QWC=3, leaving the rest of the word untouched");
+
+            // stateAddr+8 (the pending-count slot) must be cleared after close.
+            uint32_t pendingAfterClose = 0u;
+            std::memcpy(&pendingAfterClose, rdram.data() + stateAddr + 8u, sizeof(pendingAfterClose));
+            t.Equals(pendingAfterClose, 0u, "terminate must clear the pending-count slot at stateAddr+8");
+        });
+
         tc.Run("sceGsResetGraph frees its temporary GIF packet", [](TestCase &t)
         {
             PS2Runtime runtime;

--- a/ps2xTest/src/ps2_memory_tests.cpp
+++ b/ps2xTest/src/ps2_memory_tests.cpp
@@ -1353,7 +1353,7 @@ void register_ps2_memory_tests()
                      "qwc-zero compact VIF1 chain should clear the STR bit after drain");
         });
 
-        tc.Run("VIF1 packet builders keep chain qwc live before terminate", [](TestCase &t)
+        tc.Run("VIF1 packet builders finalize chain qwc at terminate", [](TestCase &t)
         {
             PS2Memory mem;
             t.IsTrue(mem.initialize(), "PS2Memory initialize should succeed");
@@ -1394,9 +1394,17 @@ void register_ps2_memory_tests()
             setRegU32(ctx, 4, kStateAddr);
             ps2_stubs::sceVif1PkCloseDirectCode(rdram, &ctx, nullptr);
 
+            // Close the outer chain the way a real title does before kicking the
+            // DMA: the DMAC reads a CNT tag's QWC from memory when it fetches the
+            // tag, so the builder must finalize that field at terminate. (The QWC
+            // is filled in at close, not incrementally as data is appended.)
+            std::memset(&ctx, 0, sizeof(ctx));
+            setRegU32(ctx, 4, kStateAddr);
+            ps2_stubs::sceVif1PkTerminate(rdram, &ctx, nullptr);
+
             uint32_t dmaTagWord = 0u;
             std::memcpy(&dmaTagWord, rdram + kBaseAddr, sizeof(dmaTagWord));
-            t.Equals(dmaTagWord & 0xFFFFu, 1u, "live packet head qwc should reflect one qword before terminate");
+            t.Equals(dmaTagWord, 0x10000001u, "packet head tag should be id=CNT with QWC=1 after terminate");
 
             std::vector<std::vector<uint8_t>> captured;
             mem.setGifPacketCallback([&](const uint8_t *data, uint32_t sizeBytes)
@@ -1409,8 +1417,8 @@ void register_ps2_memory_tests()
 
             mem.processPendingTransfers();
 
-            t.Equals(captured.size(), static_cast<size_t>(1u), "live VIF1 packet should emit one GIF packet");
-            t.Equals(captured[0].size(), static_cast<size_t>(16u), "live VIF1 packet should emit one qword");
+            t.Equals(captured.size(), static_cast<size_t>(1u), "terminated VIF1 packet should emit one GIF packet");
+            t.Equals(captured[0].size(), static_cast<size_t>(16u), "terminated VIF1 packet should emit one qword");
 
             bool payloadOk = true;
             for (uint32_t i = 0; i < 16u; ++i)
@@ -1421,7 +1429,7 @@ void register_ps2_memory_tests()
                     break;
                 }
             }
-            t.IsTrue(payloadOk, "live VIF1 packet payload should reach the GIF callback");
+            t.IsTrue(payloadOk, "terminated VIF1 packet payload should reach the GIF callback");
         });
 
         tc.Run("VIF1 DMA chain latches terminal tag bits in CHCR", [](TestCase &t)


### PR DESCRIPTION
## Problem

`writePacketBuilderCurrent()` — the helper the append, reserve and align paths call to
advance the packet-builder write cursor — also patched the pending DMAtag's QWC field on
every call. A source-chain DMAtag's QWC is filled in once, when the block closes: the DMAC
reads it from memory at tag fetch, which happens after the kick.

Some titles link their own copy of the `sceGifPk`/`sceVif1Pk` packet-builder library and
land only a few leaf entry points (`sceGifPkAddGsAD`, `sceGifPkCloseGifTag`) on these
stubs. Their own code opens and closes the block, and that close adds `(delta/16 - 1)`
onto a QWC field it expects to be zero. The eager per-append patch had already written the
final count, so the guest's add doubled it: a block holding three qwords closed with
QWC 6.

A DMAtag claiming twice its real length makes the DMAC read the following tags as inline
payload, stopping at the first zero qword it takes for a terminator. In one observed
movie-playback chain this buried roughly 896 image-transfer REF tags inside a single CNT
payload; the chain ended after two tags and none of the decoded pixel data reached the GIF.

## Fix

In `ps2xRuntime/src/lib/Kernel/Stubs/GS.cpp`:

- `writePacketBuilderCurrent()` now only advances the write cursor; the
  `refreshPacketBuilderPendingCount()` call is removed.
- `terminatePacketBuilderState()`, the block-close path, calls
  `refreshPacketBuilderPendingCount()` once, immediately after its final cursor advance.

Blocks these stubs open and close finalize to the same value as before, because the
refresh recomputes the qword delta from `pendingCountAddr` rather than accumulating. Every
site that records a new pending tag also calls `terminatePacketBuilderState()` first, so
the previous tag is still finalized before its slot is reused — check with:

```
grep -n "stateAddr + 8u\|terminatePacketBuilderState" ps2xRuntime/src/lib/Kernel/Stubs/GS.cpp
```

A guest-closed block stays untouched until the guest's own `+=` lands on the zero-seeded
field. No title, opcode or address is special-cased.

## Basis

- DMAC source-chain semantics: the QWC of a tag is read from memory when the DMAC fetches
  that tag, so the builder must fill it in at close. The guest library's
  add-onto-zero terminate follows from the same rule.
- PR #149 (merged) fixed the same defect family one layer down: `sceGifPkRefLoadImage`
  pre-seeded an A+D GIFtag's `nloop`, then `closePacketGifTag()` added the true count on
  top. That one stayed inside these stubs. This is the `pendingCountAddr` tracking used by
  the `Cnt`/terminate path, which double-counts where guest code performs the close. The
  two touch disjoint functions and neither depends on the other.

## Testing

```
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
cmake --build build --target ps2x_tests
./build/ps2xTest/ps2x_tests
```

- `ps2_gs_tests.cpp`: after three A+D appends the pending tag still reads `0x10000000`
  (id=CNT, QWC=0), cursor advanced three quadwords. Restoring the per-append refresh makes
  it read QWC 3 and this fails.
- `ps2_gs_tests.cpp`: after `sceGifPkTerminate` the tag reads `0x10000003` and the
  pending-count slot at `stateAddr+8` is cleared. Dropping the added finalization call
  leaves QWC 0 and this fails.
- `ps2_memory_tests.cpp`: the VIF1 chain test now calls `sceVif1PkTerminate` before kicking
  the DMA, and asserts the full head-tag word `0x10000001` rather than a low-16 masked
  compare. It previously kicked without terminating, and passed only because the per-append
  refresh had side-populated the tag.

## Risk and not in scope

- The QWC helpers are shared by the `sceGifPk*` and `sceVif1Pk*` builders, which populate
  the same outer-DMAtag QWC slot, so both families change the same way. The same edit
  closes the VIF1 double-count.
- Behavior change to weigh: a packet built and then kicked without a close now transfers
  nothing, matching hardware, where the DMAC finds QWC still zero at fetch. The per-append
  refresh used to mask that; the one test that leaned on the masking is updated above.
- Not in scope: the inner GIFtag `nloop` path (#149's territory). No header, signature or
  builder-state changes.

<details>
<summary>Before and after, and the pending-slot call sites</summary>

Before — the cursor advance patched the QWC on every append:

```c
void writePacketBuilderCurrent(uint8_t *rdram, PS2Runtime *runtime, uint32_t stateAddr, uint32_t currentAddr)
{
    writeGuestU32(rdram, runtime, stateAddr, currentAddr);
    refreshPacketBuilderPendingCount(rdram, runtime, stateAddr);
}
```

After — cursor only, with finalization moved into the close path:

```c
// Advances the write cursor only; does not touch the QWC (see refreshPacketBuilderPendingCount).
void writePacketBuilderCurrent(uint8_t *rdram, PS2Runtime *runtime, uint32_t stateAddr, uint32_t currentAddr)
{
    writeGuestU32(rdram, runtime, stateAddr, currentAddr);
}
```

```c
// in terminatePacketBuilderState()
writePacketBuilderCurrent(rdram, runtime, stateAddr, currentAddr);
// Finalize the pending DMAtag QWC exactly once here; see refreshPacketBuilderPendingCount.
refreshPacketBuilderPendingCount(rdram, runtime, stateAddr);
```

`refreshPacketBuilderPendingCount()` recomputes rather than accumulates, which is why a
stub-owned block finalizes to the same value under either scheme:

```c
const uint32_t deltaBytes = currentAddr - pendingCountAddr;
uint32_t deltaQwords = 0u;
if (deltaBytes >= 16u)
{
    deltaQwords = (deltaBytes >> 4u) - 1u;
}

countWord = (countWord & 0xFFFF0000u) | (deltaQwords & 0xFFFFu);
```

Among the grep's hits, the sites that record a pending tag at `stateAddr+8` each store the
value returned by an immediately preceding `terminatePacketBuilderState()`: `sceGifPkCnt`,
`sceGifPkEnd`, `sceGifPkRefLoadImage` (both tag opens), `sceVif1PkCall`, `sceVif1PkCnt` and
`sceVif1PkEnd`.

</details>
