### PR TITLE
fix(runtime): present preserves the display aspect instead of pillarboxing narrow buffers

### DIFF
--- a/ps2xRuntime/include/runtime/present_layout.h
+++ b/ps2xRuntime/include/runtime/present_layout.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <algorithm>
+
+namespace PresentLayout
+{
+    // Plain geometry result, independent of any windowing/graphics type so it
+    // can be unit-tested without a live presentation window.
+    struct PresentRect
+    {
+        float x;
+        float y;
+        float width;
+        float height;
+    };
+
+    // Fit the guest's intended display region (dispWidth x dispHeight -- the
+    // full-screen picture the GS scans out, e.g. the full 640x448 NTSC display)
+    // into the host window (screenWidth x screenHeight), preserving the display
+    // region's aspect ratio and centering it. The region is scaled by the
+    // largest factor that keeps it inside the window, so:
+    //   * a window with the same aspect as the region is filled exactly;
+    //   * a wider window pillarboxes (bars left/right);
+    //   * a taller window letterboxes (bars top/bottom).
+    // The caller draws the decoded source buffer into this rectangle, so a
+    // buffer with fewer columns than the display (a narrow DISPLAY/DISPFB
+    // buffer) is stretched across the full region and fills the window exactly
+    // as a full-width buffer does, instead of being shrunk to its own column
+    // count and pillarboxed. dispWidth/dispHeight must be positive; a degenerate
+    // region falls back to filling the window.
+    inline PresentRect computePresentDstRect(float dispWidth, float dispHeight,
+                                             float screenWidth, float screenHeight)
+    {
+        if (dispWidth <= 0.0f || dispHeight <= 0.0f)
+        {
+            return PresentRect{0.0f, 0.0f, screenWidth, screenHeight};
+        }
+        const float scale = std::min(screenWidth / dispWidth, screenHeight / dispHeight);
+        const float scaledWidth = dispWidth * scale;
+        const float scaledHeight = dispHeight * scale;
+        return PresentRect{(screenWidth - scaledWidth) * 0.5f,
+                           (screenHeight - scaledHeight) * 0.5f,
+                           scaledWidth, scaledHeight};
+    }
+}

--- a/ps2xRuntime/src/lib/ps2_runtime.cpp
+++ b/ps2xRuntime/src/lib/ps2_runtime.cpp
@@ -5,6 +5,7 @@
 #include "game_overrides.h"
 #include "ps2_runtime_macros.h"
 #include "runtime/ps2_gs_gpu.h"
+#include "runtime/present_layout.h"
 #include "ThreadNaming.h"
 #include "Kernel/Stubs/Audio.h"
 #include "Kernel/Stubs/GS.h"
@@ -2367,15 +2368,19 @@ void PS2Runtime::run()
         const float srcHeight = static_cast<float>(std::max<uint32_t>(1u, presentHeight));
         const float screenWidth = static_cast<float>(GetScreenWidth());
         const float screenHeight = static_cast<float>(GetScreenHeight());
-        const float scale = std::min(screenWidth / srcWidth, screenHeight / srcHeight);
-        const float dstWidth = srcWidth * scale;
-        const float dstHeight = srcHeight * scale;
+        // Present the guest's display region -- the full display width (FB_WIDTH)
+        // at the current decoded height -- fit into the window with its aspect
+        // preserved. The decoded buffer, whatever its column count, is stretched
+        // across the full region via srcRect, so a narrow (e.g. 512-column)
+        // buffer fills the display exactly as a 640-column one does instead of
+        // being pillarboxed at its own column count; the region itself is
+        // letterboxed rather than stretched when the window's shape differs
+        // (a resized desktop window, or the 960x544 Vita window vs. 640x448).
         const Rectangle srcRect{0.0f, 0.0f, srcWidth, srcHeight};
