### PR TITLE
fix(test): make sceGsSyncV field-parity assertions robust to vblank timing

### DIFF
--- a/ps2xRuntime/src/lib/Kernel/Stubs/GS.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Stubs/GS.cpp
@@ -10,6 +10,7 @@ namespace ps2_stubs
     {
         std::mutex g_gs_sync_v_mutex;
         uint64_t g_gs_sync_v_base_tick = 0u;
+        uint64_t g_gs_sync_v_last_tick = 0u;   // last tick consumed by sceGsSyncV (test observability)
         std::mutex g_gs_sync_v_callback_mutex;
         uint32_t g_gs_sync_v_callback_func = 0u;
         uint32_t g_gs_sync_v_callback_gp = 0u;
@@ -613,6 +614,18 @@ namespace ps2_stubs
         }
 
         return static_cast<int32_t>((tick - g_gs_sync_v_base_tick - 1u) & 1u);
+    }
+
+    uint64_t lastGsSyncVConsumedTick()
+    {
+        std::lock_guard<std::mutex> lock(g_gs_sync_v_mutex);
+        return g_gs_sync_v_last_tick;
+    }
+
+    uint64_t gsSyncVBaseTick()
+    {
+        std::lock_guard<std::mutex> lock(g_gs_sync_v_mutex);
+        return g_gs_sync_v_base_tick;
     }
 
     void resetGsSyncVCallbackState()
