### PR TITLE
fix(recomp): map COP2 control register 22 to the VU0 Q register

### DIFF
--- a/ps2xRecomp/include/ps2recomp/instructions.h
+++ b/ps2xRecomp/include/ps2recomp/instructions.h
@@ -696,7 +696,7 @@ namespace ps2recomp
         VU0_CR_FBRST4 = 18,    // VIF/VU reset register 4
         VU0_CR_ACC = 20,       // Accumulator register
         VU0_CR_INFO = 21,      // Information register
-        VU0_CR_CLIP2 = 22,     // Clipping flags register 2
+        VU0_CR_Q = 22,         // Q register
         VU0_CR_P = 26,         // P register
         VU0_CR_XITOP = 27,     // XITOP register
         VU0_CR_ITOP = 28,      // ITOP register

--- a/ps2xRecomp/src/lib/vu_translator.cpp
+++ b/ps2xRecomp/src/lib/vu_translator.cpp
@@ -73,8 +73,8 @@ namespace ps2recomp
                 return fmt::format("SET_GPR_VEC(ctx, {}, _mm_castps_si128(ctx->vu0_acc));", rt);
             case VU0_CR_INFO: // I dd found on offical docs but ok
                 return fmt::format("SET_GPR_U32(ctx, {}, ctx->vu0_info);", rt);
-            case VU0_CR_CLIP2:
-                return fmt::format("SET_GPR_U32(ctx, {}, ctx->vu0_clip_flags2);", rt);
+            case VU0_CR_Q:
+                return fmt::format("{{ uint32_t bits; std::memcpy(&bits, &ctx->vu0_q, sizeof(bits)); SET_GPR_U32(ctx, {}, bits); }}", rt);
             case VU0_CR_P:
                 return fmt::format("{{ uint32_t bits; std::memcpy(&bits, &ctx->vu0_p, sizeof(bits)); SET_GPR_U32(ctx, {}, bits); }}", rt);
             case VU0_CR_XITOP: // Maybe this does not exist, maybe we handle to vu0_itop
@@ -84,7 +84,7 @@ namespace ps2recomp
             case VU0_CR_TOP:
                 return fmt::format("SET_GPR_U32(ctx, {}, ctx->vu0_top);", rt);
             default:
-                return fmt::format("// Unimplemented CFC2 VU CReg: {}", rt);
+                return fmt::format("// Unimplemented CFC2 VU CReg: {}", rd);
             }
         }
         case COP2_QMTC2:
@@ -135,8 +135,8 @@ namespace ps2recomp
                 return fmt::format("ctx->vu0_acc = _mm_castsi128_ps(GPR_VEC(ctx, {}));", rt);
             case VU0_CR_INFO:
                 return fmt::format("ctx->vu0_info = GPR_U32(ctx, {});", rt);
-            case VU0_CR_CLIP2:
-                return fmt::format("ctx->vu0_clip_flags2 = GPR_U32(ctx, {});", rt);
+            case VU0_CR_Q:
+                return fmt::format("{{ uint32_t tmp = GPR_U32(ctx, {}); std::memcpy(&ctx->vu0_q, &tmp, sizeof(tmp)); }}", rt);
             case VU0_CR_P:
                 return fmt::format("{{ uint32_t tmp = GPR_U32(ctx, {}); std::memcpy(&ctx->vu0_p, &tmp, sizeof(tmp)); }}", rt);
             case VU0_CR_XITOP:

--- a/ps2xTest/src/code_generator_tests.cpp
+++ b/ps2xTest/src/code_generator_tests.cpp
@@ -851,6 +851,232 @@ void register_code_generator_tests()
             t.IsTrue(ctc2Code.find("Unimplemented CTC2 VU CReg") == std::string::npos, "CTC2 should not hit unimplemented CReg path");
         });
 
