### PR TITLE
fix(gs): write PMODE/SMODE2 directly in sceGsResetGraph instead of through colliding GIF A+D addresses

### DIFF
--- a/ps2xRuntime/src/lib/Kernel/Stubs/GS.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Stubs/GS.cpp
@@ -989,34 +989,36 @@ namespace ps2_stubs
 
             if (runtime)
             {
-                uint32_t pktAddr = runtime->guestMalloc(128u, 16u);
+                // PMODE/SMODE2 are privileged registers, not GIF A+D drawing registers:
+                // their old A+D addresses 0x41/0x42 alias SCISSOR_2/ALPHA_1, so route them
+                // straight to privileged state (as applyGsDispEnv does) instead.
+                runtime->memory().gs().pmode = pmode;
+                runtime->memory().gs().smode2 = smode2;
+
+                uint32_t pktAddr = runtime->guestMalloc(96u, 16u);
                 if (pktAddr != 0u)
                 {
                     uint8_t *pkt = getMemPtr(rdram, pktAddr);
                     if (pkt)
                     {
                         uint64_t *q = reinterpret_cast<uint64_t *>(pkt);
-                        q[0] = makeGiftagAplusD(7u);
+                        q[0] = makeGiftagAplusD(5u);
                         q[1] = 0xEULL;
-                        q[2] = pmode;
-                        q[3] = 0x41ULL;
-                        q[4] = smode2;
-                        q[5] = 0x42ULL;
+                        q[2] = dispfb;
+                        q[3] = 0x59ULL;
+                        q[4] = display;
+                        q[5] = 0x5aULL;
                         q[6] = dispfb;
-                        q[7] = 0x59ULL;
+                        q[7] = 0x5bULL;
                         q[8] = display;
-                        q[9] = 0x5aULL;
-                        q[10] = dispfb;
-                        q[11] = 0x5bULL;
-                        q[12] = display;
-                        q[13] = 0x5cULL;
-                        q[14] = bgcolor;
-                        q[15] = 0x5fULL;
+                        q[9] = 0x5cULL;
+                        q[10] = bgcolor;
+                        q[11] = 0x5fULL;
                         constexpr uint32_t GIF_CHANNEL = 0x1000A000;
                         constexpr uint32_t CHCR_STR_MODE0 = 0x101u;
                         auto &mem = runtime->memory();
                         mem.writeIORegister(GIF_CHANNEL + 0x10u, pktAddr);
-                        mem.writeIORegister(GIF_CHANNEL + 0x20u, 8u);
+                        mem.writeIORegister(GIF_CHANNEL + 0x20u, 6u);
                         mem.writeIORegister(GIF_CHANNEL + 0x00u, CHCR_STR_MODE0);
                         mem.processPendingTransfers();
                         runtime->guestFree(pktAddr);

--- a/ps2xTest/src/ps2_gs_tests.cpp
+++ b/ps2xTest/src/ps2_gs_tests.cpp
@@ -3343,6 +3343,60 @@ void register_ps2_gs_tests()
                                     "sceGsResetGraph should free its temporary GIF packet");
         });
 