@@ -1460,6 +1473,10 @@ namespace ps2_stubs
     void sceGsSyncV(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
         const uint64_t tick = ps2_syscalls::WaitForNextVSyncTick(rdram, runtime);
+        {
+            std::lock_guard<std::mutex> lock(g_gs_sync_v_mutex);
+            g_gs_sync_v_last_tick = tick;
+        }
         if (g_gparam.interlace != 0u)
         {
             setReturnS32(ctx, getGsSyncVFieldForTick(tick));

--- a/ps2xRuntime/src/lib/Kernel/Stubs/GS.h
+++ b/ps2xRuntime/src/lib/Kernel/Stubs/GS.h
@@ -6,6 +6,8 @@ namespace ps2_stubs
 {
     void resetGsSyncVCallbackState();
     void dispatchGsSyncVCallback(uint8_t *rdram, PS2Runtime *runtime, uint64_t tick);
+    uint64_t lastGsSyncVConsumedTick();
+    uint64_t gsSyncVBaseTick();
     void sceGifPkAddGsAD(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime);
     void sceGifPkAddGsData(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime);
     void sceGifPkCloseGifTag(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime);

--- a/ps2xTest/src/ps2_gs_tests.cpp
+++ b/ps2xTest/src/ps2_gs_tests.cpp
@@ -3359,13 +3359,44 @@ void register_ps2_gs_tests()
             setRegU32(resetCtx, 7, 1u);
             ps2_stubs::sceGsResetGraph(rdram.data(), &resetCtx, &runtime);
 
+            // interlaced reset already done above; base is the value the field parity is anchored to.
+            const uint64_t base = ps2_stubs::gsSyncVBaseTick();
+
             R5900Context sync0{};
             ps2_stubs::sceGsSyncV(rdram.data(), &sync0, &runtime);
-            t.Equals(static_cast<int32_t>(getRegU32Test(sync0, 2)), 0, "first interlaced sceGsSyncV should report even field");
+            const uint64_t tick0 = ps2_stubs::lastGsSyncVConsumedTick();
+            const int32_t field0 = static_cast<int32_t>(getRegU32Test(sync0, 2));
 
             R5900Context sync1{};
             ps2_stubs::sceGsSyncV(rdram.data(), &sync1, &runtime);
-            t.Equals(static_cast<int32_t>(getRegU32Test(sync1, 2)), 1, "second interlaced sceGsSyncV should report odd field");
+            const uint64_t tick1 = ps2_stubs::lastGsSyncVConsumedTick();
+            const int32_t field1 = static_cast<int32_t>(getRegU32Test(sync1, 2));
+
+            // Liveness.
+            t.IsTrue(tick1 > tick0, "each interlaced sceGsSyncV must consume a strictly newer vblank tick");
+
+            // Golden field: mirrors getGsSyncVFieldForTick exactly, incl. the tick<=base clause.
+            auto expectedField = [base](uint64_t tick) -> int32_t {
+                if (tick <= base) return 0;
+                return static_cast<int32_t>((tick - base - 1u) & 1u);
+            };
+
+            // Gap-aware absolute assertions — computed from measured gaps, never an assumed gap==1.
+            t.Equals(field0, expectedField(tick0),
+                     "first interlaced field must match its consumed tick's parity relative to the reset base");
+            t.Equals(field1, expectedField(tick1),
+                     "second interlaced field must match its consumed tick's parity relative to the reset base");
+
+            // Relative XOR cross-check — alternation pinned independently of absolute phase.
+            t.Equals(field0 ^ field1, static_cast<int32_t>((tick1 - tick0) & 1u),
+                     "consecutive interlaced fields differ iff an odd number of vblanks elapsed between them");
+
+            // Literal hardware anchor, asserted ONLY under the nominal gaps (base->tick0==1, delta==1).
+            if (tick0 == base + 1u && tick1 - tick0 == 1u)
+            {
+                t.Equals(field0, 0, "first interlaced sceGsSyncV should report even field");
+                t.Equals(field1, 1, "second interlaced sceGsSyncV should report odd field");
+            }
 
             R5900Context resetProgCtx{};
             setRegU32(resetProgCtx, 4, 0u);


### PR DESCRIPTION
## Problem

The interlaced field-parity test for `sceGsSyncV` races the free-running vsync-tick
source two ways:

1. **Pair incoherence.** The field each call returns and the tick it was computed from
   are never observed together — the test reads only the field.
2. **Phase assumption.** The hardcoded 0-then-1 expected fields assume the first wait
   consumes exactly `base + 1`, i.e. that exactly one vblank elapses between the reset's
   base capture and the first wait.

On a loaded runner a vblank can land in that window. When it does the true parity inverts
relative to the hardcoded assumption and the assertion fails, though the field-parity
logic is correct. It fails intermittently on Windows CI while passing reliably on Linux.

This is the test currently failing on **#137**'s `windows-msvc-x86_64` leg.

## Fix

`sceGsSyncV` records the vblank tick it consumed, under the mutex it already holds. Two
read-only accessors — `lastGsSyncVConsumedTick()` and `gsSyncVBaseTick()` — expose that
tick and the parity anchor.

The test now derives each expectation from the measured gap rather than assuming one. Its
golden field mirrors `getGsSyncVFieldForTick` exactly, including the `tick <= base` clause:

```
tick <= base  ->  0
otherwise     ->  (tick - base - 1) & 1
```

It adds a phase-independent cross-check, `field0 ^ field1 == (tick1 - tick0) & 1`, and a
liveness check, `tick1 > tick0`. The original literal even/odd anchor is kept but asserted
only where its precondition — `tick0 == base + 1 && tick1 - tick0 == 1` — actually holds.

## Basis

Every assertion is a pure function of the triple `(base, tick0, tick1)`, each read back
after its own call returns: `sceGsSyncV` then `lastGsSyncVConsumedTick()`, twice. Nothing
re-samples a live counter and nothing assumes a fixed elapsed-tick count, so whatever gap
the runner produced is the gap the expectation is derived from. The failing interleaving
becomes impossible rather than rarer.

The recording write is observation state, not behaviour. `sceGsSyncV`'s observable effects
are the value written via `setReturnS32` and the vblank wait it performs; both are
unchanged, the same consumed tick still flows into the existing parity computation, and no
guest memory, register, field arithmetic or wait timing is touched. The accessors are
lock-and-return functions using the mutex discipline the existing parity helper already
uses.

## Testing

Run the binary from the repository root — one runtime test is working-directory sensitive.

```
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-msse4.1 -DCMAKE_CXX_FLAGS=-msse4.1
cmake --build build --config Release
./build/ps2xTest/ps2x_tests
```

<details>
<summary>Mutations that falsify the reworked test</summary>

Each is a single-line change to `getGsSyncVFieldForTick` or `sceGsSyncV` in
`ps2xRuntime/src/lib/Kernel/Stubs/GS.cpp`, applied alone. Each makes exactly the
`sceGsSyncV` interlaced-parity test fail while the rest of the suite stays green.

| Mutation | Effect |
|---|---|
| drop the `-1u` phase offset from the field computation | parity shifts by one tick |
| change the parity mask `& 1u` to `& 0u` | field is always even |
| replace the vblank wait with a constant that never advances the tick | liveness check fails |

</details>

## Risk and not in scope

- The runtime change is one write plus two accessors; no behaviour is altered, which is
  confirmable from the diff plus a green suite.
- **Windows CI is the real arbiter.** The original flake is specific to loaded Windows
  runners and is not expected to reproduce on an unloaded Linux box, so a green Linux run
  does not by itself demonstrate the race is gone.
- This does not change the field-parity rule itself, only how the test establishes what to
  expect.
