### PR TITLE
fix(gs): correct depth write for all AFAIL alpha-fail modes

### DIFF
--- a/ps2xRuntime/src/lib/ps2_gs_rasterizer.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_rasterizer.cpp
@@ -136,25 +136,27 @@ namespace
     {
         bool writeFramebuffer;
         bool preserveDestinationAlpha;
+        bool writeDepth;
     };
 
     AlphaTestResult classifyAlphaTest(uint64_t testReg, uint8_t alpha)
     {
         const bool pass = passesAlphaTest(testReg, alpha);
         if (pass)
-            return {true, false};
+            return {true, false, true};
 
         // TEST.AFAIL controls what happens when the alpha comparison fails.
         switch (static_cast<uint8_t>((testReg >> 12) & 0x3u))
         {
         case 1: // FB_ONLY
-            return {true, false};
-        case 3: // RGB_ONLY
-            return {true, true};
-        case 0: // KEEP
+            return {true, false, false};
         case 2: // ZB_ONLY
+            return {false, false, true};
+        case 3: // RGB_ONLY
+            return {true, true, false};
+        case 0: // KEEP
         default:
-            return {false, false};
+            return {false, false, false};
         }
     }
 
@@ -417,7 +419,7 @@ void GSRasterizer::writePixel(GS *gs, int x, int y, int z, uint8_t r, uint8_t g,
 
     const AlphaTestResult alphaTest = classifyAlphaTest(ctx.test, a);
 
-    if (!alphaTest.writeFramebuffer)
+    if (!alphaTest.writeFramebuffer && !alphaTest.writeDepth)
         return;
 
     u8* vram = gs->m_vram;
@@ -544,9 +546,12 @@ void GSRasterizer::writePixel(GS *gs, int x, int y, int z, uint8_t r, uint8_t g,
         pixel = Rgba8888ToRgba5551(pixel);
     }
 
-    gs->WriteVram(fpsm, fbp, fbw, x, y, pixel);
+    if (alphaTest.writeFramebuffer)
+    {
+        gs->WriteVram(fpsm, fbp, fbw, x, y, pixel);
+    }
 
-    if (!zmask)
+    if (alphaTest.writeDepth && !zmask)
     {
         gs->WriteVram(zpsm, zbp, fbw, x, y, z);
     }

--- a/ps2xTest/src/ps2_gs_tests.cpp
+++ b/ps2xTest/src/ps2_gs_tests.cpp
@@ -3,6 +3,7 @@
 #include "ps2_runtime.h"
 #include "ps2_stubs.h"
 #include "ps2_syscalls.h"
+#include "runtime/ps2_gs_common.h"
 #include "runtime/ps2_gs_gpu.h"
 #include "runtime/ps2_gs_memory.h"
 #include "runtime/ps2_gs_psmct32.h"
@@ -3066,6 +3067,189 @@ void register_ps2_gs_tests()
             std::memcpy(&pixel, vram.data(), sizeof(pixel));
             t.Equals(pixel, 0xAB563412u,
                      "AFAIL=RGB_ONLY should update RGB while preserving destination alpha");
+        });
+
+        tc.Run("GS alpha test AFAIL Z-buffer-only writes depth but not color", [](TestCase &t)
+        {
+            std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
+            GS gs;
+            gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
+
+            constexpr uint32_t kFbw = 1u;
+            constexpr uint32_t kZbp = 1u;         // ZBUF page, distinct from the color page
+            const uint32_t zBlock = GSInternal::framePageBaseToBlock(kZbp);
+
+            constexpr uint32_t kColorSentinel = 0xAB030201u;
+            constexpr uint32_t kZSentinel = 0x11111111u;
+            constexpr uint32_t kDrawnZ = 0x12345678u;
+
+            std::memcpy(vram.data(), &kColorSentinel, sizeof(kColorSentinel));
+            gs.WriteVram(GS_PSM_Z32, zBlock, kFbw, 0u, 0u, kZSentinel);
+
+            constexpr uint64_t kFrame =
+                (0ull << 0) |
+                (1ull << 16) |
+                (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            const uint64_t kZbuf = static_cast<uint64_t>(kZbp) << 0; // ZBP=1, PSM nibble=0 (Z32), ZMSK=0
+            constexpr uint64_t kScissor =
+                (0ull << 0) |
+                (0ull << 16) |
+                (0ull << 32) |
+                (0ull << 48);
+            constexpr uint64_t kTest =
+                1ull |                  // ATE
+                (5ull << 1) |          // ATST = GEQUAL
+                (0x80ull << 4) |       // AREF
+                (2ull << 12) |          // AFAIL = ZB_ONLY
+                (1ull << 17);          // ZTST = ALWAYS
+            constexpr uint64_t kPrim =
+                static_cast<uint64_t>(GS_PRIM_POINT);
+            constexpr uint64_t kRgbaq =
+                (0x12ull << 0) |
+                (0x34ull << 8) |
+                (0x56ull << 16) |
+                (0x00ull << 24) |
+                (0x3F800000ull << 32); // q = 1.0f
+            const uint64_t kXyz2 = static_cast<uint64_t>(kDrawnZ) << 32;
+
+            gs.writeRegister(GS_REG_FRAME_1, kFrame);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
+            gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
+            gs.writeRegister(GS_REG_TEST_1, kTest);
+            gs.writeRegister(GS_REG_PRIM, kPrim);
+            gs.writeRegister(GS_REG_RGBAQ, kRgbaq);
+            gs.writeRegister(GS_REG_XYZ2, kXyz2);
+
+            uint32_t pixel = 0u;
+            std::memcpy(&pixel, vram.data(), sizeof(pixel));
+            t.Equals(pixel, kColorSentinel,
+                     "AFAIL=ZB_ONLY must not write the framebuffer when the alpha test fails");
+
+            const uint32_t depthResult = gs.ReadVram(GS_PSM_Z32, zBlock, kFbw, 0u, 0u);
+            t.Equals(depthResult, kDrawnZ,
+                     "AFAIL=ZB_ONLY must still write depth when the alpha test fails");
+        });
+
+        tc.Run("GS alpha test AFAIL framebuffer-only leaves the depth buffer unwritten", [](TestCase &t)
+        {
+            std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
+            GS gs;
+            gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
+
+            constexpr uint32_t kFbw = 1u;
+            constexpr uint32_t kZbp = 1u;         // ZBUF page, distinct from the color page
+            const uint32_t zBlock = GSInternal::framePageBaseToBlock(kZbp);
+
+            constexpr uint32_t kColorSentinel = 0xAB030201u;
+            constexpr uint32_t kZSentinel = 0x11111111u;
+            constexpr uint32_t kDrawnZ = 0x12345678u;
+
+            std::memcpy(vram.data(), &kColorSentinel, sizeof(kColorSentinel));
+            gs.WriteVram(GS_PSM_Z32, zBlock, kFbw, 0u, 0u, kZSentinel);
+
+            constexpr uint64_t kFrame =
+                (0ull << 0) |
+                (1ull << 16) |
+                (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            const uint64_t kZbuf = static_cast<uint64_t>(kZbp) << 0; // ZBP=1, PSM nibble=0 (Z32), ZMSK=0
+            constexpr uint64_t kScissor =
+                (0ull << 0) |
+                (0ull << 16) |
+                (0ull << 32) |
+                (0ull << 48);
+            constexpr uint64_t kTest =
+                1ull |                  // ATE
+                (5ull << 1) |          // ATST = GEQUAL
+                (0x80ull << 4) |       // AREF
+                (1ull << 12) |          // AFAIL = FB_ONLY
+                (1ull << 17);          // ZTST = ALWAYS
+            constexpr uint64_t kPrim =
+                static_cast<uint64_t>(GS_PRIM_POINT);
+            constexpr uint64_t kRgbaq =
+                (0x12ull << 0) |
+                (0x34ull << 8) |
+                (0x56ull << 16) |
+                (0x00ull << 24) |
+                (0x3F800000ull << 32); // q = 1.0f
+            const uint64_t kXyz2 = static_cast<uint64_t>(kDrawnZ) << 32;
+
+            gs.writeRegister(GS_REG_FRAME_1, kFrame);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
+            gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
+            gs.writeRegister(GS_REG_TEST_1, kTest);
+            gs.writeRegister(GS_REG_PRIM, kPrim);
+            gs.writeRegister(GS_REG_RGBAQ, kRgbaq);
+            gs.writeRegister(GS_REG_XYZ2, kXyz2);
+
+            uint32_t pixel = 0u;
+            std::memcpy(&pixel, vram.data(), sizeof(pixel));
+            t.Equals(pixel, 0x00563412u,
+                     "AFAIL=FB_ONLY must write the framebuffer when the alpha test fails");
+
+            const uint32_t depthResult = gs.ReadVram(GS_PSM_Z32, zBlock, kFbw, 0u, 0u);
+            t.Equals(depthResult, kZSentinel,
+                     "AFAIL=FB_ONLY must NOT write depth when the alpha test fails");
+        });
+
+        tc.Run("GS alpha test AFAIL RGB-only leaves the depth buffer unwritten", [](TestCase &t)
+        {
+            std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
+            GS gs;
+            gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
+
+            constexpr uint32_t kFbw = 1u;
+            constexpr uint32_t kZbp = 1u;         // ZBUF page, distinct from the color page
+            const uint32_t zBlock = GSInternal::framePageBaseToBlock(kZbp);
+
+            constexpr uint32_t kColorSentinel = 0xAB030201u;
+            constexpr uint32_t kZSentinel = 0x11111111u;
+            constexpr uint32_t kDrawnZ = 0x12345678u;
+
+            std::memcpy(vram.data(), &kColorSentinel, sizeof(kColorSentinel));
+            gs.WriteVram(GS_PSM_Z32, zBlock, kFbw, 0u, 0u, kZSentinel);
+
+            constexpr uint64_t kFrame =
+                (0ull << 0) |
+                (1ull << 16) |
+                (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            const uint64_t kZbuf = static_cast<uint64_t>(kZbp) << 0; // ZBP=1, PSM nibble=0 (Z32), ZMSK=0
+            constexpr uint64_t kScissor =
+                (0ull << 0) |
+                (0ull << 16) |
+                (0ull << 32) |
+                (0ull << 48);
+            constexpr uint64_t kTest =
+                1ull |                  // ATE
+                (5ull << 1) |          // ATST = GEQUAL
+                (0x80ull << 4) |       // AREF
+                (3ull << 12) |          // AFAIL = RGB_ONLY
+                (1ull << 17);          // ZTST = ALWAYS
+            constexpr uint64_t kPrim =
+                static_cast<uint64_t>(GS_PRIM_POINT);
+            constexpr uint64_t kRgbaq =
+                (0x12ull << 0) |
+                (0x34ull << 8) |
+                (0x56ull << 16) |
+                (0x00ull << 24) |
+                (0x3F800000ull << 32); // q = 1.0f
+            const uint64_t kXyz2 = static_cast<uint64_t>(kDrawnZ) << 32;
+
+            gs.writeRegister(GS_REG_FRAME_1, kFrame);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
+            gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
+            gs.writeRegister(GS_REG_TEST_1, kTest);
+            gs.writeRegister(GS_REG_PRIM, kPrim);
+            gs.writeRegister(GS_REG_RGBAQ, kRgbaq);
+            gs.writeRegister(GS_REG_XYZ2, kXyz2);
+
+            uint32_t pixel = 0u;
+            std::memcpy(&pixel, vram.data(), sizeof(pixel));
+            t.Equals(pixel, 0xAB563412u,
+                     "AFAIL=RGB_ONLY must write RGB and preserve destination alpha when the alpha test fails");
+
+            const uint32_t depthResult = gs.ReadVram(GS_PSM_Z32, zBlock, kFbw, 0u, 0u);
+            t.Equals(depthResult, kZSentinel,
+                     "AFAIL=RGB_ONLY must NOT write depth when the alpha test fails");
         });
 
         tc.Run("GS triangle fan subpixel quad fills rows without interior holes", [](TestCase &t)


### PR DESCRIPTION
## Problem

`classifyAlphaTest` in `ps2xRuntime/src/lib/ps2_gs_rasterizer.cpp` carried a single
`writeFramebuffer` flag standing in for both the color and the depth disposition of an
alpha-test failure, and `writePixel` returned early only when that flag was false. Any
fragment that got past the early-out reached an unconditional depth write, gated only by
ZMSK. On alpha-fail that gave:

- `FB_ONLY` wrote the framebuffer and also wrote Z.
- `RGB_ONLY` wrote RGB and also wrote Z.
- `ZB_ONLY` shared `KEEP`'s branch, so it took the early-out and wrote neither color nor
  its required Z.

`KEEP` was already correct.

## Fix

- `AlphaTestResult` gains an independent `writeDepth` field, so each case states its own
  color and depth disposition instead of deriving both from one flag.
- `ZB_ONLY` gets its own `case 2` in `classifyAlphaTest` (color off, depth on) rather
  than falling through to `KEEP`.
- The early-out returns only when `writeFramebuffer` and `writeDepth` are both false.
- `writePixel` gates the color `WriteVram` on `writeFramebuffer` and the depth
  `WriteVram` on `writeDepth && !zmask`. ZMSK still suppresses the depth write.
- An alpha-test pass returns `writeDepth = true`, so a passing fragment still writes both
  buffers.
- The depth test is unchanged: `if (!zpass) return;` still precedes both `WriteVram`
  calls, so a fragment that fails ZTST writes nothing.

## Hardware basis

TEST.AFAIL selects what a fragment that fails the alpha test still writes:

| AFAIL       | color write | depth write |
|-------------|-------------|-------------|
| KEEP (0)    | no          | no          |
| FB_ONLY (1) | yes         | no          |
| ZB_ONLY (2) | no          | yes         |
| RGB_ONLY (3)| rgb only    | no          |

## Testing

New tests in `ps2xTest/src/ps2_gs_tests.cpp` sit next to the existing AFAIL framebuffer
pins and cover `ZB_ONLY`, `FB_ONLY` and `RGB_ONLY`. Each fails the alpha test with
ZTST=ALWAYS and programs ZMSK=0, a ZBUF page distinct from the color page, and a
pre-seeded depth value, so the depth write is observable. The pre-existing AFAIL pins
program ZMSK=1 and assert framebuffer contents only, which is why the new tests set up
their own Z page.

From the repository root:

```
cmake -S . -B build -DCMAKE_CXX_FLAGS="-msse4.1 -include cstdint" -DCMAKE_C_FLAGS=-msse4.1
cmake --build build --target ps2x_tests
./build/ps2xTest/ps2x_tests
```

<details>

<summary>Color and depth assertions of the new ZB_ONLY, FB_ONLY and RGB_ONLY tests</summary>

- **AFAIL=ZB_ONLY** — the framebuffer keeps its seeded value; the Z page holds the drawn
  fragment's z.
- **AFAIL=FB_ONLY** — the framebuffer holds the drawn color; the Z page keeps its seeded
  value.
- **AFAIL=RGB_ONLY** — RGB is written and destination alpha preserved; the Z page keeps
  its seeded value.

</details>

## Risk and not in scope

- Behavior changes only for fragments that fail the alpha test with AFAIL other than
  KEEP. Alpha-pass fragments, `ATE=0` draws, and the depth test are unaffected.
- Integrator note: a `ZB_ONLY` fragment now runs the color path (framebuffer read,
  blending, FBMSK, FBA alpha correction) and discards the result; only the depth write is
  committed. No write is added on that path.
- `AFAIL=KEEP` keeps its previous behavior and has no test of its own: it is held by the
  early-out condition, not by an assertion.
- No test in the suite asserts the depth write on an alpha-test pass. Every
  `GS_REG_ZBUF` write under `ps2xTest/src/` outside the tests added here sets ZMSK=1, so
  no depth write executes: `grep -rn GS_REG_ZBUF ps2xTest/src/`.
