### PR TITLE
feat(hle): implement sceVu0 macro-mode matrix/vector math library

### DIFF
--- a/ps2xRuntime/src/lib/Kernel/Stubs/VU.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Stubs/VU.cpp
@@ -1,13 +1,8 @@
 #include "Common.h"
 #include "VU.h"
-//TODO use glm
 
 namespace ps2_stubs
 {
-    void sceVu0ecossin(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
-    {
-        TODO_NAMED("sceVu0ecossin", rdram, ctx, runtime);
-    }
 
     namespace
     {
@@ -77,6 +72,7 @@ namespace ps2_stubs
             return true;
         }
 
+        // Row-major matrix product: out = lhs * rhs (lhs is the left factor).
         void mulVuMatrix(const float (&lhs)[16], const float (&rhs)[16], float (&out)[16])
         {
             std::fill(std::begin(out), std::end(out), 0.0f);
@@ -99,6 +95,94 @@ namespace ps2_stubs
             out[5] = 1.0f;
             out[10] = 1.0f;
             out[15] = 1.0f;
+        }
+
+        // Rigid-transform inverse under the file's row-vector convention
+        // (translation in row 3, ApplyMatrix computes v*M): transpose the 3x3
+        // rotation block, zero its 4th column, and set the translation row to
+        // -t*R^T -- each lane dots t with a ROW of R: out[12+col] =
+        // -(t . R[col]). This makes M * rigidInverse(M) == I. Copy [15].
+        void rigidInverse(const float (&in)[16], float (&out)[16])
+        {
+            for (int row = 0; row < 3; ++row)
+            {
+                for (int col = 0; col < 3; ++col)
+                    out[4 * row + col] = in[4 * col + row];
+                out[4 * row + 3] = 0.0f;
+            }
+            const float tx = in[12], ty = in[13], tz = in[14];
+            for (int col = 0; col < 3; ++col)
+                out[12 + col] = -((tx * in[4 * col]) + (ty * in[4 * col + 1]) + (tz * in[4 * col + 2]));
+            out[15] = in[15];
+        }
+
+        void axisRotateMatrix(const float (&in)[16], float angle, int axis, float (&out)[16])
+        {
+            float rot[16]{};
+            makeIdentityMatrix(rot);
+            const float cs = std::cos(angle);
+            const float sn = std::sin(angle);
+            if (axis == 2)
+            {
+                rot[0] = cs;
+                rot[1] = sn;
+                rot[4] = -sn;
+                rot[5] = cs;
+            }
+            else if (axis == 1)
+            {
+                rot[0] = cs;
+                rot[2] = -sn;
+                rot[8] = sn;
+                rot[10] = cs;
+            }
+            else
+            {
+                rot[5] = cs;
+                rot[6] = sn;
+                rot[9] = -sn;
+                rot[10] = cs;
+            }
+            mulVuMatrix(in, rot, out);
+        }
+
+        // Applies the matrix to the vertex, perspective-divides xyz by w
+        // (w==0 maps to a zero divide rather than Inf/NaN), then converts
+        // x/y to 12.4 fixed point (x16) unconditionally. z/w take the same
+        // x16 conversion when fullFtoi4 is set; otherwise they are plain
+        // integer-truncated (FTOI0) after the divide instead.
+        void rotTransPersOne(const float (&m)[16], const float (&v)[4], bool fullFtoi4, int32_t (&out)[4])
+        {
+            float t[4];
+            t[0] = (m[0] * v[0]) + (m[4] * v[1]) + (m[8] * v[2]) + (m[12] * v[3]);
+            t[1] = (m[1] * v[0]) + (m[5] * v[1]) + (m[9] * v[2]) + (m[13] * v[3]);
+            t[2] = (m[2] * v[0]) + (m[6] * v[1]) + (m[10] * v[2]) + (m[14] * v[3]);
+            t[3] = (m[3] * v[0]) + (m[7] * v[1]) + (m[11] * v[2]) + (m[15] * v[3]);
+            const float q = (t[3] != 0.0f) ? (1.0f / t[3]) : 0.0f;
+            t[0] *= q;
+            t[1] *= q;
+            t[2] *= q;
+            out[0] = static_cast<int32_t>(t[0] * 16.0f);
+            out[1] = static_cast<int32_t>(t[1] * 16.0f);
+            out[2] = fullFtoi4 ? static_cast<int32_t>(t[2] * 16.0f) : static_cast<int32_t>(t[2]);
+            out[3] = fullFtoi4 ? static_cast<int32_t>(t[3] * 16.0f) : static_cast<int32_t>(t[3]);
+        }
+
+        // Guard-band proxy for the COP2 sticky clip flags: nonzero => the
+        // vertex is offscreen. Not the hardware per-plane flag layout.
+        constexpr float kScreenClipGuard = 4096.0f;
+        int32_t screenClipCode(const float (&v)[4])
+        {
+            int32_t code = 0;
+            if (v[0] > kScreenClipGuard)
+                code |= 0x1;
+            if (v[0] < -kScreenClipGuard)
+                code |= 0x2;
+            if (v[1] > kScreenClipGuard)
+                code |= 0x4;
+            if (v[1] < -kScreenClipGuard)
+                code |= 0x8;
+            return code;
         }
     }
 
@@ -147,27 +231,139 @@ namespace ps2_stubs
 
     void sceVu0CameraMatrix(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0CameraMatrix", rdram, ctx, runtime);
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t eyeAddr = getRegU32(ctx, 5);
+        const uint32_t fwdAddr = getRegU32(ctx, 6);
+        const uint32_t upAddr = getRegU32(ctx, 7);
+        float eye[4]{}, fwd[4]{}, up[4]{};
+        if (readVuVec4f(rdram, eyeAddr, eye) && readVuVec4f(rdram, fwdAddr, fwd) && readVuVec4f(rdram, upAddr, up))
+        {
+            auto cross = [](const float (&l)[4], const float (&r)[4], float (&o)[4])
+            {
+                o[0] = (l[1] * r[2]) - (l[2] * r[1]);
+                o[1] = (l[2] * r[0]) - (l[0] * r[2]);
+                o[2] = (l[0] * r[1]) - (l[1] * r[0]);
+                o[3] = 0.0f;
+            };
+            auto normalize = [](const float (&s)[4], float (&o)[4])
+            {
+                const float len = std::sqrt((s[0] * s[0]) + (s[1] * s[1]) + (s[2] * s[2]) + (s[3] * s[3]));
+                const float inv = (len > 1.0e-6f) ? (1.0f / len) : 0.0f;
+                for (int i = 0; i < 4; ++i)
+                    o[i] = s[i] * inv;
+            };
+            float rawCross[4]{}, row0[4]{}, row1[4]{}, row2[4]{};
+            cross(up, fwd, rawCross);
+            normalize(rawCross, row0);
+            normalize(fwd, row2);
+            cross(row2, row0, row1);
+
+            float m[16]{};
+            for (int i = 0; i < 4; ++i)
+            {
+                m[i] = row0[i];
+                m[4 + i] = row1[i];
+                m[8 + i] = row2[i];
+            }
+            m[12] = eye[0];
+            m[13] = eye[1];
+            m[14] = eye[2];
+            m[15] = 1.0f;
+
+            float out[16]{};
+            rigidInverse(m, out);
+
+            (void)writeVuMatrix4f(rdram, dstAddr, out);
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0ClampVector(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0ClampVector", rdram, ctx, runtime);
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t srcAddr = getRegU32(ctx, 5);
+        const float lo = ctx ? ctx->f[12] : 0.0f;
+        const float hi = ctx ? ctx->f[13] : 0.0f;
+        float src[4]{}, out[4]{};
+        if (readVuVec4f(rdram, srcAddr, src))
+        {
+            for (int i = 0; i < 4; ++i)
+            {
+                float v = src[i];
+                v = (v < lo) ? lo : v;
+                v = (v > hi) ? hi : v;
+                out[i] = v;
+            }
+            (void)writeVuVec4f(rdram, dstAddr, out);
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0ClipAll(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0ClipAll", rdram, ctx, runtime);
+        const uint32_t loAddr = getRegU32(ctx, 4);
+        const uint32_t hiAddr = getRegU32(ctx, 5);
+        const uint32_t matAddr = getRegU32(ctx, 6);
+        uint32_t vAddr = getRegU32(ctx, 7);
+        const int32_t count = static_cast<int32_t>(getRegU32(ctx, 8));
+        float lo[4]{}, hi[4]{}, m[16]{};
+        int32_t result = 0;
+        if (readVuVec4f(rdram, loAddr, lo) && readVuVec4f(rdram, hiAddr, hi) && readVuMatrix4f(rdram, matAddr, m))
+        {
+            result = 1;
+            for (int32_t i = 0; i < count; ++i)
+            {
+                float v[4]{};
+                if (!readVuVec4f(rdram, vAddr, v))
+                    break;
+                const float tx = (m[0] * v[0]) + (m[4] * v[1]) + (m[8] * v[2]) + (m[12] * v[3]);
+                const float ty = (m[1] * v[0]) + (m[5] * v[1]) + (m[9] * v[2]) + (m[13] * v[3]);
+                const float tw = (m[3] * v[0]) + (m[7] * v[1]) + (m[11] * v[2]) + (m[15] * v[3]);
+                const bool outsideX = (tx < lo[0] * tw) || (tx > hi[0] * tw);
+                const bool outsideY = (ty < lo[1] * tw) || (ty > hi[1] * tw);
+                if (!outsideX && !outsideY)
+                {
+                    result = 0;
+                    break;
+                }
+                vAddr += 16u;
+            }
+        }
+        setReturnS32(ctx, result);
     }
 
     void sceVu0ClipScreen(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0ClipScreen", rdram, ctx, runtime);
+        const uint32_t vAddr = getRegU32(ctx, 4);
+        float v[4]{};
+        int32_t code = 0;
+        if (readVuVec4f(rdram, vAddr, v))
+        {
+            code = screenClipCode(v);
+        }
+        setReturnS32(ctx, code);
     }
 
     void sceVu0ClipScreen3(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0ClipScreen3", rdram, ctx, runtime);
+        const uint32_t v0Addr = getRegU32(ctx, 4);
+        const uint32_t v1Addr = getRegU32(ctx, 5);
+        const uint32_t v2Addr = getRegU32(ctx, 6);
+        float v0[4]{}, v1[4]{}, v2[4]{};
+        int32_t code = 0;
+        if (readVuVec4f(rdram, v0Addr, v0))
+        {
+            code |= screenClipCode(v0);
+        }
+        if (readVuVec4f(rdram, v1Addr, v1))
+        {
+            code |= screenClipCode(v1);
+        }
+        if (readVuVec4f(rdram, v2Addr, v2))
+        {
+            code |= screenClipCode(v2);
+        }
+        setReturnS32(ctx, code);
     }
 
     void sceVu0CopyMatrix(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
@@ -211,17 +407,108 @@ namespace ps2_stubs
 
     void sceVu0DivVector(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0DivVector", rdram, ctx, runtime);
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t srcAddr = getRegU32(ctx, 5);
+        const float divisor = ctx ? ctx->f[12] : 1.0f;
+        float src[4]{}, out[4]{};
+        if (readVuVec4f(rdram, srcAddr, src))
+        {
+            const float q = (divisor != 0.0f) ? (1.0f / divisor) : 0.0f;
+            for (int i = 0; i < 4; ++i)
+            {
+                out[i] = src[i] * q;
+            }
+            (void)writeVuVec4f(rdram, dstAddr, out);
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0DivVectorXYZ(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0DivVectorXYZ", rdram, ctx, runtime);
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t srcAddr = getRegU32(ctx, 5);
+        const float divisor = ctx ? ctx->f[12] : 1.0f;
+        float src[4]{}, out[4]{};
+        if (readVuVec4f(rdram, srcAddr, src))
+        {
+            const float q = (divisor != 0.0f) ? (1.0f / divisor) : 0.0f;
+            out[0] = src[0] * q;
+            out[1] = src[1] * q;
+            out[2] = src[2] * q;
+            out[3] = src[3];
+            (void)writeVuVec4f(rdram, dstAddr, out);
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0DropShadowMatrix(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0DropShadowMatrix", rdram, ctx, runtime);
+        // Two documented drop-shadow modes reconstructed from behavior; not
+        // claimed bit-exact to a specific SDK build.
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t nAddr = getRegU32(ctx, 5);
+        const uint32_t mode = getRegU32(ctx, 6);
+        const float lx = ctx ? ctx->f[12] : 0.0f;
+        const float ly = ctx ? ctx->f[13] : 0.0f;
+        const float lz = ctx ? ctx->f[14] : 0.0f;
+        float n[4]{};
+        if (readVuVec4f(rdram, nAddr, n))
+        {
+            const float nx = n[0], ny = n[1], nz = n[2];
+            const float d = (lx * nx) + (ly * ny) + (lz * nz);
+            float out[16]{};
+            if (mode != 0)
+            {
+                const float k = 1.0f - d;
+                out[0] = (lx * nx) + k;
+                out[1] = lx * ny;
+                out[2] = lx * nz;
+                out[3] = lx;
+                out[4] = ly * nx;
+                out[5] = (ly * ny) + k;
+                out[6] = ly * nz;
+                out[7] = ly;
+                out[8] = lz * nx;
+                out[9] = lz * ny;
+                out[10] = (lz * nz) + k;
+                out[11] = lz;
+                out[12] = -nx;
+                out[13] = -ny;
+                out[14] = -nz;
+                out[15] = -d;
+            }
+            else
+            {
+                const float k = (d != 0.0f) ? (-1.0f / d) : 0.0f;
+                out[0] = k * ((lx * nx) - d);
+                out[1] = k * (lx * ny);
+                out[2] = k * (lx * nz);
+                out[3] = 0.0f;
+                out[4] = k * (ly * nx);
+                out[5] = k * ((ly * ny) - d);
+                out[6] = k * (ly * nz);
+                out[7] = 0.0f;
+                out[8] = k * (lz * nx);
+                out[9] = k * (lz * ny);
+                out[10] = k * ((lz * nz) - d);
+                out[11] = 0.0f;
+                out[12] = k * -nx;
+                out[13] = k * -ny;
+                out[14] = k * -nz;
+                out[15] = 1.0f;
+            }
+            (void)writeVuMatrix4f(rdram, dstAddr, out);
+        }
+        setReturnS32(ctx, 0);
+    }
+
+    void sceVu0ecossin(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
+    {
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const float angle = ctx ? ctx->f[12] : 0.0f;
+        float out[4] = {std::cos(angle), std::sin(angle), 0.0f, 0.0f};
+        (void)writeVuVec4f(rdram, dstAddr, out);
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0FTOI0Vector(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
@@ -280,17 +567,53 @@ namespace ps2_stubs
 
     void sceVu0InterVector(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0InterVector", rdram, ctx, runtime);
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t aAddr = getRegU32(ctx, 5);
+        const uint32_t bAddr = getRegU32(ctx, 6);
+        const float t = ctx ? ctx->f[12] : 0.0f;
+        float a[4]{}, b[4]{}, out[4]{};
+        if (readVuVec4f(rdram, aAddr, a) && readVuVec4f(rdram, bAddr, b))
+        {
+            const float invT = 1.0f - t;
+            for (int i = 0; i < 4; ++i)
+            {
+                out[i] = (a[i] * t) + (b[i] * invT);
+            }
+            (void)writeVuVec4f(rdram, dstAddr, out);
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0InterVectorXYZ(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0InterVectorXYZ", rdram, ctx, runtime);
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t aAddr = getRegU32(ctx, 5);
+        const uint32_t bAddr = getRegU32(ctx, 6);
+        const float t = ctx ? ctx->f[12] : 0.0f;
+        float a[4]{}, b[4]{}, out[4]{};
+        if (readVuVec4f(rdram, aAddr, a) && readVuVec4f(rdram, bAddr, b))
+        {
+            const float invT = 1.0f - t;
+            out[0] = (a[0] * t) + (b[0] * invT);
+            out[1] = (a[1] * t) + (b[1] * invT);
+            out[2] = (a[2] * t) + (b[2] * invT);
+            out[3] = a[3];
+            (void)writeVuVec4f(rdram, dstAddr, out);
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0InversMatrix(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0InversMatrix", rdram, ctx, runtime);
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t srcAddr = getRegU32(ctx, 5);
+        float in[16]{}, out[16]{};
+        if (readVuMatrix4f(rdram, srcAddr, in))
+        {
+            rigidInverse(in, out);
+            (void)writeVuMatrix4f(rdram, dstAddr, out);
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0ITOF0Vector(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
@@ -346,17 +669,60 @@ namespace ps2_stubs
 
     void sceVu0LightColorMatrix(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0LightColorMatrix", rdram, ctx, runtime);
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t c0Addr = getRegU32(ctx, 5);
+        const uint32_t c1Addr = getRegU32(ctx, 6);
+        const uint32_t c2Addr = getRegU32(ctx, 7);
+        const uint32_t c3Addr = getRegU32(ctx, 8);
+        float c0[4]{}, c1[4]{}, c2[4]{}, c3[4]{};
+        if (readVuVec4f(rdram, c0Addr, c0) && readVuVec4f(rdram, c1Addr, c1) &&
+            readVuVec4f(rdram, c2Addr, c2) && readVuVec4f(rdram, c3Addr, c3))
+        {
+            float out[16]{};
+            for (int i = 0; i < 4; ++i)
+            {
+                out[i] = c0[i];
+                out[4 + i] = c1[i];
+                out[8 + i] = c2[i];
+                out[12 + i] = c3[i];
+            }
+            (void)writeVuMatrix4f(rdram, dstAddr, out);
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0MulMatrix(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0MulMatrix", rdram, ctx, runtime);
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t m0Addr = getRegU32(ctx, 5);
+        const uint32_t m1Addr = getRegU32(ctx, 6);
+        float m0[16]{}, m1[16]{}, out[16]{};
+        if (readVuMatrix4f(rdram, m0Addr, m0) && readVuMatrix4f(rdram, m1Addr, m1))
+        {
+            // out = m0 * m1 (first source . second source), matching the
+            // file's mulVuMatrix(lhs,rhs)=lhs.rhs convention and the RotMatrix
+            // / ViewScreenMatrix siblings (first operand on the left).
+            mulVuMatrix(m0, m1, out);
+            (void)writeVuMatrix4f(rdram, dstAddr, out);
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0MulVector(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0MulVector", rdram, ctx, runtime);
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t lhsAddr = getRegU32(ctx, 5);
+        const uint32_t rhsAddr = getRegU32(ctx, 6);
+        float lhs[4]{}, rhs[4]{}, out[4]{};
+        if (readVuVec4f(rdram, lhsAddr, lhs) && readVuVec4f(rdram, rhsAddr, rhs))
+        {
+            for (int i = 0; i < 4; ++i)
+            {
+                out[i] = lhs[i] * rhs[i];
+            }
+            (void)writeVuVec4f(rdram, dstAddr, out);
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0Normalize(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
@@ -382,7 +748,42 @@ namespace ps2_stubs
 
     void sceVu0NormalLightMatrix(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0NormalLightMatrix", rdram, ctx, runtime);
+        // Rows = normalize(-light); the 4x4 is transposed so directions occupy
+        // columns (one ApplyMatrix then yields per-light N.L).
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t l0Addr = getRegU32(ctx, 5);
+        const uint32_t l1Addr = getRegU32(ctx, 6);
+        const uint32_t l2Addr = getRegU32(ctx, 7);
+        float l0[4]{}, l1[4]{}, l2[4]{};
+        if (readVuVec4f(rdram, l0Addr, l0) && readVuVec4f(rdram, l1Addr, l1) && readVuVec4f(rdram, l2Addr, l2))
+        {
+            auto negNormalize = [](const float (&s)[4], float (&o)[4])
+            {
+                const float len = std::sqrt((s[0] * s[0]) + (s[1] * s[1]) + (s[2] * s[2]) + (s[3] * s[3]));
+                const float inv = (len > 1.0e-6f) ? (1.0f / len) : 0.0f;
+                for (int i = 0; i < 4; ++i)
+                    o[i] = -s[i] * inv;
+            };
+            float r0[4]{}, r1[4]{}, r2[4]{};
+            negNormalize(l0, r0);
+            negNormalize(l1, r1);
+            negNormalize(l2, r2);
+            float m[16]{};
+            for (int i = 0; i < 4; ++i)
+            {
+                m[i] = r0[i];
+                m[4 + i] = r1[i];
+                m[8 + i] = r2[i];
+                m[12 + i] = 0.0f;
+            }
+            m[15] = 1.0f;
+            float out[16]{};
+            for (int row = 0; row < 4; ++row)
+                for (int col = 0; col < 4; ++col)
+                    out[4 * row + col] = m[4 * col + row];
+            (void)writeVuMatrix4f(rdram, dstAddr, out);
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0OuterProduct(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
@@ -404,7 +805,19 @@ namespace ps2_stubs
 
     void sceVu0RotMatrix(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0RotMatrix", rdram, ctx, runtime);
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t srcAddr = getRegU32(ctx, 5);
+        const uint32_t rotAddr = getRegU32(ctx, 6);
+        float src[16]{}, rotVec[4]{};
+        if (readVuMatrix4f(rdram, srcAddr, src) && readVuVec4f(rdram, rotAddr, rotVec))
+        {
+            float afterZ[16]{}, afterY[16]{}, afterX[16]{};
+            axisRotateMatrix(src, rotVec[2], 2, afterZ);
+            axisRotateMatrix(afterZ, rotVec[1], 1, afterY);
+            axisRotateMatrix(afterY, rotVec[0], 0, afterX);
+            (void)writeVuMatrix4f(rdram, dstAddr, afterX);
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0RotMatrixX(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
@@ -472,12 +885,44 @@ namespace ps2_stubs
 
     void sceVu0RotTransPers(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0RotTransPers", rdram, ctx, runtime);
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t matAddr = getRegU32(ctx, 5);
+        const uint32_t vAddr = getRegU32(ctx, 6);
+        const bool fullFtoi4 = (getRegU32(ctx, 7) != 0);
+        float m[16]{}, v[4]{};
+        if (readVuMatrix4f(rdram, matAddr, m) && readVuVec4f(rdram, vAddr, v))
+        {
+            int32_t out[4]{};
+            rotTransPersOne(m, v, fullFtoi4, out);
+            (void)writeVuVec4i(rdram, dstAddr, out);
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0RotTransPersN(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0RotTransPersN", rdram, ctx, runtime);
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t matAddr = getRegU32(ctx, 5);
+        uint32_t vAddr = getRegU32(ctx, 6);
+        const int32_t count = static_cast<int32_t>(getRegU32(ctx, 7));
+        const bool fullFtoi4 = (getRegU32(ctx, 8) != 0);
+        float m[16]{};
+        if (readVuMatrix4f(rdram, matAddr, m))
+        {
+            uint32_t outAddr = dstAddr;
+            for (int32_t i = 0; i < count; ++i)
+            {
+                float v[4]{};
+                if (!readVuVec4f(rdram, vAddr, v))
+                    break;
+                int32_t out[4]{};
+                rotTransPersOne(m, v, fullFtoi4, out);
+                (void)writeVuVec4i(rdram, outAddr, out);
+                vAddr += 16u;
+                outAddr += 16u;
+            }
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0ScaleVector(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
@@ -509,7 +954,19 @@ namespace ps2_stubs
 
     void sceVu0ScaleVectorXYZ(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0ScaleVectorXYZ", rdram, ctx, runtime);
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t srcAddr = getRegU32(ctx, 5);
+        const float scale = ctx ? ctx->f[12] : 0.0f;
+        float src[4]{}, out[4]{};
+        if (readVuVec4f(rdram, srcAddr, src))
+        {
+            out[0] = src[0] * scale;
+            out[1] = src[1] * scale;
+            out[2] = src[2] * scale;
+            out[3] = src[3];
+            (void)writeVuVec4f(rdram, dstAddr, out);
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0SubVector(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
@@ -531,7 +988,20 @@ namespace ps2_stubs
 
     void sceVu0TransMatrix(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0TransMatrix", rdram, ctx, runtime);
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const uint32_t srcAddr = getRegU32(ctx, 5);
+        const uint32_t vAddr = getRegU32(ctx, 6);
+        float src[16]{}, v[4]{};
+        if (readVuMatrix4f(rdram, srcAddr, src) && readVuVec4f(rdram, vAddr, v))
+        {
+            float out[16]{};
+            std::memcpy(out, src, sizeof(out));
+            out[12] = src[12] + v[0];
+            out[13] = src[13] + v[1];
+            out[14] = src[14] + v[2];
+            (void)writeVuMatrix4f(rdram, dstAddr, out);
+        }
+        setReturnS32(ctx, 0);
     }
 
     void sceVu0TransposeMatrix(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
@@ -579,6 +1049,55 @@ namespace ps2_stubs
 
     void sceVu0ViewScreenMatrix(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
-        TODO_NAMED("sceVu0ViewScreenMatrix", rdram, ctx, runtime);
+        // Near/far params handled by formula shape; SDK parameter names
+        // not pinned. Args follow the out-of-line libvu0 register convention
+        // used throughout this file: eight scalar floats in f12..f19 (p0..p7)
+        // and the ninth (p8) as the first stack-passed argument. That
+        // eight-FP-arg-register layout is the n32/EABI convention the EE
+        // toolchain emits (an o32 layout would carry only two FP args in
+        // f12/f14 and spill p2..p7 too), and under it no GPR home/save area is
+        // reserved, so the ninth float is at 0(sp) -- read below. A target ABI
+        // that reserves a home area would shift only that read by its size.
+        const uint32_t dstAddr = getRegU32(ctx, 4);
+        const float p0 = ctx ? ctx->f[12] : 0.0f;
+        const float p1 = ctx ? ctx->f[13] : 0.0f;
+        const float p2 = ctx ? ctx->f[14] : 0.0f;
+        const float p3 = ctx ? ctx->f[15] : 0.0f;
+        const float p4 = ctx ? ctx->f[16] : 0.0f;
+        const float p5 = ctx ? ctx->f[17] : 0.0f;
+        const float p6 = ctx ? ctx->f[18] : 0.0f;
+        const float p7 = ctx ? ctx->f[19] : 0.0f;
+        float p8 = 0.0f;
+        if (const uint8_t *sp = getConstMemPtr(rdram, getRegU32(ctx, 29)))
+        {
+            std::memcpy(&p8, sp, sizeof(p8));
+        }
+
+        const float denom = p8 - p7;
+        const float zScale = (denom != 0.0f) ? ((p8 * p7 * (p6 - p5)) / denom) : 0.0f;
+        const float zOffset = (denom != 0.0f) ? (((p5 * p8) - (p6 * p7)) / denom) : 0.0f;
+
+        float scaleMat[16]{};
+        makeIdentityMatrix(scaleMat);
+        scaleMat[0] = p0;
+        scaleMat[5] = p0;
+        scaleMat[10] = 0.0f;
+        scaleMat[11] = 1.0f;
+        scaleMat[14] = 1.0f;
+        scaleMat[15] = 0.0f;
+
+        float projMat[16]{};
+        makeIdentityMatrix(projMat);
+        projMat[0] = p1;
+        projMat[5] = p2;
+        projMat[10] = zScale;
+        projMat[12] = p3;
+        projMat[13] = p4;
+        projMat[14] = zOffset;
+
+        float out[16]{};
+        mulVuMatrix(scaleMat, projMat, out);
+        (void)writeVuMatrix4f(rdram, dstAddr, out);
+        setReturnS32(ctx, 0);
     }
 }

--- a/ps2xTest/CMakeLists.txt
+++ b/ps2xTest/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(ps2_test_lib STATIC
     src/ps2_runtime_interrupt_tests.cpp
     src/ps2_memory_tests.cpp
     src/ps2_vu1_tests.cpp
+    src/ps2_vu_tests.cpp
     src/ps2_gs_tests.cpp
     src/ps2_iop_tests.cpp
     src/ps2_sif_rpc_tests.cpp

--- a/ps2xTest/src/main.cpp
+++ b/ps2xTest/src/main.cpp
@@ -11,6 +11,7 @@ void register_ps2_runtime_kernel_tests();
 void register_ps2_runtime_interrupt_tests();
 void register_ps2_memory_tests();
 void register_ps2_vu1_tests();
+void register_ps2_vu_tests();
 void register_ps2_gs_tests();
 void register_ps2_iop_tests();
 void register_ps2_sif_rpc_tests();
@@ -32,6 +33,7 @@ int main()
     register_ps2_runtime_interrupt_tests();
     register_ps2_memory_tests();
     register_ps2_vu1_tests();
+    register_ps2_vu_tests();
     register_ps2_gs_tests();
     register_ps2_iop_tests();
     register_ps2_sif_rpc_tests();

--- a/ps2xTest/src/ps2_vu_tests.cpp
+++ b/ps2xTest/src/ps2_vu_tests.cpp
@@ -1,0 +1,1045 @@
+#include "MiniTest.h"
+#include "ps2_runtime.h"
+#include "ps2_runtime_macros.h"
+#include "runtime/ps2_memory.h"
+#include "Kernel/Stubs/VU.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace
+{
+    constexpr float kEps = 1e-4f;
+
+    bool nearlyEqual(float a, float b, float eps = kEps)
+    {
+        return std::fabs(a - b) <= eps;
+    }
+
+    constexpr uint32_t kDst = 0x1000u;
+    constexpr uint32_t kA = 0x1100u;
+    constexpr uint32_t kB = 0x1200u;
+    constexpr uint32_t kC = 0x1300u;
+    constexpr uint32_t kD = 0x1400u;
+    constexpr uint32_t kDst2 = 0x1500u;
+    constexpr uint32_t kArr = 0x1600u;
+    constexpr uint32_t kOut = 0x1700u;
+    constexpr uint32_t kOut2 = 0x1800u;
+    constexpr uint32_t kSp = 0x1900u;
+
+    struct VuEnv
+    {
+        std::vector<uint8_t> rdram;
+        R5900Context ctx{};
+        PS2Runtime runtime;
+
+        VuEnv() : rdram(PS2_RAM_SIZE, 0)
+        {
+            std::memset(&ctx, 0, sizeof(ctx));
+        }
+    };
+
+    void writeVec4(VuEnv &env, uint32_t addr, float x, float y, float z, float w)
+    {
+        float v[4] = {x, y, z, w};
+        std::memcpy(getMemPtr(env.rdram.data(), addr), v, sizeof(v));
+    }
+
+    void readVec4f(VuEnv &env, uint32_t addr, float (&out)[4])
+    {
+        std::memcpy(out, getConstMemPtr(env.rdram.data(), addr), sizeof(out));
+    }
+
+    void readVec4i(VuEnv &env, uint32_t addr, int32_t (&out)[4])
+    {
+        std::memcpy(out, getConstMemPtr(env.rdram.data(), addr), sizeof(out));
+    }
+
+    void writeMat4(VuEnv &env, uint32_t addr, const float (&m)[16])
+    {
+        std::memcpy(getMemPtr(env.rdram.data(), addr), m, sizeof(m));
+    }
+
+    void readMat4(VuEnv &env, uint32_t addr, float (&out)[16])
+    {
+        std::memcpy(out, getConstMemPtr(env.rdram.data(), addr), sizeof(out));
+    }
+
+    void makeIdentity(float (&m)[16])
+    {
+        std::fill(std::begin(m), std::end(m), 0.0f);
+        m[0] = 1.0f;
+        m[5] = 1.0f;
+        m[10] = 1.0f;
+        m[15] = 1.0f;
+    }
+}
+
+void register_ps2_vu_tests()
+{
+    MiniTest::Case("PS2VU0Math", [](TestCase &tc)
+    {
+        tc.Run("MulVector_componentwise", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, 2.0f, 3.0f, 4.0f, 5.0f);
+            writeVec4(env, kB, 10.0f, 10.0f, 10.0f, 10.0f);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            ps2_stubs::sceVu0MulVector(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[4]{};
+            readVec4f(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[0], 20.0f) && nearlyEqual(out[1], 30.0f) &&
+                         nearlyEqual(out[2], 40.0f) && nearlyEqual(out[3], 50.0f),
+                     "MulVector should multiply lanes component-wise");
+        });
+
+        tc.Run("ScaleVectorXYZ_scales_xyz", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, 2.0f, 4.0f, 6.0f, 9.0f);
+            env.ctx.f[12] = 3.0f;
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            ps2_stubs::sceVu0ScaleVectorXYZ(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[4]{};
+            readVec4f(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[0], 6.0f) && nearlyEqual(out[1], 12.0f) && nearlyEqual(out[2], 18.0f),
+                     "ScaleVectorXYZ should scale xyz by f12");
+        });
+
+        tc.Run("ScaleVectorXYZ_w_passthrough", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, 2.0f, 4.0f, 6.0f, 9.0f);
+            env.ctx.f[12] = 3.0f;
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            ps2_stubs::sceVu0ScaleVectorXYZ(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[4]{};
+            readVec4f(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[3], 9.0f), "ScaleVectorXYZ should pass w through unscaled");
+        });
+
+        tc.Run("ClampVector_low", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, -5.0f, -10.0f, 50.0f, 3.0f);
+            env.ctx.f[12] = 0.0f;
+            env.ctx.f[13] = 100.0f;
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            ps2_stubs::sceVu0ClampVector(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[4]{};
+            readVec4f(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[0], 0.0f) && nearlyEqual(out[1], 0.0f), "ClampVector should clamp below lo");
+        });
+
+        tc.Run("ClampVector_high", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, -5.0f, 20.0f, 50.0f, 3.0f);
+            env.ctx.f[12] = -100.0f;
+            env.ctx.f[13] = 10.0f;
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            ps2_stubs::sceVu0ClampVector(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[4]{};
+            readVec4f(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[1], 10.0f) && nearlyEqual(out[2], 10.0f), "ClampVector should clamp above hi");
+        });
+
+        tc.Run("DivVector_reciprocal", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, 2.0f, 4.0f, 6.0f, 8.0f);
+            env.ctx.f[12] = 2.0f;
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            ps2_stubs::sceVu0DivVector(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[4]{};
+            readVec4f(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[0], 1.0f) && nearlyEqual(out[1], 2.0f) &&
+                         nearlyEqual(out[2], 3.0f) && nearlyEqual(out[3], 4.0f),
+                     "DivVector should multiply by the reciprocal of the divisor");
+        });
+
+        tc.Run("DivVector_divzero_zero", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, 5.0f, 5.0f, 5.0f, 5.0f);
+            env.ctx.f[12] = 0.0f;
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            ps2_stubs::sceVu0DivVector(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[4]{};
+            readVec4f(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[0], 0.0f) && nearlyEqual(out[1], 0.0f) &&
+                         nearlyEqual(out[2], 0.0f) && nearlyEqual(out[3], 0.0f),
+                     "DivVector should produce finite zero, not Inf/NaN, when the divisor is zero");
+        });
+
+        tc.Run("DivVectorXYZ_w_passthrough", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, 2.0f, 4.0f, 6.0f, 9.0f);
+            env.ctx.f[12] = 2.0f;
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            ps2_stubs::sceVu0DivVectorXYZ(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[4]{};
+            readVec4f(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[3], 9.0f), "DivVectorXYZ should pass w through unchanged");
+        });
+
+        tc.Run("InterVector_lerp", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, 10.0f, 10.0f, 10.0f, 10.0f);
+            writeVec4(env, kB, 0.0f, 0.0f, 0.0f, 0.0f);
+            env.ctx.f[12] = 0.25f;
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            ps2_stubs::sceVu0InterVector(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[4]{};
+            readVec4f(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[0], 2.5f) && nearlyEqual(out[3], 2.5f),
+                     "InterVector should lerp as a*t + b*(1-t)");
+        });
+
+        tc.Run("InterVectorXYZ_w_from_a", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, 10.0f, 10.0f, 10.0f, 99.0f);
+            writeVec4(env, kB, 0.0f, 0.0f, 0.0f, 0.0f);
+            env.ctx.f[12] = 0.25f;
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            ps2_stubs::sceVu0InterVectorXYZ(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[4]{};
+            readVec4f(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[3], 99.0f), "InterVectorXYZ should take w unmodified from a");
+        });
+
+        tc.Run("TransMatrix_adds_translation", [](TestCase &t)
+        {
+            VuEnv env;
+            float src[16] = {
+                1, 0, 0, 0,
+                0, 1, 0, 0,
+                0, 0, 1, 0,
+                100, 200, 300, 1};
+            writeMat4(env, kA, src);
+            writeVec4(env, kB, 5.0f, 6.0f, 7.0f, 0.0f);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            ps2_stubs::sceVu0TransMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[16]{};
+            readMat4(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[12], 105.0f) && nearlyEqual(out[13], 206.0f) && nearlyEqual(out[14], 307.0f),
+                     "TransMatrix should add the translation vector onto row3.xyz");
+        });
+
+        tc.Run("TransMatrix_rows_unchanged", [](TestCase &t)
+        {
+            VuEnv env;
+            float src[16] = {
+                1, 2, 3, 4,
+                5, 6, 7, 8,
+                9, 10, 11, 12,
+                100, 200, 300, 1};
+            writeMat4(env, kA, src);
+            writeVec4(env, kB, 1.0f, 1.0f, 1.0f, 0.0f);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            ps2_stubs::sceVu0TransMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[16]{};
+            readMat4(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[0], 1.0f) && nearlyEqual(out[5], 6.0f) && nearlyEqual(out[10], 11.0f) &&
+                         nearlyEqual(out[15], 1.0f),
+                     "TransMatrix should leave rows 0-2 and row3.w copied verbatim from src");
+        });
+
+        tc.Run("MulMatrix_identity_left", [](TestCase &t)
+        {
+            VuEnv env;
+            float ident[16]{};
+            makeIdentity(ident);
+            float a[16] = {
+                1, 2, 3, 4,
+                5, 6, 7, 8,
+                9, 10, 11, 12,
+                13, 14, 15, 16};
+            writeMat4(env, kA, ident);
+            writeMat4(env, kB, a);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            ps2_stubs::sceVu0MulMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[16]{};
+            readMat4(env, kDst, out);
+            bool allMatch = true;
+            for (int i = 0; i < 16; ++i)
+            {
+                if (!nearlyEqual(out[i], a[i]))
+                {
+                    allMatch = false;
+                }
+            }
+            t.IsTrue(allMatch, "MulMatrix(dst, I, A) should equal A");
+        });
+
+        tc.Run("MulMatrix_equals_arg1_times_arg2", [](TestCase &t)
+        {
+            VuEnv env;
+            float m0[16] = {
+                1, 3, 2, 4,
+                5, 2, 6, 1,
+                3, 7, 1, 5,
+                2, 4, 3, 1};
+            float m1[16] = {
+                1, 2, 3, 4,
+                5, 6, 7, 8,
+                9, 10, 11, 12,
+                13, 14, 15, 16};
+            float expected[16]{};
+            for (int i = 0; i < 4; ++i)
+            {
+                for (int j = 0; j < 4; ++j)
+                {
+                    float sum = 0.0f;
+                    for (int k = 0; k < 4; ++k)
+                    {
+                        // expected = mulVuMatrix(m0, m1) = m0 * m1 (arg1 * arg2);
+                        // mulVuMatrix is file-local to VU.cpp, so mirror its formula here.
+                        sum += m1[4 * k + j] * m0[4 * i + k];
+                    }
+                    expected[4 * i + j] = sum;
+                }
+            }
+            writeMat4(env, kA, m0);
+            writeMat4(env, kB, m1);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            ps2_stubs::sceVu0MulMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[16]{};
+            readMat4(env, kDst, out);
+            bool allMatch = true;
+            for (int i = 0; i < 16; ++i)
+            {
+                if (!nearlyEqual(out[i], expected[i]))
+                {
+                    allMatch = false;
+                }
+            }
+            t.IsTrue(allMatch, "MulMatrix(dst, m0, m1) should equal m0*m1 (mulVuMatrix(m0,m1), arg1*arg2)");
+        });
+
+        tc.Run("RotMatrix_Z_matches_RotMatrixZ", [](TestCase &t)
+        {
+            VuEnv env;
+            float ident[16]{};
+            makeIdentity(ident);
+            const float angle = 0.3f;
+            writeMat4(env, kA, ident);
+            writeVec4(env, kB, 0.0f, 0.0f, angle, 0.0f);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            ps2_stubs::sceVu0RotMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float rotOut[16]{};
+            readMat4(env, kDst, rotOut);
+
+            VuEnv env2;
+            writeMat4(env2, kA, ident);
+            env2.ctx.f[12] = angle;
+            SET_GPR_U32(&env2.ctx, 4, kDst2);
+            SET_GPR_U32(&env2.ctx, 5, kA);
+            ps2_stubs::sceVu0RotMatrixZ(env2.rdram.data(), &env2.ctx, &env2.runtime);
+            float zOut[16]{};
+            readMat4(env2, kDst2, zOut);
+
+            bool allMatch = true;
+            for (int i = 0; i < 16; ++i)
+            {
+                if (!nearlyEqual(rotOut[i], zOut[i]))
+                {
+                    allMatch = false;
+                }
+            }
+            t.IsTrue(allMatch, "RotMatrix with rotVec=(0,0,angle) should match RotMatrixZ(angle)");
+        });
+
+        tc.Run("RotMatrix_X_matches_RotMatrixX", [](TestCase &t)
+        {
+            VuEnv env;
+            float ident[16]{};
+            makeIdentity(ident);
+            const float angle = 0.4f;
+            writeMat4(env, kA, ident);
+            writeVec4(env, kB, angle, 0.0f, 0.0f, 0.0f);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            ps2_stubs::sceVu0RotMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float rotOut[16]{};
+            readMat4(env, kDst, rotOut);
+
+            VuEnv env2;
+            writeMat4(env2, kA, ident);
+            env2.ctx.f[12] = angle;
+            SET_GPR_U32(&env2.ctx, 4, kDst2);
+            SET_GPR_U32(&env2.ctx, 5, kA);
+            ps2_stubs::sceVu0RotMatrixX(env2.rdram.data(), &env2.ctx, &env2.runtime);
+            float xOut[16]{};
+            readMat4(env2, kDst2, xOut);
+
+            bool allMatch = true;
+            for (int i = 0; i < 16; ++i)
+            {
+                if (!nearlyEqual(rotOut[i], xOut[i]))
+                {
+                    allMatch = false;
+                }
+            }
+            t.IsTrue(allMatch, "RotMatrix with rotVec=(angle,0,0) should match RotMatrixX(angle)");
+        });
+
+        tc.Run("RotMatrix_Y_matches_RotMatrixY", [](TestCase &t)
+        {
+            VuEnv env;
+            float ident[16]{};
+            makeIdentity(ident);
+            const float angle = 0.5f;
+            writeMat4(env, kA, ident);
+            writeVec4(env, kB, 0.0f, angle, 0.0f, 0.0f);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            ps2_stubs::sceVu0RotMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float rotOut[16]{};
+            readMat4(env, kDst, rotOut);
+
+            VuEnv env2;
+            writeMat4(env2, kA, ident);
+            env2.ctx.f[12] = angle;
+            SET_GPR_U32(&env2.ctx, 4, kDst2);
+            SET_GPR_U32(&env2.ctx, 5, kA);
+            ps2_stubs::sceVu0RotMatrixY(env2.rdram.data(), &env2.ctx, &env2.runtime);
+            float yOut[16]{};
+            readMat4(env2, kDst2, yOut);
+
+            bool allMatch = true;
+            for (int i = 0; i < 16; ++i)
+            {
+                if (!nearlyEqual(rotOut[i], yOut[i]))
+                {
+                    allMatch = false;
+                }
+            }
+            t.IsTrue(allMatch, "RotMatrix with rotVec=(0,angle,0) should match RotMatrixY(angle)");
+        });
+
+        tc.Run("RotMatrix_multi_axis_order", [](TestCase &t)
+        {
+            // RotMatrix composes dst = src * Rz * Ry * Rx (Z first, then Y, then X).
+            // Cross-check against chaining the trusted single-axis siblings in the
+            // same order. Distinct nonzero angles about non-commuting axes make the
+            // ordering observable: reordering the three composition steps diverges.
+            VuEnv env;
+            float ident[16]{};
+            makeIdentity(ident);
+            const float ax = 0.3f, ay = 0.5f, az = 0.7f;
+
+            writeMat4(env, kA, ident);
+            writeVec4(env, kB, ax, ay, az, 0.0f);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            ps2_stubs::sceVu0RotMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float rotOut[16]{};
+            readMat4(env, kDst, rotOut);
+
+            // Reference: RotMatrixX(RotMatrixY(RotMatrixZ(src, az), ay), ax).
+            VuEnv env2;
+            writeMat4(env2, kA, ident);
+            env2.ctx.f[12] = az;
+            SET_GPR_U32(&env2.ctx, 4, kB); // kB <- src * Rz
+            SET_GPR_U32(&env2.ctx, 5, kA);
+            ps2_stubs::sceVu0RotMatrixZ(env2.rdram.data(), &env2.ctx, &env2.runtime);
+            env2.ctx.f[12] = ay;
+            SET_GPR_U32(&env2.ctx, 4, kC); // kC <- (src*Rz) * Ry
+            SET_GPR_U32(&env2.ctx, 5, kB);
+            ps2_stubs::sceVu0RotMatrixY(env2.rdram.data(), &env2.ctx, &env2.runtime);
+            env2.ctx.f[12] = ax;
+            SET_GPR_U32(&env2.ctx, 4, kD); // kD <- (src*Rz*Ry) * Rx
+            SET_GPR_U32(&env2.ctx, 5, kC);
+            ps2_stubs::sceVu0RotMatrixX(env2.rdram.data(), &env2.ctx, &env2.runtime);
+            float refOut[16]{};
+            readMat4(env2, kD, refOut);
+
+            bool allMatch = true;
+            for (int i = 0; i < 16; ++i)
+            {
+                if (!nearlyEqual(rotOut[i], refOut[i], 1e-3f))
+                {
+                    allMatch = false;
+                }
+            }
+            t.IsTrue(allMatch,
+                     "RotMatrix(src,(ax,ay,az)) should equal RotMatrixX(RotMatrixY(RotMatrixZ(src,az),ay),ax)");
+        });
+
+        tc.Run("InversMatrix_transposes_rotation", [](TestCase &t)
+        {
+            VuEnv env;
+            float in[16] = {
+                1, 2, 3, 0,
+                4, 5, 6, 0,
+                7, 8, 9, 0,
+                100, 200, 300, 1};
+            writeMat4(env, kA, in);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            ps2_stubs::sceVu0InversMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[16]{};
+            readMat4(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[1], 4.0f), "InversMatrix should transpose the 3x3 rotation block");
+        });
+
+        tc.Run("InversMatrix_negRt_translation", [](TestCase &t)
+        {
+            VuEnv env;
+            float in[16] = {
+                1, 2, 3, 0,
+                4, 5, 6, 0,
+                7, 8, 9, 0,
+                100, 200, 300, 1};
+            writeMat4(env, kA, in);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            ps2_stubs::sceVu0InversMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[16]{};
+            readMat4(env, kDst, out);
+            // Corrected rigid-inverse translation = -t*R^T (t dotted with rotation
+            // ROWS). t=(100,200,300), R rows (1,2,3)/(4,5,6)/(7,8,9):
+            // out[12]=-(100+400+900)=-1400, out[13]=-(400+1000+1800)=-3200,
+            // out[14]=-(700+1600+2700)=-5000.
+            t.IsTrue(nearlyEqual(out[12], -1400.0f) && nearlyEqual(out[13], -3200.0f) &&
+                         nearlyEqual(out[14], -5000.0f),
+                     "InversMatrix translation row should be -t*R^T (t dotted with rotation rows)");
+        });
+
+        tc.Run("InversMatrix_roundtrip_identity", [](TestCase &t)
+        {
+            VuEnv env;
+            float ident[16]{};
+            makeIdentity(ident);
+            writeMat4(env, kA, ident);
+            env.ctx.f[12] = 0.5f;
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            ps2_stubs::sceVu0RotMatrixZ(env.rdram.data(), &env.ctx, &env.runtime);
+            float rot[16]{};
+            readMat4(env, kDst, rot);
+
+            writeMat4(env, kB, rot);
+            SET_GPR_U32(&env.ctx, 4, kDst2);
+            SET_GPR_U32(&env.ctx, 5, kB);
+            ps2_stubs::sceVu0InversMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float inv[16]{};
+            readMat4(env, kDst2, inv);
+
+            writeMat4(env, kC, inv);
+            writeMat4(env, kD, rot);
+            SET_GPR_U32(&env.ctx, 4, kOut);
+            SET_GPR_U32(&env.ctx, 5, kC);
+            SET_GPR_U32(&env.ctx, 6, kD);
+            ps2_stubs::sceVu0MulMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float product[16]{};
+            readMat4(env, kOut, product);
+
+            float ident2[16]{};
+            makeIdentity(ident2);
+            bool allMatch = true;
+            for (int i = 0; i < 16; ++i)
+            {
+                if (!nearlyEqual(product[i], ident2[i], 1e-3f))
+                {
+                    allMatch = false;
+                }
+            }
+            t.IsTrue(allMatch, "R * InversMatrix(R) should be the identity for a pure rotation");
+        });
+
+        tc.Run("InversMatrix_roundtrip_rigid", [](TestCase &t)
+        {
+            // M = rotation (Z by 0.5) with a NONZERO translation row. Its rigid
+            // inverse must satisfy M * InversMatrix(M) == I, which exercises the
+            // translation term (the pure-rotation roundtrip above leaves it zero).
+            VuEnv env;
+            float ident[16]{};
+            makeIdentity(ident);
+            writeMat4(env, kA, ident);
+            env.ctx.f[12] = 0.5f;
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            ps2_stubs::sceVu0RotMatrixZ(env.rdram.data(), &env.ctx, &env.runtime);
+            float M[16]{};
+            readMat4(env, kDst, M);
+            M[12] = 3.0f;
+            M[13] = 7.0f;
+            M[14] = -2.0f; // nonzero translation
+            writeMat4(env, kB, M);
+
+            SET_GPR_U32(&env.ctx, 4, kDst2);
+            SET_GPR_U32(&env.ctx, 5, kB);
+            ps2_stubs::sceVu0InversMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float inv[16]{};
+            readMat4(env, kDst2, inv);
+
+            writeMat4(env, kC, M);
+            writeMat4(env, kD, inv);
+            SET_GPR_U32(&env.ctx, 4, kOut);
+            SET_GPR_U32(&env.ctx, 5, kC); // M
+            SET_GPR_U32(&env.ctx, 6, kD); // InversMatrix(M)
+            ps2_stubs::sceVu0MulMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float product[16]{};
+            readMat4(env, kOut, product);
+
+            float ident2[16]{};
+            makeIdentity(ident2);
+            bool allMatch = true;
+            for (int i = 0; i < 16; ++i)
+            {
+                if (!nearlyEqual(product[i], ident2[i], 1e-3f))
+                {
+                    allMatch = false;
+                }
+            }
+            t.IsTrue(allMatch, "M * InversMatrix(M) should be identity for a rotation+translation");
+        });
+
+        tc.Run("CameraMatrix_orthonormal_basis", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, 0.0f, 0.0f, 0.0f, 1.0f); // eye
+            writeVec4(env, kB, 0.0f, 0.0f, 1.0f, 0.0f); // fwd
+            writeVec4(env, kC, 0.0f, 1.0f, 0.0f, 0.0f); // up
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            SET_GPR_U32(&env.ctx, 7, kC);
+            ps2_stubs::sceVu0CameraMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[16]{};
+            readMat4(env, kDst, out);
+            float ident[16]{};
+            makeIdentity(ident);
+            bool allMatch = true;
+            for (int i = 0; i < 16; ++i)
+            {
+                if (!nearlyEqual(out[i], ident[i], 1e-3f))
+                {
+                    allMatch = false;
+                }
+            }
+            t.IsTrue(allMatch, "CameraMatrix at the origin with a standard basis should be the identity");
+        });
+
+        tc.Run("CameraMatrix_nonorigin_eye_maps_to_origin", [](TestCase &t)
+        {
+            // The world-to-view matrix must map the eye point to the view-space
+            // origin. A diagonal fwd gives a NON-symmetric (45-deg Y) rotation, so
+            // the translation-row formula is actually exercised: with the wrong
+            // (column-dotted) term the eye does NOT map to the origin.
+            VuEnv env;
+            writeVec4(env, kA, 10.0f, 20.0f, 30.0f, 1.0f); // eye (w=1)
+            writeVec4(env, kB, 1.0f, 0.0f, 1.0f, 0.0f);    // fwd (diagonal)
+            writeVec4(env, kC, 0.0f, 1.0f, 0.0f, 0.0f);    // up
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            SET_GPR_U32(&env.ctx, 7, kC);
+            ps2_stubs::sceVu0CameraMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+
+            // ApplyMatrix(dst, matrix, src) computes src*matrix; eye*view xyz ~ 0.
+            SET_GPR_U32(&env.ctx, 4, kOut);
+            SET_GPR_U32(&env.ctx, 5, kDst); // the camera (world-to-view) matrix
+            SET_GPR_U32(&env.ctx, 6, kA);   // eye
+            ps2_stubs::sceVu0ApplyMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float mapped[4]{};
+            readVec4f(env, kOut, mapped);
+            t.IsTrue(nearlyEqual(mapped[0], 0.0f, 1e-3f) && nearlyEqual(mapped[1], 0.0f, 1e-3f) &&
+                         nearlyEqual(mapped[2], 0.0f, 1e-3f),
+                     "CameraMatrix should map the eye point to the view-space origin");
+        });
+
+        tc.Run("NormalLightMatrix_neg_normalized", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, 1.0f, 0.0f, 0.0f, 0.0f);
+            writeVec4(env, kB, 0.0f, 1.0f, 0.0f, 0.0f);
+            writeVec4(env, kC, 0.0f, 0.0f, 1.0f, 0.0f);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            SET_GPR_U32(&env.ctx, 7, kC);
+            ps2_stubs::sceVu0NormalLightMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[16]{};
+            readMat4(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[0], -1.0f), "NormalLightMatrix rows should be normalize(-light)");
+        });
+
+        tc.Run("NormalLightMatrix_transposed", [](TestCase &t)
+        {
+            // Magnitudes (not signs) distinguish rows 6/9 here so this test
+            // stays independent of NormalLightMatrix_neg_normalized's sign
+            // convention: l1's direction has a 0.8-magnitude z component,
+            // l2's a 1.0-magnitude y component. Only a genuine row<->column
+            // transpose swaps which magnitude lands at out[6] vs out[9].
+            VuEnv env;
+            writeVec4(env, kA, 1.0f, 0.0f, 0.0f, 0.0f);
+            writeVec4(env, kB, 0.0f, 3.0f, 4.0f, 0.0f);
+            writeVec4(env, kC, 0.0f, -1.0f, 0.0f, 0.0f);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            SET_GPR_U32(&env.ctx, 7, kC);
+            ps2_stubs::sceVu0NormalLightMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[16]{};
+            readMat4(env, kDst, out);
+            t.IsTrue(nearlyEqual(std::fabs(out[6]), 1.0f) && nearlyEqual(std::fabs(out[9]), 0.8f),
+                     "NormalLightMatrix should transpose the light-direction rows into columns");
+        });
+
+        tc.Run("LightColorMatrix_verbatim_rows", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, 1.0f, 2.0f, 3.0f, 4.0f);
+            writeVec4(env, kB, 5.0f, 6.0f, 7.0f, 8.0f);
+            writeVec4(env, kC, 9.0f, 10.0f, 11.0f, 12.0f);
+            writeVec4(env, kD, 13.0f, 14.0f, 15.0f, 16.0f);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            SET_GPR_U32(&env.ctx, 7, kC);
+            SET_GPR_U32(&env.ctx, 8, kD);
+            ps2_stubs::sceVu0LightColorMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[16]{};
+            readMat4(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[4], 5.0f) && nearlyEqual(out[8], 9.0f) && nearlyEqual(out[12], 13.0f),
+                     "LightColorMatrix should copy the 4 color vectors verbatim into the 4 rows");
+        });
+
+        tc.Run("RotTransPers_apply_persp_ftoi4", [](TestCase &t)
+        {
+            VuEnv env;
+            float ident[16]{};
+            makeIdentity(ident);
+            writeMat4(env, kA, ident);
+            writeVec4(env, kB, 32.0f, 64.0f, 16.0f, 2.0f);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            SET_GPR_U32(&env.ctx, 7, 1u); // fullFtoi4 = true
+            ps2_stubs::sceVu0RotTransPers(env.rdram.data(), &env.ctx, &env.runtime);
+            int32_t out[4]{};
+            readVec4i(env, kDst, out);
+            t.IsTrue(out[0] == 256 && out[1] == 512 && out[2] == 128 && out[3] == 32,
+                     "RotTransPers should perspective-divide x/y/z then FTOI4, with w taking the un-divided FTOI4 value");
+        });
+
+        tc.Run("RotTransPers_ftoi0_z_when_flag0", [](TestCase &t)
+        {
+            VuEnv env;
+            float ident[16]{};
+            makeIdentity(ident);
+            writeMat4(env, kA, ident);
+            writeVec4(env, kB, 32.0f, 64.0f, 16.0f, 2.0f);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            SET_GPR_U32(&env.ctx, 7, 0u); // fullFtoi4 = false
+            ps2_stubs::sceVu0RotTransPers(env.rdram.data(), &env.ctx, &env.runtime);
+            int32_t out[4]{};
+            readVec4i(env, kDst, out);
+            t.IsTrue(out[2] == 8 && out[3] == 2,
+                     "RotTransPers should FTOI0-truncate z/w instead of FTOI4 when fullFtoi4 is clear");
+        });
+
+        tc.Run("RotTransPers_persp_wzero_zero", [](TestCase &t)
+        {
+            VuEnv env;
+            float ident[16]{};
+            makeIdentity(ident);
+            writeMat4(env, kA, ident);
+            writeVec4(env, kB, 5.0f, 5.0f, 5.0f, 0.0f);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            SET_GPR_U32(&env.ctx, 7, 1u);
+            ps2_stubs::sceVu0RotTransPers(env.rdram.data(), &env.ctx, &env.runtime);
+            int32_t out[4]{};
+            readVec4i(env, kDst, out);
+            t.IsTrue(out[0] == 0 && out[1] == 0 && out[2] == 0,
+                     "RotTransPers should produce finite zero (not Inf/NaN) when w is zero");
+        });
+
+        tc.Run("RotTransPers_nonidentity_matrix_apply", [](TestCase &t)
+        {
+            // The other RotTransPers/RotTransPersN cases feed an identity matrix,
+            // which is symmetric and hides the matrix-apply lane indexing. This
+            // case uses a NON-symmetric rotation+translation matrix so the per-lane
+            // m[4*i+j] dot (v*M, translation in row 3) is actually exercised. The
+            // 4th matrix column is (0,0,0,1) so w stays 1 and the perspective divide
+            // is exact (q = 1/1 = 1, xyz unchanged). v = (1,2,3,1); hand-derived:
+            //   t0 = m0*1 + m4*2 + m8*3  + m12*1 = 2 + 0  + 15 + 10 = 27
+            //   t1 = m1*1 + m5*2 + m9*3  + m13*1 = 3 + 2  + 0  + 20 = 25
+            //   t2 = m2*1 + m6*2 + m10*3 + m14*1 = 0 + 8  + 3  + 30 = 41
+            //   t3 = m3*1 + m7*2 + m11*3 + m15*1 = 1
+            // fullFtoi4=true => every lane x16: (432, 400, 656, 16).
+            VuEnv env;
+            float m[16] = {
+                2.0f, 3.0f, 0.0f, 0.0f,
+                0.0f, 1.0f, 4.0f, 0.0f,
+                5.0f, 0.0f, 1.0f, 0.0f,
+                10.0f, 20.0f, 30.0f, 1.0f,
+            };
+            writeMat4(env, kA, m);
+            writeVec4(env, kB, 1.0f, 2.0f, 3.0f, 1.0f);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kB);
+            SET_GPR_U32(&env.ctx, 7, 1u); // fullFtoi4 = true
+            ps2_stubs::sceVu0RotTransPers(env.rdram.data(), &env.ctx, &env.runtime);
+            int32_t out[4]{};
+            readVec4i(env, kDst, out);
+            t.IsTrue(out[0] == 432 && out[1] == 400 && out[2] == 656 && out[3] == 16,
+                     "RotTransPers matrix-apply should dot the vertex with matrix rows (v*M, translation in row 3)");
+        });
+
+        tc.Run("RotTransPersN_iterates", [](TestCase &t)
+        {
+            VuEnv env;
+            float ident[16]{};
+            makeIdentity(ident);
+            writeMat4(env, kA, ident);
+            writeVec4(env, kArr, 1.0f, 2.0f, 3.0f, 4.0f);
+            writeVec4(env, kArr + 16u, 10.0f, 20.0f, 30.0f, 40.0f);
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, kArr);
+            SET_GPR_U32(&env.ctx, 7, 2u);
+            SET_GPR_U32(&env.ctx, 8, 1u);
+            ps2_stubs::sceVu0RotTransPersN(env.rdram.data(), &env.ctx, &env.runtime);
+            int32_t out0[4]{}, out1[4]{};
+            readVec4i(env, kDst, out0);
+            readVec4i(env, kDst + 16u, out1);
+            t.IsTrue(out0[3] == 64, "RotTransPersN first vertex should use w=4");
+            t.IsTrue(out1[3] == 640, "RotTransPersN second vertex should advance the input/output stride by 16 bytes");
+        });
+
+        tc.Run("ecossin_cos_sin", [](TestCase &t)
+        {
+            VuEnv env;
+            const float angle = 1.0f;
+            env.ctx.f[12] = angle;
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            ps2_stubs::sceVu0ecossin(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[4]{};
+            readVec4f(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[0], std::cos(angle)) && nearlyEqual(out[1], std::sin(angle)) &&
+                         nearlyEqual(out[2], 0.0f) && nearlyEqual(out[3], 0.0f),
+                     "ecossin should write {cos(angle), sin(angle), 0, 0}");
+        });
+
+        tc.Run("ClipScreen_inside_zero", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, 100.0f, 100.0f, 0.0f, 0.0f);
+            SET_GPR_U32(&env.ctx, 4, kA);
+            ps2_stubs::sceVu0ClipScreen(env.rdram.data(), &env.ctx, &env.runtime);
+            t.Equals(getRegU32(&env.ctx, 2), 0u, "ClipScreen should return 0 for an in-bounds vertex");
+        });
+
+        tc.Run("ClipScreen_offscreen_nonzero", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, 5000.0f, 100.0f, 0.0f, 0.0f);
+            SET_GPR_U32(&env.ctx, 4, kA);
+            ps2_stubs::sceVu0ClipScreen(env.rdram.data(), &env.ctx, &env.runtime);
+            t.IsTrue(getRegU32(&env.ctx, 2) != 0u, "ClipScreen should return nonzero when x exceeds the guard band");
+        });
+
+        tc.Run("ClipScreen_negx_nonzero", [](TestCase &t)
+        {
+            // Pins the negative-x guard-band clause (v[0] < -kScreenClipGuard => 0x2),
+            // the mirror of ClipScreen_offscreen_nonzero's +x clause. Without this
+            // case, deleting the negative-x clause leaves the suite green.
+            VuEnv env;
+            writeVec4(env, kA, -5000.0f, 100.0f, 0.0f, 0.0f);
+            SET_GPR_U32(&env.ctx, 4, kA);
+            ps2_stubs::sceVu0ClipScreen(env.rdram.data(), &env.ctx, &env.runtime);
+            t.IsTrue(getRegU32(&env.ctx, 2) != 0u, "ClipScreen should return nonzero when x is below the negative guard band");
+        });
+
+        tc.Run("ClipScreen3_ors_three", [](TestCase &t)
+        {
+            // Both offscreen vertices trip the y-guard clauses (not x) so this
+            // test does not overlap ClipScreen_offscreen_nonzero's x-guard mutation.
+            VuEnv env;
+            writeVec4(env, kA, 0.0f, 5000.0f, 0.0f, 0.0f);
+            writeVec4(env, kB, 0.0f, 0.0f, 0.0f, 0.0f);
+            writeVec4(env, kC, 0.0f, -5000.0f, 0.0f, 0.0f);
+            SET_GPR_U32(&env.ctx, 4, kA);
+            SET_GPR_U32(&env.ctx, 5, kB);
+            SET_GPR_U32(&env.ctx, 6, kC);
+            ps2_stubs::sceVu0ClipScreen3(env.rdram.data(), &env.ctx, &env.runtime);
+            t.Equals(getRegU32(&env.ctx, 2), 0xCu, "ClipScreen3 should OR the guard-band codes across all 3 vertices");
+        });
+
+        tc.Run("ClipAll_all_out_returns_1", [](TestCase &t)
+        {
+            VuEnv env;
+            float ident[16]{};
+            makeIdentity(ident);
+            writeVec4(env, kA, -1.0f, -1.0f, 0.0f, 0.0f); // lo
+            writeVec4(env, kB, 1.0f, 1.0f, 0.0f, 0.0f);   // hi
+            writeMat4(env, kC, ident);
+            writeVec4(env, kArr, 5.0f, 5.0f, 0.0f, 1.0f);
+            writeVec4(env, kArr + 16u, -5.0f, -5.0f, 0.0f, 1.0f);
+            SET_GPR_U32(&env.ctx, 4, kA);
+            SET_GPR_U32(&env.ctx, 5, kB);
+            SET_GPR_U32(&env.ctx, 6, kC);
+            SET_GPR_U32(&env.ctx, 7, kArr);
+            SET_GPR_U32(&env.ctx, 8, 2u);
+            ps2_stubs::sceVu0ClipAll(env.rdram.data(), &env.ctx, &env.runtime);
+            t.Equals(static_cast<int32_t>(getRegU32(&env.ctx, 2)), 1, "ClipAll should return 1 (cull) when every vertex is outside");
+        });
+
+        tc.Run("ClipAll_one_in_returns_0", [](TestCase &t)
+        {
+            VuEnv env;
+            float ident[16]{};
+            makeIdentity(ident);
+            writeVec4(env, kA, -1.0f, -1.0f, 0.0f, 0.0f); // lo
+            writeVec4(env, kB, 1.0f, 1.0f, 0.0f, 0.0f);   // hi
+            writeMat4(env, kC, ident);
+            writeVec4(env, kArr, 5.0f, 5.0f, 0.0f, 1.0f);
+            writeVec4(env, kArr + 16u, 0.0f, 0.0f, 0.0f, 1.0f);
+            SET_GPR_U32(&env.ctx, 4, kA);
+            SET_GPR_U32(&env.ctx, 5, kB);
+            SET_GPR_U32(&env.ctx, 6, kC);
+            SET_GPR_U32(&env.ctx, 7, kArr);
+            SET_GPR_U32(&env.ctx, 8, 2u);
+            ps2_stubs::sceVu0ClipAll(env.rdram.data(), &env.ctx, &env.runtime);
+            t.Equals(static_cast<int32_t>(getRegU32(&env.ctx, 2)), 0, "ClipAll should return 0 as soon as one vertex is inside");
+        });
+
+        tc.Run("ClipAll_w_scaling_homogeneous", [](TestCase &t)
+        {
+            VuEnv env;
+            float ident[16]{};
+            makeIdentity(ident);
+            writeVec4(env, kA, -1.0f, -1.0f, 0.0f, 0.0f); // lo
+            writeVec4(env, kB, 1.0f, 1.0f, 0.0f, 0.0f);   // hi
+            writeMat4(env, kC, ident);
+            // Vertex x=2 sits OUTSIDE the raw [-1,1] band but INSIDE the
+            // homogeneous band [-w,w] = [-4,4] once scaled by w=4. With the
+            // * tw factor this vertex is judged inside -> ClipAll returns 0;
+            // without it the vertex is judged outside -> ClipAll returns 1.
+            writeVec4(env, kArr, 2.0f, 0.0f, 0.0f, 4.0f);
+            SET_GPR_U32(&env.ctx, 4, kA);
+            SET_GPR_U32(&env.ctx, 5, kB);
+            SET_GPR_U32(&env.ctx, 6, kC);
+            SET_GPR_U32(&env.ctx, 7, kArr);
+            SET_GPR_U32(&env.ctx, 8, 1u);
+            ps2_stubs::sceVu0ClipAll(env.rdram.data(), &env.ctx, &env.runtime);
+            t.Equals(static_cast<int32_t>(getRegU32(&env.ctx, 2)), 0,
+                     "ClipAll must scale the lo/hi bounds by the vertex w (homogeneous guard planes)");
+        });
+
+        tc.Run("ViewScreenMatrix_zscale", [](TestCase &t)
+        {
+            VuEnv env;
+            env.ctx.f[12] = 1.0f; // p0
+            env.ctx.f[13] = 1.0f; // p1
+            env.ctx.f[14] = 1.0f; // p2
+            env.ctx.f[15] = 0.0f; // p3
+            env.ctx.f[16] = 0.0f; // p4
+            env.ctx.f[17] = 1.0f; // p5
+            env.ctx.f[18] = 2.0f; // p6
+            env.ctx.f[19] = 100.0f; // p7
+            const float p8 = 200.0f;
+            std::memcpy(getMemPtr(env.rdram.data(), kSp), &p8, sizeof(p8));
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 29, kSp);
+            ps2_stubs::sceVu0ViewScreenMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[16]{};
+            readMat4(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[14], 200.0f, 1e-2f), "ViewScreenMatrix zScale should follow the documented formula");
+        });
+
+        tc.Run("ViewScreenMatrix_denom_zero", [](TestCase &t)
+        {
+            VuEnv env;
+            env.ctx.f[12] = 1.0f;
+            env.ctx.f[13] = 1.0f;
+            env.ctx.f[14] = 1.0f;
+            env.ctx.f[15] = 0.0f;
+            env.ctx.f[16] = 0.0f;
+            env.ctx.f[17] = 1.0f;
+            env.ctx.f[18] = 2.0f;
+            env.ctx.f[19] = 50.0f; // p7 == p8 -> denom == 0
+            const float p8 = 50.0f;
+            std::memcpy(getMemPtr(env.rdram.data(), kSp), &p8, sizeof(p8));
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 29, kSp);
+            ps2_stubs::sceVu0ViewScreenMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[16]{};
+            readMat4(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[14], 0.0f) && nearlyEqual(out[10] /*unused row*/, 0.0f),
+                     "ViewScreenMatrix should guard the near/far denominator against divide-by-zero");
+        });
+
+        tc.Run("DropShadow_directional_mode", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, 0.0f, 1.0f, 0.0f, 0.0f); // n
+            env.ctx.f[12] = 1.0f; // lx
+            env.ctx.f[13] = 0.0f; // ly
+            env.ctx.f[14] = 0.0f; // lz
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, 1u); // mode != 0
+            ps2_stubs::sceVu0DropShadowMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[16]{};
+            readMat4(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[0], 1.0f), "DropShadowMatrix directional mode should include the diagonal (1-d) term");
+        });
+
+        tc.Run("DropShadow_point_mode", [](TestCase &t)
+        {
+            VuEnv env;
+            writeVec4(env, kA, 1.0f, 0.0f, 0.0f, 0.0f); // n
+            env.ctx.f[12] = 1.0f; // lx
+            env.ctx.f[13] = 0.0f; // ly
+            env.ctx.f[14] = 0.0f; // lz
+            SET_GPR_U32(&env.ctx, 4, kDst);
+            SET_GPR_U32(&env.ctx, 5, kA);
+            SET_GPR_U32(&env.ctx, 6, 0u); // mode == 0
+            ps2_stubs::sceVu0DropShadowMatrix(env.rdram.data(), &env.ctx, &env.runtime);
+            float out[16]{};
+            readMat4(env, kDst, out);
+            t.IsTrue(nearlyEqual(out[0], 0.0f), "DropShadowMatrix point mode should subtract d before scaling by k");
+        });
+    });
+}