+        tc.Run("CFC2 from the Q control register reads vu0_q as raw bits", [](TestCase &t) {
+            CodeGenerator gen({}, {});
+
+            Instruction cfc2{};
+            cfc2.opcode = OPCODE_COP2;
+            cfc2.rs = COP2_CFC2;
+            cfc2.rt = 19;
+            cfc2.rd = VU0_CR_Q;
+
+            std::string code = gen.translateInstruction(cfc2);
+            printGeneratedCode("CFC2 from the Q control register reads vu0_q as raw bits", code);
+            t.Equals(code,
+                     std::string("{ uint32_t bits; std::memcpy(&bits, &ctx->vu0_q, sizeof(bits)); SET_GPR_U32(ctx, 19, bits); }"),
+                     "CFC2 from the Q control register should copy all of vu0_q's bits into rt");
+
+            cfc2.rt = 24;
+            code = gen.translateInstruction(cfc2);
+            printGeneratedCode("CFC2 from the Q control register reads vu0_q as raw bits (rt 24)", code);
+            t.Equals(code,
+                     std::string("{ uint32_t bits; std::memcpy(&bits, &ctx->vu0_q, sizeof(bits)); SET_GPR_U32(ctx, 24, bits); }"),
+                     "CFC2 from the Q control register should write whichever GPR rt names");
+
+            cfc2.rt = 31;
+            code = gen.translateInstruction(cfc2);
+            printGeneratedCode("CFC2 from the Q control register reads vu0_q as raw bits (rt 31)", code);
+            t.Equals(code,
+                     std::string("{ uint32_t bits; std::memcpy(&bits, &ctx->vu0_q, sizeof(bits)); SET_GPR_U32(ctx, 31, bits); }"),
+                     "CFC2 from the Q control register should name rt with no bits dropped");
+        });
+
+        tc.Run("CTC2 to the Q control register writes vu0_q as raw bits", [](TestCase &t) {
+            CodeGenerator gen({}, {});
+
+            Instruction ctc2{};
+            ctc2.opcode = OPCODE_COP2;
+            ctc2.rs = COP2_CTC2;
+            ctc2.rt = 19;
+            ctc2.rd = VU0_CR_Q;
+
+            std::string code = gen.translateInstruction(ctc2);
+            printGeneratedCode("CTC2 to the Q control register writes vu0_q as raw bits", code);
+            t.Equals(code,
+                     std::string("{ uint32_t tmp = GPR_U32(ctx, 19); std::memcpy(&ctx->vu0_q, &tmp, sizeof(tmp)); }"),
+                     "CTC2 to the Q control register should copy all of rt's low bits into vu0_q");
+
+            ctc2.rt = 24;
+            code = gen.translateInstruction(ctc2);
+            printGeneratedCode("CTC2 to the Q control register writes vu0_q as raw bits (rt 24)", code);
+            t.Equals(code,
+                     std::string("{ uint32_t tmp = GPR_U32(ctx, 24); std::memcpy(&ctx->vu0_q, &tmp, sizeof(tmp)); }"),
+                     "CTC2 to the Q control register should read whichever GPR rt names");
+
+            ctc2.rt = 31;
+            code = gen.translateInstruction(ctc2);
+            printGeneratedCode("CTC2 to the Q control register writes vu0_q as raw bits (rt 31)", code);
+            t.Equals(code,
+                     std::string("{ uint32_t tmp = GPR_U32(ctx, 31); std::memcpy(&ctx->vu0_q, &tmp, sizeof(tmp)); }"),
+                     "CTC2 to the Q control register should name rt with no bits dropped");
+        });
+
+        tc.Run("the Q register is COP2 control register 22", [](TestCase &t) {
+            t.Equals(static_cast<int>(VU0_CR_Q), 22, "Q is COP2 control register 22");
+        });
+
+        tc.Run("CFC2 from VU0_CR_CLIP still reads vu0_clip_flags", [](TestCase &t) {
+            CodeGenerator gen({}, {});
+
+            Instruction cfc2{};
+            cfc2.opcode = OPCODE_COP2;
+            cfc2.rs = COP2_CFC2;
+            cfc2.rt = 24;
+            cfc2.rd = VU0_CR_CLIP;
+
+            std::string code = gen.translateInstruction(cfc2);
+            printGeneratedCode("CFC2 from VU0_CR_CLIP still reads vu0_clip_flags", code);
+            t.Equals(code,
+                     std::string("SET_GPR_U32(ctx, 24, ctx->vu0_clip_flags);"),
+                     "the CFC2 VU0_CR_CLIP arm should still read vu0_clip_flags");
+        });
+
+        tc.Run("CFC2 from an unmapped control register names the control register", [](TestCase &t) {
+            CodeGenerator gen({}, {});
+
+            Instruction cfc2{};
+            cfc2.opcode = OPCODE_COP2;
+            cfc2.rs = COP2_CFC2;
+            cfc2.rt = 24;
+            cfc2.rd = 19;
+
+            std::string code = gen.translateInstruction(cfc2);
+            printGeneratedCode("CFC2 from an unmapped control register names the control register", code);
+            t.Equals(code,
+                     std::string("// Unimplemented CFC2 VU CReg: 19"),
+                     "the CFC2 fallback should report the control register with no bits added");
+
+            cfc2.rd = 25;
+            code = gen.translateInstruction(cfc2);
+            printGeneratedCode("CFC2 from an unmapped control register names the control register (25)", code);
+            t.Equals(code,
+                     std::string("// Unimplemented CFC2 VU CReg: 25"),
+                     "the CFC2 fallback should report the control register number, not rt");
+
+            cfc2.rd = 30;
+            code = gen.translateInstruction(cfc2);
+            printGeneratedCode("CFC2 from an unmapped control register names the control register (30)", code);
+            t.Equals(code,
+                     std::string("// Unimplemented CFC2 VU CReg: 30"),
+                     "the CFC2 fallback should report whichever control register was named");
+
+            cfc2.rd = 23;
+            code = gen.translateInstruction(cfc2);
+            printGeneratedCode("CFC2 from an unmapped control register names the control register (23)", code);
+            t.Equals(code,
+                     std::string("// Unimplemented CFC2 VU CReg: 23"),
+                     "the CFC2 fallback should report the control register without truncating the register field");
+        });
+
+        tc.Run("CTC2 to VU0_CR_CLIP still writes vu0_clip_flags", [](TestCase &t) {
+            CodeGenerator gen({}, {});
+
+            Instruction ctc2{};
+            ctc2.opcode = OPCODE_COP2;
+            ctc2.rs = COP2_CTC2;
+            ctc2.rt = 24;
+            ctc2.rd = VU0_CR_CLIP;
+
+            std::string code = gen.translateInstruction(ctc2);
+            printGeneratedCode("CTC2 to VU0_CR_CLIP still writes vu0_clip_flags", code);
+            t.Equals(code,
+                     std::string("ctx->vu0_clip_flags = GPR_U32(ctx, 24);"),
+                     "the CTC2 VU0_CR_CLIP arm should still write vu0_clip_flags");
+        });
+
+        tc.Run("CTC2 to an unmapped control register names the control register", [](TestCase &t) {
+            CodeGenerator gen({}, {});
+
+            Instruction ctc2{};
+            ctc2.opcode = OPCODE_COP2;
+            ctc2.rs = COP2_CTC2;
+            ctc2.rt = 24;
+            ctc2.rd = 19;
+
+            std::string code = gen.translateInstruction(ctc2);
+            printGeneratedCode("CTC2 to an unmapped control register names the control register", code);
+            t.Equals(code,
+                     std::string("// Unimplemented CTC2 VU CReg: 19"),
+                     "the CTC2 fallback should report the control register with no bits added");
+
+            ctc2.rd = 25;
+            code = gen.translateInstruction(ctc2);
+            printGeneratedCode("CTC2 to an unmapped control register names the control register (25)", code);
+            t.Equals(code,
+                     std::string("// Unimplemented CTC2 VU CReg: 25"),
+                     "the CTC2 fallback should report the control register number, not rt");
+
+            ctc2.rd = 30;
+            code = gen.translateInstruction(ctc2);
+            printGeneratedCode("CTC2 to an unmapped control register names the control register (30)", code);
+            t.Equals(code,
+                     std::string("// Unimplemented CTC2 VU CReg: 30"),
+                     "the CTC2 fallback should report whichever control register was named");
+
+            ctc2.rd = 23;
+            code = gen.translateInstruction(ctc2);
+            printGeneratedCode("CTC2 to an unmapped control register names the control register (23)", code);
+            t.Equals(code,
+                     std::string("// Unimplemented CTC2 VU CReg: 23"),
+                     "the CTC2 fallback should report the control register without truncating the register field");
+        });
+
+        tc.Run("CFC2 and CTC2 still route the I, INFO and P control registers to their own fields", [](TestCase &t) {
+            CodeGenerator gen({}, {});
+
+            Instruction cfc2{};
+            cfc2.opcode = OPCODE_COP2;
+            cfc2.rs = COP2_CFC2;
+            cfc2.rt = 24;
+
+            cfc2.rd = VU0_CR_I;
+            std::string code = gen.translateInstruction(cfc2);
+            printGeneratedCode("CFC2 from VU0_CR_I still reads vu0_i", code);
+            t.Equals(code,
+                     std::string("{ uint32_t bits; std::memcpy(&bits, &ctx->vu0_i, sizeof(bits)); SET_GPR_U32(ctx, 24, bits); }"),
+                     "the CFC2 VU0_CR_I arm should still read vu0_i");
+
+            cfc2.rd = VU0_CR_INFO;
+            code = gen.translateInstruction(cfc2);
+            printGeneratedCode("CFC2 from VU0_CR_INFO still reads vu0_info", code);
+            t.Equals(code,
+                     std::string("SET_GPR_U32(ctx, 24, ctx->vu0_info);"),
+                     "the CFC2 VU0_CR_INFO arm should still read vu0_info");
+
+            cfc2.rd = VU0_CR_P;
+            code = gen.translateInstruction(cfc2);
+            printGeneratedCode("CFC2 from VU0_CR_P still reads vu0_p", code);
+            t.Equals(code,
+                     std::string("{ uint32_t bits; std::memcpy(&bits, &ctx->vu0_p, sizeof(bits)); SET_GPR_U32(ctx, 24, bits); }"),
+                     "the CFC2 VU0_CR_P arm should still read vu0_p");
+
+            Instruction ctc2{};
+            ctc2.opcode = OPCODE_COP2;
+            ctc2.rs = COP2_CTC2;
+            ctc2.rt = 24;
+
+            ctc2.rd = VU0_CR_I;
+            code = gen.translateInstruction(ctc2);
+            printGeneratedCode("CTC2 to VU0_CR_I still writes vu0_i", code);
+            t.Equals(code,
+                     std::string("{ uint32_t tmp = GPR_U32(ctx, 24); std::memcpy(&ctx->vu0_i, &tmp, sizeof(tmp)); }"),
+                     "the CTC2 VU0_CR_I arm should still write vu0_i");
+
+            ctc2.rd = VU0_CR_INFO;
+            code = gen.translateInstruction(ctc2);
+            printGeneratedCode("CTC2 to VU0_CR_INFO still writes vu0_info", code);
+            t.Equals(code,
+                     std::string("ctx->vu0_info = GPR_U32(ctx, 24);"),
+                     "the CTC2 VU0_CR_INFO arm should still write vu0_info");
+
+            ctc2.rd = VU0_CR_P;
+            code = gen.translateInstruction(ctc2);
+            printGeneratedCode("CTC2 to VU0_CR_P still writes vu0_p", code);
+            t.Equals(code,
+                     std::string("{ uint32_t tmp = GPR_U32(ctx, 24); std::memcpy(&ctx->vu0_p, &tmp, sizeof(tmp)); }"),
+                     "the CTC2 VU0_CR_P arm should still write vu0_p");
+        });
+
         tc.Run("scalar logical immediates emit low64 operations", [](TestCase &t) {
             CodeGenerator gen({}, {});
 


### PR DESCRIPTION
# fix(recomp): map COP2 control register 22 to the VU0 Q register

## Problem

`CFC2`/`CTC2` map COP2 control register 22 to `VU0_CR_CLIP2`, "Clipping flags
register 2," which is not a hardware register. Register 22 is the Q register.
Neither switch has a Q arm, so Q — the only destination of `VDIV`, `VSQRT` and
`VRSQRT` — cannot be moved to the EE, and a guest write to Q lands on the
invented register.

The rest of Q is already modelled: `vu_translation_helpers.cpp` writes
`ctx->vu0_q` from those three instructions, the `q`-suffixed family consumes
it, and `R5900Context::vu0_q` is saved and restored across VU0 micro
subroutines. A guest that computes a scalar in VU0 macro mode and reads it back
with `cfc2` silently gets a clipping-flag word: zero unless a micro-subroutine
restore left flags in it, so `0.0f` or a nonsense tiny float.

```
vsqrt $Q, $vf5x     ; Q = sqrt(...)
vwaitq              ; stall specifically for Q
cfc2  $v0, $vi22    ; read Q
mtc1  $v0, $f0      ; reinterpret the bits as a float result
```

Nothing stalls for Q and then reads an unrelated flag register.

## Fix

- `instructions.h`: `VU0_CR_CLIP2 = 22` becomes `VU0_CR_Q = 22`.
- `vu_translator.cpp`: one new arm in each of the `CFC2` and `CTC2` switches
  moves Q's raw bits with `std::memcpy`, the shape the file already uses for the
  scalar float-valued control registers. No other arm, runtime or decoder code
  changes.
- `vu_translator.cpp`: the `CFC2` unimplemented-register fallback formatted
  `rt`, naming the wrong register; the number is in `rd`, as the `CTC2` fallback
  beside it already formats.

`CTC2` is included because hardware lists Q as writable and the `q`-suffixed
family reads `ctx->vu0_q`. Today that write goes to `vu0_clip_flags2`, which no
VU0 arithmetic reads, so it is already lost; converting only `CFC2` would leave
it lost.

## Hardware basis

Sony's VU User's Manual v6.0:

- §5.1.3 "Control Registers" — `CCR[2,22]` is the **Q register**; the clipping
  flag is `CCR[2,18]`, and there is exactly one of them.
- §6.2, `CFC2` — "Transfers the sign-extended 32-bit data of `CCR[2,id]` ...
  to `GPR[rt]` ... (However, the integer registers VI00 through VI15 are 16
  bits and are mapped to the lower 16 bits of `CCR[2,0]` through
  `CCR[2,15]`, therefore, these registers are in fact not sign-extended.)"
  The parenthetical exempts `CCR[2,0]`-`CCR[2,15]` only, so `CCR[2,22]` is
  sign-extended. `CFC2` moves bits rather than converting — hence `std::memcpy`
  plus `SET_GPR_U32`, which already sign-extends.
- §6.2, `CTC2` — "Transfers the lower 32-bit data of `GPR[rt]` ... to
  `CCR[2,id]`." The same raw 32 bits the other way: `GPR_U32`, the low 32 bits
  of the GPR, plus `std::memcpy`.
- §5.4.7 "Q Register Synchronization" — "perform synchronization with
  `VWAITQ` before accessing the Q register."

§5.1.3's access-limit table gives Q `r/w` while VU0 is stopped and `-/-` while
it is running; the argument that a macro-mode `CFC2` after a `VWAITQ` is still
in the `r/w` column is below.

## Testing

```
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-msse4.1 -DCMAKE_CXX_FLAGS=-msse4.1
cmake --build build -j "$(nproc)"
./build/ps2xTest/ps2x_tests
```

New cases in the `CodeGenerator` suite compare the whole emitted string in both
directions at control register 22, covering direction, destination operand and
width, and assert `VU0_CR_Q` = 22 separately. They hold the neighbouring
`VU0_CR_CLIP`, `VU0_CR_I`, `VU0_CR_INFO` and `VU0_CR_P` arms to their own
context fields, and both unimplemented-register fallbacks to naming the control
register. Each is held by a one-line mutation that makes it fail; the table
below gives each mutation and its measured result.

## Risk and not in scope

- Reads at control register 22 stop returning the `vu0_clip_flags2` word and
  start returning Q's bits; writes stop landing there and start setting Q.
- Both directions reach both VU0 modes; the paths are below. Guest code that
  writes Q from the EE and consumes it inside VU0 therefore changes even without
  `VDIV`, `VSQRT` or `VRSQRT`.
- Control register 22 currently names a register that does not exist on the
  hardware, so no guest can depend on its present behavior.
- For a guest that never transfers control register 22, nothing executable
  changes: the only differing emission outside the two new arms is the `CFC2`
  fallback comment, which generates no code.
- Taking effect requires regenerating output; a runtime-only rebuild changes
  nothing.

Not fixed here:

- The rest of this enum's numbering, wrong at nearly every entry. Register 22 is
  corrected alone because it displaces nothing; the hardware numbering is below.
- `R5900Context::vu0_clip_flags2`, now write-only dead state. Removing it is a
  public-struct change.
- Q pipeline latency and `VWAITQ` stall modelling in the macro-mode path.

<details>
<summary><b>Detail: the access-limit argument, blast radius, and test evidence</b></summary>

### §5.1.3's access limits, and why a macro-mode transfer is inside them

§5.1.3's access-limit table gives Q `r/w` in its "VU0 is stopped" column and
`-/-` in its "VU0 is operating (Running state)" column. The heading itself names
the state, and of §1.3's three states (Ready, Run, Stop) that is Run. §1.3.1
shifts the VU from Ready to Run when "a micro subroutine is started or a
macroinstruction is executed". §1.3.2 shifts it back to Ready "at micro
subroutine E bit termination or macroinstruction execution termination". So a
macroinstruction executes with VU0 in Run.

The `-/-` is the in-flight hazard that §5.4.7's `VWAITQ` exists to resolve, and
§1.3.2 places coprocessor transfers outside what the Run state turns away. What
the VU in Run "cannot receive" is "micro subroutine start-up nor
macroinstructions from the EE Core," while "a coprocessor transfer instruction
may or may not stall, according to the user specification" — stall or no stall,
it is not refused. A `CFC2` issued after a `VWAITQ` is therefore in the `r/w`
column.

§5.1.3 also carries a note under the field diagrams of its "R, I, Q register"
subsection: "These registers are used for accessing the R, I, Q registers in VU0
during debugging". That remark is attached to those register descriptions, not
to the access-limit table's stopped/operating columns. It does not narrow the
transfer instructions either. §5.1.3 opens by saying of the control registers
generally that they "can be accessed only by the CTC2/CFC2 instruction", and Q
is one of them. So `CFC2` and `CTC2` are the only defined paths between
`CCR[2,22]` and the EE Core, and a static recompiler has to reproduce what
either instruction does when a guest executes it.

### Where a Q transfer is visible

`R5900Context::vu0_q` starts at `1.0f`. A `CTC2` write to it reaches both VU0
modes. Macro mode reads `ctx->vu0_q` through `_mm_set1_ps(ctx->vu0_q)` in
`VMULq`, `VADDq`, `VSUBq`, `VMADDq`, `VMSUBq` and the accumulator forms. The
runtime seeds the micro-mode interpreter's `q` from `ctx->vu0_q` before a VU0
micro subroutine runs, where `MULq`, `ADDq`, `SUBq`, `MADDq` and `MSUBq` read
it. The read direction draws on both modes as well.
`ctx->vu0_q` is written by the macro-mode `VDIV`, `VSQRT` and `VRSQRT` emissions
and by the runtime's copy-back of the interpreter's `q` when a micro subroutine
finishes, so `cfc2` can return a value produced in either mode.

`vu0_clip_flags2` is left with one declaration and two writes, both in the
runtime's VU0 seed and restore paths, and no reads:

```
grep -rn "vu0_clip_flags2" ps2xRecomp ps2xRuntime ps2xTest
```

### The rest of the enum

Per §5.1.2, registers 0-15 are the integer registers `VI00`-`VI15`. Per §5.1.3,
16, 17 and 18 are the Status, MAC and clipping flags; 20 and 21 are R and I; 26
through 29 are TPC, CMSAR0, FBRST and VPU-STAT; and 31 is CMSAR1. Registers 19,
23, 24, 25 and 30 are reserved. Every other entry in this enum is wrong in one
of two ways. Some name a real control register at a number the hardware does not
use for it —
`VU0_CR_CMSAR1` is CMSAR1, which lives at `CCR[2,31]`. The rest name registers
with no COP2 control-register slot at all, `VU0_CR_ACC` among them.

Register 22 is corrected on its own because it displaces nothing: no enumerator
here named Q, and the number it belongs at held an invented register. The entry
goes in where it is, and nothing that already emits has to move. Correcting any
other entry means renumbering or removing it, and either changes what some
number emits today, mostly onto a number another entry already occupies. That
needs its own review and test matrix.

### Baseline and result

On unmodified `main` the suite passes. With this change it passes again,
including the new cases. `translateInstruction` returns the COP2 emission
verbatim — no wrapping, no indentation, no trailing newline — so these
assertions compare whole emissions, not substrings.

### New tests

In `ps2xTest/src/code_generator_tests.cpp`, `CodeGenerator` suite:

- `CFC2 from the Q control register reads vu0_q as raw bits` — driven at GPR 19,
  24 and 31
- `CTC2 to the Q control register writes vu0_q as raw bits` — driven at GPR 19,
  24 and 31
- `the Q register is COP2 control register 22`
- `CFC2 from VU0_CR_CLIP still reads vu0_clip_flags`
- `CFC2 from an unmapped control register names the control register` — driven
  at 19, 23, 25 and 30
- `CTC2 to VU0_CR_CLIP still writes vu0_clip_flags`
- `CTC2 to an unmapped control register names the control register` — driven at
  19, 23, 25 and 30
- `CFC2 and CTC2 still route the I, INFO and P control registers to their own fields`

`VU0_CR_P` is the arm the Q arms were copied from, so a copied-but-unedited
context field there is the most plausible way this change could go wrong.

### Mutation coverage

For each row: apply the one-line mutation to production code, rebuild, run the
suite, confirm the named test fails, then restore the file from a pre-mutation
copy, confirm byte-identity with `cmp`, and rebuild to confirm the suite is
green again.

| # | Mutation | Fails | Stays green |
|---|---|---|---|
| E1 | `vu_translator.cpp` **CFC2** Q arm: `std::memcpy(&bits, &ctx->vu0_q, sizeof(bits))` → `std::memcpy(&ctx->vu0_q, &bits, sizeof(bits))` | `CFC2 from the Q control register reads vu0_q as raw bits` | every other test |
| E2 | `vu_translator.cpp` **CFC2** Q arm: format arg `rt` → `rd` (emits `SET_GPR_U32(ctx, 22, bits)`) | `CFC2 from the Q control register reads vu0_q as raw bits`, all three assertions | every other test |
| E3 | `vu_translator.cpp` **CTC2** Q arm: `std::memcpy(&ctx->vu0_q, &tmp, sizeof(tmp))` → `std::memcpy(&tmp, &ctx->vu0_q, sizeof(tmp))` | `CTC2 to the Q control register writes vu0_q as raw bits` | every other test |
| E4 | `vu_translator.cpp` **CFC2** Q arm: `sizeof(bits)` → `sizeof(uint16_t)` | `CFC2 from the Q control register reads vu0_q as raw bits` | every other test |
| M5 | `instructions.h`: `VU0_CR_Q = 22` → `VU0_CR_Q = 24` | `the Q register is COP2 control register 22` | every other test — the fallback `rd` points are 19, 23, 25 and 30, and no test drives `rd` or `rt` at 24 |
| M6 | `vu_translator.cpp` **CFC2** `VU0_CR_CLIP` arm: `ctx->vu0_clip_flags` → `ctx->vu0_status` | `CFC2 from VU0_CR_CLIP still reads vu0_clip_flags` | every other test |
| M7 | `vu_translator.cpp` **CFC2** `default:` arm: format arg `rd` → `rt` (reverts the fallback fix) | `CFC2 from an unmapped control register names the control register` | every other test |
| M8 | `vu_translator.cpp` **CTC2** Q arm: format arg `rt` → `rd` (emits `GPR_U32(ctx, 22)`) | `CTC2 to the Q control register writes vu0_q as raw bits`, all three assertions | every other test |
| M9 | `vu_translator.cpp`: delete the **CFC2** `case VU0_CR_Q:` label only, so creg 22 falls to `default:` | `CFC2 from the Q control register reads vu0_q as raw bits` | every other test |
| M10 | `vu_translator.cpp` **CFC2** Q arm: `&ctx->vu0_q` → `&ctx->vu0_clip_flags2` | `CFC2 from the Q control register reads vu0_q as raw bits` | every other test |
| M11 | `vu_translator.cpp` **CTC2** `default:` arm: format arg `rd` → `rt` | `CTC2 to an unmapped control register names the control register` | every other test |
| M12 | `vu_translator.cpp` **CTC2** `VU0_CR_CLIP` arm: `ctx->vu0_clip_flags` → `ctx->vu0_status` | `CTC2 to VU0_CR_CLIP still writes vu0_clip_flags` | every other test |
| M13 | `vu_translator.cpp` **CFC2** `default:` arm: replace the `fmt::format(...)` call with the literal `std::string("// Unimplemented CFC2 VU CReg: 25")` | `CFC2 from an unmapped control register names the control register` (its `rd = 19`, `rd = 23` and `rd = 30` assertions; the `rd = 25` assertion still matches the literal) | every other test |
| M14 | `vu_translator.cpp` **CTC2** `default:` arm: replace the `fmt::format(...)` call with the literal `std::string("// Unimplemented CTC2 VU CReg: 25")` | `CTC2 to an unmapped control register names the control register` (its `rd = 19`, `rd = 23` and `rd = 30` assertions; the `rd = 25` assertion still matches the literal) | every other test |
| N15 | `vu_translator.cpp` **CFC2** Q arm: format arg `rt` → `format` | `CFC2 from the Q control register reads vu0_q as raw bits` (all three assertions) | every other test |
| N16 | `vu_translator.cpp` **CTC2** Q arm: format arg `rt` → `format` | `CTC2 to the Q control register writes vu0_q as raw bits` (all three assertions) | every other test |
| N17 | `vu_translator.cpp` **CFC2** `VU0_CR_CLIP` arm: format arg `rt` → `format` | `CFC2 from VU0_CR_CLIP still reads vu0_clip_flags` | every other test |
| N18 | `vu_translator.cpp` **CFC2** Q arm: format arg `rt` → `rt & 3` (emits 3, 0, 3) | `CFC2 from the Q control register reads vu0_q as raw bits` (all three assertions) | every other test |
| N19 | `vu_translator.cpp` **CTC2** Q arm: format arg `rt` → `rt & 3` (emits 3, 0, 3) | `CTC2 to the Q control register writes vu0_q as raw bits` (all three assertions) | every other test |
| N20 | `vu_translator.cpp` **CFC2** `VU0_CR_P` arm: `&ctx->vu0_p` → `&ctx->vu0_q` | `CFC2 and CTC2 still route the I, INFO and P control registers to their own fields` (its "the CFC2 VU0_CR_P arm should still read vu0_p" assertion) | every other test |
| N21 | `vu_translator.cpp` **CFC2** `VU0_CR_INFO` arm: `ctx->vu0_info` → `ctx->vu0_q` | `CFC2 and CTC2 still route the I, INFO and P control registers to their own fields` (its "the CFC2 VU0_CR_INFO arm should still read vu0_info" assertion) | every other test |
| N22 | `vu_translator.cpp` **CFC2** `VU0_CR_I` arm: `&ctx->vu0_i` → `&ctx->vu0_q` | `CFC2 and CTC2 still route the I, INFO and P control registers to their own fields` (its "the CFC2 VU0_CR_I arm should still read vu0_i" assertion) | every other test |
| N23 | `vu_translator.cpp` **CTC2** `VU0_CR_P` arm: `&ctx->vu0_p` → `&ctx->vu0_q` | `CFC2 and CTC2 still route the I, INFO and P control registers to their own fields` (its "the CTC2 VU0_CR_P arm should still write vu0_p" assertion) | every other test |
| N24 | `vu_translator.cpp` **CTC2** `VU0_CR_INFO` arm: `ctx->vu0_info` → `ctx->vu0_q` | `CFC2 and CTC2 still route the I, INFO and P control registers to their own fields` (its "the CTC2 VU0_CR_INFO arm should still write vu0_info" assertion) | every other test |
| N25 | `vu_translator.cpp` **CTC2** `VU0_CR_I` arm: `&ctx->vu0_i` → `&ctx->vu0_q` | `CFC2 and CTC2 still route the I, INFO and P control registers to their own fields` (its "the CTC2 VU0_CR_I arm should still write vu0_i" assertion) | every other test |
| N26 | `vu_translator.cpp` **CFC2** Q arm: format arg `rt` → the literal `24` | `CFC2 from the Q control register reads vu0_q as raw bits` (its `rt = 19` and `rt = 31` assertions only) | every other test |
| N27 | `vu_translator.cpp` **CTC2** Q arm: format arg `rt` → the literal `24` | `CTC2 to the Q control register writes vu0_q as raw bits` (its `rt = 19` and `rt = 31` assertions only) | every other test |
| N28 | `vu_translator.cpp` **CFC2** Q arm: format arg `rt` → `rt & 30` | `CFC2 from the Q control register reads vu0_q as raw bits` (its `rt = 19` and `rt = 31` assertions only) | every other test |
| N29 | `vu_translator.cpp` **CTC2** Q arm: format arg `rt` → `rt & 30` | `CTC2 to the Q control register writes vu0_q as raw bits` (its `rt = 19` and `rt = 31` assertions only) | every other test |
| N30 | `vu_translator.cpp` **CFC2** Q arm: format arg `rt` → `rt \| 24` | `CFC2 from the Q control register reads vu0_q as raw bits` (its `rt = 19` assertion only) | every other test |
| N31 | `vu_translator.cpp` **CTC2** Q arm: format arg `rt` → `rt \| 24` | `CTC2 to the Q control register writes vu0_q as raw bits` (its `rt = 19` assertion only) | every other test |
| N32 | `vu_translator.cpp` **CFC2** `default:` arm: format arg `rd` → `rd & 27` | `CFC2 from an unmapped control register names the control register` (its `rd = 23` and `rd = 30` assertions) | every other test |
| N33 | `vu_translator.cpp` **CTC2** `default:` arm: format arg `rd` → `rd & 27` | `CTC2 to an unmapped control register names the control register` (its `rd = 23` and `rd = 30` assertions) | every other test |
| N34 | `vu_translator.cpp` **CFC2** `default:` arm: format arg `rd` → `rd \| 24` | `CFC2 from an unmapped control register names the control register` (its `rd = 19` and `rd = 23` assertions) | every other test |
| N35 | `vu_translator.cpp` **CTC2** `default:` arm: format arg `rd` → `rd \| 24` | `CTC2 to an unmapped control register names the control register` (its `rd = 19` and `rd = 23` assertions) | every other test |
| N36 | `vu_translator.cpp` **CFC2** `default:` arm: format arg `rd` → `rd % 24` | `CFC2 from an unmapped control register names the control register` (its `rd = 25` and `rd = 30` assertions) | every other test |
| N37 | `vu_translator.cpp` **CTC2** `default:` arm: format arg `rd` → `rd % 24` | `CTC2 to an unmapped control register names the control register` (its `rd = 25` and `rd = 30` assertions) | every other test |

M13, M14, N26 and N27 are low-realism shapes — a hand-written literal in place
of a format call — kept because they show that the tests pin the register number
and the GPR number themselves, not the particular numbers the tests drive.

### What the driven operand numbers cover

The register fields are five bits wide: the decoder masks the raw instruction
with `0x1F` to produce `rt` and `rd`, so every legal operand is in `0`-`31`. The
Q arms are driven at 19, 24 and 31, the fallbacks at 19, 23, 25 and 30, and each
set carries all five bits between its members.

Closed by those numbers:

- `rt & M` — the only `M` that keeps every bit of every driven number is the
  five-bit field itself, which is not a change.
- An XOR, an addition, a subtraction, a shift or a scaling — each moves every
  non-zero register number.
- A threshold of the form `rd % n` or `rd < n ? rd : 0` — it holds every number
  below `n` and moves the rest. The Q arms drive `rt = 31` and close this
  outright. The fallbacks top out at 30, since 31 is CMSAR1 and not a legal
  fallback target, so any modulus above 30 is an identity there and survives;
  the rows above use `rd % 24`, and the residue is listed under what stays open.
- `(rt & M) | K` — with all five bits present in each set, any composite that
  leaves the emission unchanged is the same function as `rt | K`.

Open, and disclosed:

- `rt | K` survives when `K` sets only bits every driven number already has, that
  is when `K` is contained in the bitwise AND of the driven set. That AND is 16
  for both sets, so `| 16` is not caught.
- `| 16` cannot be closed at the fallback arms: a fallback number must be one the
  switch leaves unmapped, every unmapped control register number has bit 4 set,
  and an OR of 16 only sets a bit that is already there. At the Q arms the
  operands are GPR numbers, which carry no such constraint, so closing it there
  would leave the fallback arms open.
- A floor — `rd < n ? 0 : rd`, or `max(rd, k)` — holds every number at or above
  its threshold, so it survives whenever that threshold is at or below 19, the
  smallest number driven at any of these arms. At the fallback arms 19 is also
  the smallest unmapped control register number, so it is unclosable there for
  the same reason as `| 16`.
- The untouched `VU0_CR_CLIP`, `VU0_CR_I`, `VU0_CR_INFO` and `VU0_CR_P` arms are
  driven at one GPR number each, so neither family is closed in their tests.
  Those arms are unmodified, and what those tests cover is the field each arm
  names, which any single driven number catches.
- Where a mutation's counterpart in the other direction is caught by that
  direction's own whole-string assertion, only one row is listed above. A
  direction without its own row is still covered by that direction's assertion.
- The list above covers the shapes named. It is not a claim about every function
  that could agree with these emissions at every driven number.

</details>