+        tc.Run("sceGsResetGraph writes PMODE/SMODE2 to privileged state without clobbering the drawing context", [](TestCase &t)
+        {
+            PS2Runtime runtime;
+            t.IsTrue(runtime.memory().initialize(), "runtime memory initialize should succeed");
+            // Bind the GS core to guest memory up front (the same one-time bind
+            // sceGsResetGraph triggers internally via syncCoreSubsystems()) so that
+            // seeding the drawing context below survives the call under test —
+            // otherwise the lazy first-time bind would reset the context we seeded.
+            t.IsTrue(runtime.syncCoreSubsystems(), "runtime core subsystems should sync");
+
+            constexpr uint16_t kScissorX0 = 0x111;
+            constexpr uint16_t kScissorX1 = 0x222;
+            constexpr uint16_t kScissorY0 = 0x333;
+            constexpr uint16_t kScissorY1 = 0x444;
+            const uint64_t kScissorSentinel = static_cast<uint64_t>(kScissorX0) |
+                                               (static_cast<uint64_t>(kScissorX1) << 16) |
+                                               (static_cast<uint64_t>(kScissorY0) << 32) |
+                                               (static_cast<uint64_t>(kScissorY1) << 48);
+            constexpr uint64_t kAlphaSentinel = 0x1122334455667788ULL;
+
+            // Seed the drawing context directly through the same register addresses
+            // sceGsResetGraph's old (buggy) A+D packet used for PMODE/SMODE2.
+            runtime.gs().writeRegister(0x41, kScissorSentinel);
+            runtime.gs().writeRegister(0x42, kAlphaSentinel);
+
+            // Poison privileged state so a positive assertion below is meaningful.
+            runtime.memory().gs().pmode = 0;
+            runtime.memory().gs().smode2 = 0;
+
+            // Use the runtime's own guest memory (not a disconnected local buffer):
+            // the temporary GIF packet sceGsResetGraph builds and kicks is read back
+            // by the DMA engine through runtime memory, so the packet writer and the
+            // DMA reader must share the same backing storage for the kick to have any
+            // observable effect on GS context state.
+            uint8_t *const rdram = runtime.memory().getRDRAM();
+            R5900Context ctx{};
+            setRegU32(ctx, 4, 0u);
+            setRegU32(ctx, 5, 1u);
+            setRegU32(ctx, 6, 2u);
+            setRegU32(ctx, 7, 1u);
+            ps2_stubs::sceGsResetGraph(rdram, &ctx, &runtime);
+
+            t.Equals(runtime.memory().gs().pmode, makePmode(1, 0, 0, 0, 0, 0x80),
+                     "sceGsResetGraph writes PMODE to privileged state");
+            t.Equals(runtime.memory().gs().smode2, static_cast<uint64_t>((1u & 1u) | ((1u & 1u) << 1)),
+                     "sceGsResetGraph writes SMODE2 to privileged state");
+
+            GSDebugSnapshot snap = runtime.gs().getDebugSnapshot();
+            t.IsTrue(snap.ctx[1].scissor.x0 == kScissorX0 && snap.ctx[1].scissor.x1 == kScissorX1 &&
+                     snap.ctx[1].scissor.y0 == kScissorY0 && snap.ctx[1].scissor.y1 == kScissorY1,
+                     "sceGsResetGraph leaves SCISSOR_2 untouched");
+            t.Equals(snap.ctx[0].alpha, kAlphaSentinel, "sceGsResetGraph leaves ALPHA_1 untouched");
+        });
+
         tc.Run("sceGsSyncV waits on VBlank and reports interlaced field parity", [](TestCase &t)
         {
             notifyRuntimeStop();


### PR DESCRIPTION
## Problem

`sceGsResetGraph` programmed `PMODE` and `SMODE2` by placing them in the GIF A+D
packet it builds and kicks, at register addresses `0x41` and `0x42`. Those addresses
are not free. `GS::writeRegister` decodes `0x41` as `SCISSOR_2` and `0x42` as
`ALPHA_1` and applies both as drawing-context state: the scissor rectangle of the
second context, the alpha-blend register of the first. The kick's
`processPendingTransfers` submits the packet to the GIF, which walks the A+D entries
through that switch. So the two qwords overwrote scissor and alpha with display-mode
bit patterns, and `PMODE` and `SMODE2` never received the values the function had
computed for them.

## Fix

Write `PMODE` and `SMODE2` straight to privileged state — `runtime->memory().gs().pmode`
and `.smode2` — instead of routing them through the A+D packet. The two entries are
removed, and the GIFtag `NLOOP` (7 to 5), the packet allocation (128 to 96 bytes) and
the QWC written to the GIF channel (8 to 6) shrink to match.

The five remaining entries — `DISPFB1`, `DISPLAY1`, `DISPFB2`, `DISPLAY2`, `BGCOLOR` —
keep their values, register addresses and order. They were never broken, so they stay
on the A+D path and this change stays confined to the defect.

## Basis

- `ps2xRuntime/include/runtime/ps2_gs_gpu.h` assigns `GS_REG_SCISSOR_2 = 0x41` and
  `GS_REG_ALPHA_1 = 0x42`. Both reach real context state in `writeRegister`
  (`m_ctx[1].scissor`, `m_ctx[0].alpha`).
- The drawing registers this codebase decodes occupy `0x00`-`0x54` and `0x60`-`0x62`,
  leaving `0x55`-`0x5f` unassigned. The display registers the packet still carries
  (`0x59`, `0x5a`, `0x5b`, `0x5c`, `0x5f`) sit in that gap, and each has a
  pass-through case in `writeRegister` that assigns a privileged register and touches
  no drawing state. `0x41` and `0x42` do not.
- `applyGsDispEnv` in `Kernel/Stubs/Helpers/Support.h` already programs `pmode` and
  `smode2` as direct assignments to the privileged register block, so the fix follows
  an existing convention rather than adding one.

## Testing

`ps2xTest/src/ps2_gs_tests.cpp` gains a case that seeds `0x41` and `0x42` with
sentinels through `GS::writeRegister`, zeroes `pmode` and `smode2`, then calls
`sceGsResetGraph` in reset mode over the runtime's own guest RAM. It asserts that the
privileged registers now carry the computed `PMODE` and `SMODE2` values and that both
sentinels survive in the drawing context.

<details>
<summary>New test assertions, why it binds the GS core first and uses runtime RAM, and the commands to reproduce the address collision and run the suite</summary>

- Asserts `pmode == makePmode(1, 0, 0, 0, 0, 0x80)` and `smode2 == (interlace & 1) | ((ffmode & 1) << 1)`.
- Reads back `GSDebugSnapshot` and asserts `ctx[1].scissor` still holds the four
  seeded 11-bit fields and `ctx[0].alpha` still holds its 64-bit sentinel.
- Calls `syncCoreSubsystems()` before seeding: `sceGsResetGraph` performs that bind
  itself on first use, and the bind would reset the context the test just seeded.
- Passes the runtime's own `getRDRAM()` rather than a local buffer, because the DMA
  engine reads the kicked packet back through runtime memory; a disconnected buffer
  would give the kick no observable effect.

Show the collision in-tree:

```
grep -n "GS_REG_SCISSOR_2\|GS_REG_ALPHA_1" ps2xRuntime/include/runtime/ps2_gs_gpu.h
grep -n "case GS_REG_SCISSOR_2\|case GS_REG_ALPHA_1" ps2xRuntime/src/lib/ps2_gs_gpu.cpp
```

Run the regression coverage. The test binary runs its whole suite in one process and
takes no filter argument:

```
cmake --build build --target ps2_runtime ps2x_tests
./build/ps2xTest/ps2x_tests
```

</details>

## Risk and not in scope

- **Blast radius:** `sceGsResetGraph` alone. The removed entries never applied as
  `PMODE`/`SMODE2`, so nothing could have depended on them; their only observable
  effect was corrupting scissor and alpha. The direct writes sit inside the
  `if (runtime)` guard the function already had, so no new failure path appears.
- **Rebase:** #184 reworks this file and deletes the `resetGsSyncVState()` call from
  inside `sceGsResetGraph`, a few lines above the block edited here. Locate the
  function by name rather than by line number, and reconcile the two hunks by hand
  once it is clear which lands first.
- **Related:** #152 changes `applyGsDispEnv` and the `sceGsSetDefDBuff` seeds and does
  not touch `sceGsResetGraph`. Its statement that `sceGsResetGraph` enables `EN1` only
  describes the `PMODE` value this change finally delivers.
- **Not fixed here:** the other five privileged writes still travel as an A+D packet.
  Moving them to direct writes and dropping the DMA packet and kick entirely is the
  natural follow-up, but it is a larger, separate change.