-        const Rectangle dstRect{
-            (screenWidth - dstWidth) * 0.5f,
-            (screenHeight - dstHeight) * 0.5f,
-            dstWidth,
-            dstHeight};
+        const PresentLayout::PresentRect dst =
+            PresentLayout::computePresentDstRect(static_cast<float>(FB_WIDTH), srcHeight,
+                                               screenWidth, screenHeight);
+        const Rectangle dstRect{dst.x, dst.y, dst.width, dst.height};
         DrawTexturePro(frameTex, srcRect, dstRect, Vector2{0.0f, 0.0f}, 0.0f, WHITE);
         if (m_debugUiInitialized && m_debugUiDrawCallback)
         {

--- a/ps2xTest/CMakeLists.txt
+++ b/ps2xTest/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(ps2_test_lib STATIC
     src/ps2_sif_dma_tests.cpp
     src/ps2_recompiler_tests.cpp
     src/ps2_runtime_expansion_tests.cpp
+    src/present_layout_tests.cpp
 )
 
 target_include_directories(ps2_test_lib PRIVATE

--- a/ps2xTest/src/main.cpp
+++ b/ps2xTest/src/main.cpp
@@ -17,6 +17,7 @@ void register_ps2_sif_rpc_tests();
 void register_ps2_sif_dma_tests();
 void register_ps2_recompiler_tests();
 void register_ps2_runtime_expansion_tests();
+void register_present_layout_tests();
 void reset_ps2_test_function_table();
 
 int main()
@@ -38,6 +39,7 @@ int main()
     register_ps2_sif_dma_tests();
     register_ps2_recompiler_tests();
     register_ps2_runtime_expansion_tests();
+    register_present_layout_tests();
     int res = MiniTest::Run();
     std::cout.flush();
     std::cerr.flush();

--- a/ps2xTest/src/present_layout_tests.cpp
+++ b/ps2xTest/src/present_layout_tests.cpp
@@ -1,0 +1,90 @@
+#include "MiniTest.h"
+#include "runtime/present_layout.h"
+
+using PresentLayout::computePresentDstRect;
+using PresentLayout::PresentRect;
+
+void register_present_layout_tests()
+{
+    MiniTest::Case("PresentLayout", [](TestCase &tc)
+    {
+        // A window whose aspect matches the display region is filled exactly.
+        // This is the native desktop case (640x448 window): the decoded buffer,
+        // stretched into this rectangle via the caller's srcRect, covers the
+        // whole window instead of being pillarboxed at its own column count.
+        tc.Run("display region fills a window of the same aspect", [](TestCase &t)
+        {
+            const PresentRect r = computePresentDstRect(640.0f, 448.0f, 640.0f, 448.0f);
+            t.Equals(r.x, 0.0f, "matching-aspect dst x must be 0");
+            t.Equals(r.y, 0.0f, "matching-aspect dst y must be 0");
+            t.Equals(r.width, 640.0f, "matching-aspect dst width must fill the window");
+            t.Equals(r.height, 448.0f, "matching-aspect dst height must fill the window");
+        });
+
+        // A window WIDER than the display aspect pillarboxes (bars left/right)
+        // rather than stretching. This is the Vita window's shape: 960x544 is
+        // wider than the 640x448 region, so it pillarboxes exactly like this.
+        // The bar widths at 960x544 are non-integer, so this pins the property
+        // with clean (power-of-two-scale) arithmetic instead.
+        tc.Run("wider window pillarboxes without stretching (Vita-shaped)", [](TestCase &t)
+        {
+            const PresentRect r = computePresentDstRect(640.0f, 448.0f, 1600.0f, 896.0f);
+            t.Equals(r.x, 160.0f, "wide-window dst must be inset horizontally (pillarbox)");
+            t.Equals(r.y, 0.0f, "wide-window dst y must be 0");
+            t.Equals(r.width, 1280.0f, "wide-window dst width must keep the region aspect, not fill");
+            t.Equals(r.height, 896.0f, "wide-window dst height must scale to the window height");
+        });
+
+        // A window TALLER than the display aspect letterboxes (bars top/bottom).
+        tc.Run("taller window letterboxes top and bottom", [](TestCase &t)
+        {
+            const PresentRect r = computePresentDstRect(640.0f, 448.0f, 640.0f, 896.0f);
+            t.Equals(r.x, 0.0f, "tall-window dst x must be 0");
+            t.Equals(r.y, 224.0f, "tall-window dst must be inset vertically (letterbox)");
+            t.Equals(r.width, 640.0f, "tall-window dst width must scale to the window width");
+            t.Equals(r.height, 448.0f, "tall-window dst height must keep the region aspect, not fill");
+        });
+
+        // The preserved aspect is the DISPLAY REGION's, not the window's: a
+        // narrow region pillarboxes. This is why the caller passes the full
+        // display width (FB_WIDTH), not the decoded narrow column count.
+        tc.Run("aspect follows the display region, not the window", [](TestCase &t)
+        {
+            const PresentRect r = computePresentDstRect(320.0f, 448.0f, 640.0f, 448.0f);
+            t.Equals(r.x, 160.0f, "narrow-region dst must pillarbox (params are live)");
+            t.Equals(r.y, 0.0f, "narrow-region dst y must be 0");
+            t.Equals(r.width, 320.0f, "narrow-region dst width must follow the region, not the window");
+            t.Equals(r.height, 448.0f, "narrow-region dst height must equal the window height");
+        });
+
+        // A degenerate display region -- a non-positive width or height -- cannot
+        // be fit or centered (scaling would divide by zero), so the helper falls
+        // back to filling the window. This case pins the WIDTH axis of the guard;
+        // without it a wrong fallback (e.g. {0,0,0,0}) passes every aspect case
+        // above, since none of them exercises a non-positive region. Its height
+        // sibling below pins the other axis.
+        tc.Run("degenerate display width fills the window", [](TestCase &t)
+        {
+            const PresentRect r = computePresentDstRect(0.0f, 448.0f, 640.0f, 448.0f);
+            t.Equals(r.x, 0.0f, "degenerate-width dst x must be 0");
+            t.Equals(r.y, 0.0f, "degenerate-width dst y must be 0");
+            t.Equals(r.width, 640.0f, "degenerate-width dst width must fill the window");
+            t.Equals(r.height, 448.0f, "degenerate-width dst height must fill the window");
+        });
+
+        // Symmetric to the degenerate-width case: a non-positive display HEIGHT
+        // is equally unfittable (scaling would divide by zero on the height
+        // axis), so the guard falls back to filling the window here too. Without
+        // this case a guard weakened to test only width (`if (dispWidth <= 0.0f)`)
+        // passes every case above while leaving a dispHeight==0 caller to produce
+        // a divide-by-zero-derived rect; this case fails that mutation.
+        tc.Run("degenerate display height fills the window", [](TestCase &t)
+        {
+            const PresentRect r = computePresentDstRect(640.0f, 0.0f, 640.0f, 448.0f);
+            t.Equals(r.x, 0.0f, "degenerate-height dst x must be 0");
+            t.Equals(r.y, 0.0f, "degenerate-height dst y must be 0");
+            t.Equals(r.width, 640.0f, "degenerate-height dst width must fill the window");
+            t.Equals(r.height, 448.0f, "degenerate-height dst height must fill the window");
+        });
+    });
+}


### PR DESCRIPTION
## Problem

`PS2Runtime::run()`'s present step built its destination rectangle from the decoded
buffer's own pixel dimensions: it scaled by
`min(screenWidth / srcWidth, screenHeight / srcHeight)` and centred the result. For a
buffer as wide as the window that is a no-op, but any display buffer **narrower** than
the window was shrunk to its own column count and padded with black down both sides.

A title programming a 512-column display buffer rendered correct content, pillarboxed,
in the 640-wide window — where a 640-column buffer already filled it.

## Fix

The buffer's column count is not the display's width. The GS scans a `DISPLAY`/`DISPFB`
buffer of any column count across the full display region, so a 512-column buffer is the
same full-screen picture as a 640-column one, produced from fewer columns.

`computePresentDstRect(dispWidth, dispHeight, screenWidth, screenHeight)` now fits the
**display region** — `FB_WIDTH` at the current decoded height — into the window,
preserving that region's aspect and centring it. The source rectangle still samples the
decoded buffer, so a narrow buffer is stretched across the region and fills the window
exactly as a full-width one does. `UploadFrame`'s decoding and the source rectangle are
unchanged; only the destination rectangle moves.

The helper lives in `ps2xRuntime/include/runtime/present_layout.h`, which includes only
`<algorithm>` — no windowing or graphics type — so the geometry is testable without a
live presentation window.

No title check and no per-game dimension: one destination-rectangle computation that runs
identically for every frame.

## Basis

The GS scans a display buffer across the full display region regardless of its column
count. Treating the column count as the picture's on-screen width is what pillarboxed
narrow buffers.

## Testing

`PresentLayout` suite, in `ps2xTest/src/present_layout_tests.cpp`:

- a window matching the display aspect is filled exactly
- a wider window pillarboxes, a taller window letterboxes, neither stretches
- the preserved aspect is the display region's, not the window's
- a degenerate display width, and a degenerate display height, each fall back to filling
  the window

Build and run:

```
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
cmake --build build -j
./build/ps2xTest/ps2x_tests
```

<details>
<summary>Mutation evidence: which mutation falsifies which property</summary>

Each is a one-line change to `computePresentDstRect`, applied alone.

| Mutation | Fails |
|---|---|
| return `{0, 0, screenWidth, screenHeight}` unconditionally (pure window fill) | pillarbox, letterbox, aspect-follows-the-region. The matching-aspect fill still passes, and **both degenerate cases still pass** — fallback and fill agree there |
| guard returns `{0, 0, 0, 0}` | both degenerate cases |
| guard tests only the width axis | the degenerate-height case alone |

The first row is why the degenerate cases need their own guard mutation: a pure-fill
mutation cannot distinguish them.

</details>

## Risk and not in scope

- **Full-width buffers at the native window size are unchanged.** Fill and aspect-fit
  agree when the window already matches the display aspect (640x448).
- **When the window's shape differs from the display's** — a resized desktop window, or
  the fixed 960x544 Vita window against a 640x448 region — the region is letterboxed or
  pillarboxed rather than stretched, so the picture keeps its aspect on every platform.
  An earlier iteration that simply filled the raw window horizontally stretched 640x448
  content on the Vita screen; preserving the display aspect avoids that.
- Manual check: a title whose decoded buffer is narrower than the window renders
  edge-to-edge instead of inset with black bars. That observation is not reproducible
  from this repository.