### PR DESCRIPTION
## Problem
Kernel/Stubs/VU.cpp declares the full sceVu0 macro-mode math surface, but a
block of the matrix/geometry/clip/lighting entry points are still TODO_NAMED
stubs. A TODO_NAMED stub aborts the call without ever writing the caller's
output operand -- it throws std::runtime_error on its first calls, and only
once its per-name warning budget is exhausted does it suppress to returning -1.
Any title that links the out-of-line
libvu0 macro-mode library therefore receives silent garbage for camera
matrices, model transforms, perspective projection, clipping, and lighting:
the destination pointer is never written, and the caller feeds stale bytes
into the transform/GS pipeline. A single unimplemented foundational routine
(CameraMatrix, RotTransPers, ...) can break an entire scene.

## Change
Replace the stubbed bodies with a self-contained host-side implementation of
the documented sceVu0 contract, using the argument/return conventions the
already-implemented sceVu0 functions in the same file establish: vector/matrix
operands as guest pointers in the integer arg registers (a0 = destination),
scalar floats in ctx->f[12]+, results via setReturnS32/output-operand write,
all through the existing getMemPtr/getConstMemPtr helpers. No new runtime
state, no threading, no new headers, no ABI or signature change, no VU.h
change, no interaction with the recompiler or scheduler. Small shared helpers
(vec/mat read-write, 4x4 multiply, identity/axis-rotation builders, a
shared perspective-transform core) live in an anonymous namespace, mirroring
the file's existing structure.

