### PR TITLE
fix(gs): decode sceGsSetDefDBuff trailing args via EABI registers, not o32 stack offsets

### DIFF
--- a/ps2xRuntime/src/lib/Kernel/Stubs/GS.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Stubs/GS.cpp
@@ -1122,9 +1122,10 @@ namespace ps2_stubs
         uint32_t psm = getRegU32(ctx, 5);
         uint32_t w = getRegU32(ctx, 6);
         uint32_t h = getRegU32(ctx, 7);
-        const uint32_t ztest = readStackU32(rdram, ctx, 16);
-        const uint32_t zpsm = readStackU32(rdram, ctx, 20);
-        const uint32_t clear = readStackU32(rdram, ctx, 24);
+        const GsTrailingArgs3 trailing = decodeGsTrailingArgs3(rdram, ctx);
+        const uint32_t ztest = trailing.arg0;
+        const uint32_t zpsm = trailing.arg1;
+        const uint32_t clear = trailing.arg2;
         (void)clear;
 
         if (w == 0u)

--- a/ps2xTest/src/ps2_gs_tests.cpp
+++ b/ps2xTest/src/ps2_gs_tests.cpp
@@ -594,6 +594,49 @@ void register_ps2_gs_tests()
                      "sceGsSwapDBuffDc should honor a clear packet seeded from register-based trailing args");
         });
 
+        tc.Run("sceGsSetDefDBuff decodes trailing args from the recompiler register ABI", [](TestCase &t)
+        {
+            PS2Runtime runtime;
+            t.IsTrue(runtime.memory().initialize(), "runtime memory initialize should succeed");
+
+            std::vector<uint8_t> rdram(PS2_RAM_SIZE, 0u);
+            constexpr uint32_t kEnvAddr = 0x9000u;
+            constexpr uint32_t kStackAddr = 0xC00u;
+            constexpr uint32_t kZbuf1ValOffset = 0x60u + 0x10u;
+            constexpr uint32_t kTest1ValOffset = 0x60u + 0x70u;
+
+            R5900Context ctx{};
+            setRegU32(ctx, 4, kEnvAddr);
+            setRegU32(ctx, 5, 0u);
+            setRegU32(ctx, 6, 640u);
+            setRegU32(ctx, 7, 448u);
+            setRegU32(ctx, 8, 2u);  // ztest
+            setRegU32(ctx, 9, 1u);  // zpsm
+            setRegU32(ctx, 10, 1u); // clear
+            setRegU32(ctx, 29, kStackAddr);
+
+            const uint32_t kStackZtest = 1u;
+            std::memcpy(rdram.data() + kStackAddr + 16u, &kStackZtest, sizeof(kStackZtest));
+            const uint32_t kStackZpsm = 0xEu;
+            std::memcpy(rdram.data() + kStackAddr + 20u, &kStackZpsm, sizeof(kStackZpsm));
+            const uint32_t kStackClear = 1u;
+            std::memcpy(rdram.data() + kStackAddr + 24u, &kStackClear, sizeof(kStackClear));
+
+            std::memset(rdram.data() + kEnvAddr, 0xCD, 0x330u);
+
+            ps2_stubs::sceGsSetDefDBuff(rdram.data(), &ctx, &runtime);
+
+            uint64_t zbuf1 = 0u;
+            std::memcpy(&zbuf1, rdram.data() + kEnvAddr + kZbuf1ValOffset, sizeof(zbuf1));
+            uint64_t test1 = 0u;
+            std::memcpy(&test1, rdram.data() + kEnvAddr + kTest1ValOffset, sizeof(test1));
+
+            t.Equals((zbuf1 >> 24) & 0xFull, 1ull,
+                     "sceGsSetDefDBuff should seed ZBUF PSM from the register-passed zpsm argument, not caller stack bytes");
+            t.Equals((test1 >> 17) & 0x3ull, 2ull,
+                     "sceGsSetDefDBuff should seed TEST from the register-passed ztest argument, not caller stack bytes");
+        });
+
         tc.Run("clearFramebufferContext clears the requested context even if another context is active", [](TestCase &t)
         {
             std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);


### PR DESCRIPTION
## Problem

`sceGsSetDefDBuff` reads its ztest, zpsm and clear arguments from stack offsets 16, 20
and 24. Under this runtime's EABI those three are register-passed in `$t0`–`$t2`
(GPRs 8–10), so the reads pick up caller-frame bytes and seed the double buffer's Z-test
and Z-format from stale stack data on every call.

## Fix

Swap the three `readStackU32` calls for `decodeGsTrailingArgs3`, which reads the registers
first and falls back to the old stack offsets only when all three registers are zero.

That helper already exists and is already used by `sceGsSetDefDBuffDc` for the identical
three arguments — this makes the two siblings consistent. Because the fallback triggers
only on an all-zero register triple, the sole behavioural change is for register-passed
nonzero trailing arguments, which is the buggy case.

## Basis

The EE calling convention passes eight integer arguments in GPRs 4–11. **The test for any
`readStackU32` site is how many register arguments precede it: fewer than eight is a bug,
eight or more is correct.**

`sceGifPkRefLoadImage` in the same file also calls `readStackU32`, at offsets 0 and 8, and
is left untouched — it consumes eight register arguments first (GPRs 4–11), so its width
and height genuinely are the ninth and tenth arguments and belong on the stack.

#195 fixes the same defect class in `sceSifSendCmd`.

## Testing

One added test, `sceGsSetDefDBuff decodes trailing args from the recompiler register ABI`:
it seeds distinct sentinels in GPRs 8–10 and at the o32 stack offsets, then asserts the
written ZBUF and TEST fields carry the register values rather than the stack bytes.

```
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_C_FLAGS=-msse4.1 -DCMAKE_CXX_FLAGS="-msse4.1 -include cstdint"
cmake --build build
./build/ps2xTest/ps2x_tests
```

The `-include cstdint` is needed to build this branch as it stands: the vendored ELFIO
header omits it and newer libstdc++ no longer supplies the typedefs transitively. #199
fixed that on `main`, so the flag becomes unnecessary once this branch is rebased.

Mutation: revert the three-line helper swap and the two new assertions report the stack
sentinels instead of the register sentinels.

## Risk and not in scope

- No repo-wide audit of other `readStackU32` sites was done. `SIF.cpp` and
  `MemoryCard.cpp` also call it; auditing them is separate follow-up work.
- The all-zero-register fallback preserves the previous behaviour exactly for callers that
  genuinely pass zeros in all three registers, so such a caller sees no change.