Functions implemented: MulMatrix, TransMatrix, RotMatrix, InversMatrix,
CameraMatrix, NormalLightMatrix, LightColorMatrix, DropShadowMatrix,
ViewScreenMatrix, RotTransPers, RotTransPersN, ClipScreen, ClipScreen3,
ClipAll, MulVector, ScaleVectorXYZ, DivVector, DivVectorXYZ, InterVector,
InterVectorXYZ, ClampVector, ecossin.

InterVector/InterVectorXYZ interpolate as out = a*t + b*(1-t) (the t weight applies to the first
operand, matching the reference libvu0 behavior these routines mirror); happy to adjust the operand
convention if the maintainer has a preferred lerp direction.

## Confidence tiers
High-confidence core (documented, unambiguous math, fully unit-tested):
MulMatrix, MulVector, TransMatrix, InversMatrix, CameraMatrix, RotMatrix,
DivVector, DivVectorXYZ, InterVector, InterVectorXYZ, ClampVector,
ScaleVectorXYZ, LightColorMatrix, NormalLightMatrix, RotTransPers,
RotTransPersN, ecossin.

Functional-contract tier: ClipScreen/ClipScreen3/ClipAll provide the
"nonzero => offscreen" guard-band contract callers depend on, not a bit-exact
reproduction of the hardware COP2 sticky clip-flag register; ViewScreenMatrix
handles the near/far reciprocal-difference parameters by formula shape;
DropShadowMatrix reconstructs the two documented drop-shadow modes. These are
correct-by-construction for the common call patterns but do not claim
hardware clip-flag fidelity. If you prefer a strictly-documented-only first
cut, this tier can be dropped and landed separately.

ViewScreenMatrix takes nine scalar float parameters: eight in f12..f19 and the ninth as the first
stack-passed argument at 0($sp), consistent with the eight-FP-argument-register (n32/EABI) convention
the EE toolchain uses; if your target ABI reserves a GPR home/save area, that single read shifts by
its size.

## How to verify (no game needed)
ps2xTest/src/ps2_vu_tests.cpp exercises each routine against its documented
formula in isolation (build a scratch RDRAM region, set arg registers/floats,
call the function, compare the destination within a float epsilon):

```
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_C_FLAGS=-msse4.1 -DCMAKE_CXX_FLAGS=-msse4.1
cmake --build build --config Release
./build/ps2xTest/ps2x_tests
```

Representative checks: M . InversMatrix(M) ~ I; MulMatrix(I,A) ~ A and
MulMatrix(A,I) ~ A; RotMatrix about a single axis matches the existing
RotMatrixX/Y/Z; RotTransPers equals ApplyMatrix + perspective divide +
fixed-point convert; the component-wise vector ops against their scalar
definitions.

## Scope
Implements the out-of-line libvu0 function ABI only. Inline/pure macro-mode
COP2 emission is handled by the recompiler's COP2 path and is out of scope.
No claim about any specific title's end-to-end rendering.
