### PR TITLE
fix(sif): decode sceSifSendCmd's extra-copy destination and size from the EE argument registers

### DIFF
--- a/ps2xRuntime/src/lib/Kernel/Stubs/SIF.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Stubs/SIF.cpp
@@ -21,8 +21,8 @@ namespace ps2_stubs
     void sceSifSendCmd(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime)
     {
         const uint32_t srcAddr = getRegU32(ctx, 7); // $a3
-        const uint32_t dstAddr = readStackU32(rdram, ctx, 16);
-        const uint32_t size = readStackU32(rdram, ctx, 20);
+        const uint32_t dstAddr = getRegU32(ctx, 8);
+        const uint32_t size = getRegU32(ctx, 9);
         if (size != 0u && srcAddr != 0u && dstAddr != 0u)
         {
             for (uint32_t i = 0; i < size; ++i)

--- a/ps2xRuntime/src/lib/Kernel/Syscalls/RPC.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Syscalls/RPC.cpp
@@ -1009,11 +1009,8 @@ namespace ps2_syscalls
         uint32_t packetSize = getRegU32(ctx, 6);
         uint32_t srcExtra = getRegU32(ctx, 7);
 
-        uint32_t sp = getRegU32(ctx, 29);
-        uint32_t destExtra = 0;
-        uint32_t sizeExtra = 0;
-        readStackU32(rdram, sp, 0x10, destExtra);
-        readStackU32(rdram, sp, 0x14, sizeExtra);
+        const uint32_t destExtra = getRegU32(ctx, 8);
+        const uint32_t sizeExtra = getRegU32(ctx, 9);
 
         if (sizeExtra > 0 && srcExtra && destExtra)
         {

--- a/ps2xTest/src/ps2_sif_rpc_tests.cpp
+++ b/ps2xTest/src/ps2_sif_rpc_tests.cpp
@@ -1221,5 +1221,159 @@ void register_ps2_sif_rpc_tests()
             t.IsTrue(stackHandle != 0u, "DTX handle should be written to stack-selected recv buffer");
             t.Equals(regHandle, 0u, "register recv buffer should remain untouched when stack ABI is preferred");
         });
+
+        tc.Run("ps2_syscalls::sceSifSendCmd copies to the register-supplied destination", [](TestCase &t)
+        {
+            TestEnv env;
+
+            constexpr uint32_t kPacketAddr = 0x0003E000u;
+            constexpr uint32_t kSrcAddr = 0x0003E100u;
+            constexpr uint32_t kRegDestAddr = 0x0003E200u;
+            constexpr uint32_t kStackDestAddr = 0x0003E300u;
+            constexpr uint32_t kExtraSize = 8u;
+            constexpr uint32_t kStackSize = 4u;
+
+            std::array<uint8_t, kExtraSize> payload{};
+            for (size_t i = 0; i < payload.size(); ++i)
+            {
+                payload[i] = static_cast<uint8_t>(0x70u + i);
+            }
+            std::memcpy(env.rdram.data() + kSrcAddr, payload.data(), payload.size());
+            std::memset(env.rdram.data() + kRegDestAddr, 0, payload.size());
+            std::memset(env.rdram.data() + kStackDestAddr, 0, payload.size());
+
+            setRegU32(env.ctx, 4, 0x11u);         // cid
+            setRegU32(env.ctx, 5, kPacketAddr);   // packet
+            setRegU32(env.ctx, 6, 0x20u);         // packetSize
+            setRegU32(env.ctx, 7, kSrcAddr);      // srcExtra ($a3)
+            setRegU32(env.ctx, 8, kRegDestAddr);  // destExtra: EE arg register t0
+            setRegU32(env.ctx, 9, kExtraSize);    // sizeExtra: EE arg register t1
+            setRegU32(env.ctx, 29, K_STACK_ADDR);
+            // Stale o32 stack-argument slots -- immediately above the 16-byte
+            // caller-reserved save area -- that the old decode read from,
+            // holding a different, also-valid destination and a different,
+            // also-valid size, so each of the two reads is separately
+            // distinguishable.
+            writeGuestU32(env.rdram.data(), K_STACK_ADDR + 0x10u, kStackDestAddr);
+            writeGuestU32(env.rdram.data(), K_STACK_ADDR + 0x14u, kStackSize);
+
+            ps2_syscalls::sceSifSendCmd(env.rdram.data(), &env.ctx, &env.runtime);
+
+            t.IsTrue(std::memcmp(env.rdram.data() + kRegDestAddr, payload.data(), payload.size()) == 0,
+                     "extra payload should land at the register-supplied destination");
+            const std::array<uint8_t, kExtraSize> zeros{};
+            t.IsTrue(std::memcmp(env.rdram.data() + kStackDestAddr, zeros.data(), zeros.size()) == 0,
+                     "stack-named destination should be left untouched");
+        });
+
+        tc.Run("ps2_stubs::sceSifSendCmd copies to the register-supplied destination", [](TestCase &t)
+        {
+            TestEnv env;
+
+            constexpr uint32_t kSrcAddr = 0x0003F000u;
+            constexpr uint32_t kRegDestAddr = 0x0003F100u;
+            constexpr uint32_t kStackDestAddr = 0x0003F200u;
+            constexpr uint32_t kExtraSize = 8u;
+            constexpr uint32_t kStackSize = 4u;
+
+            std::array<uint8_t, kExtraSize> payload{};
+            for (size_t i = 0; i < payload.size(); ++i)
+            {
+                payload[i] = static_cast<uint8_t>(0x90u + i);
+            }
+            std::memcpy(env.rdram.data() + kSrcAddr, payload.data(), payload.size());
+            std::memset(env.rdram.data() + kRegDestAddr, 0, payload.size());
+            std::memset(env.rdram.data() + kStackDestAddr, 0, payload.size());
+
+            setRegU32(env.ctx, 7, kSrcAddr);      // srcAddr ($a3)
+            setRegU32(env.ctx, 8, kRegDestAddr);  // dstAddr: EE arg register t0
+            setRegU32(env.ctx, 9, kExtraSize);    // size: EE arg register t1
+            setRegU32(env.ctx, 29, K_STACK_ADDR);
+            // Stale o32 stack-argument slots -- immediately above the 16-byte
+            // caller-reserved save area -- that the old decode read from,
+            // holding a different, also-valid destination and a different,
+            // also-valid size, so each of the two reads is separately
+            // distinguishable.
+            writeGuestU32(env.rdram.data(), K_STACK_ADDR + 0x10u, kStackDestAddr);
+            writeGuestU32(env.rdram.data(), K_STACK_ADDR + 0x14u, kStackSize);
+
+            ps2_stubs::sceSifSendCmd(env.rdram.data(), &env.ctx, &env.runtime);
+
+            t.IsTrue(std::memcmp(env.rdram.data() + kRegDestAddr, payload.data(), payload.size()) == 0,
+                     "payload should land at the register-supplied destination");
+            const std::array<uint8_t, kExtraSize> zeros{};
+            t.IsTrue(std::memcmp(env.rdram.data() + kStackDestAddr, zeros.data(), zeros.size()) == 0,
+                     "stack-named destination should be left untouched");
+        });
+
+        tc.Run("ps2_syscalls::sceSifSendCmd skips the copy when the argument registers are zero", [](TestCase &t)
+        {
+            TestEnv env;
+
+            constexpr uint32_t kPacketAddr = 0x00040000u;
+            constexpr uint32_t kSrcAddr = 0x00040100u;
+            constexpr uint32_t kStackDestAddr = 0x00040200u;
+            constexpr uint32_t kStackSize = 8u;
+
+            std::array<uint8_t, kStackSize> payload{};
+            for (size_t i = 0; i < payload.size(); ++i)
+            {
+                payload[i] = static_cast<uint8_t>(0xB0u + i);
+            }
+            std::memcpy(env.rdram.data() + kSrcAddr, payload.data(), payload.size());
+            std::memset(env.rdram.data() + kStackDestAddr, 0, payload.size());
+
+            setRegU32(env.ctx, 4, 0x13u);         // cid
+            setRegU32(env.ctx, 5, kPacketAddr);   // packet
+            setRegU32(env.ctx, 6, 0x20u);         // packetSize
+            setRegU32(env.ctx, 7, kSrcAddr);      // srcExtra ($a3)
+            setRegU32(env.ctx, 8, 0u);            // destExtra: caller asked for no extra copy
+            setRegU32(env.ctx, 9, 0u);            // sizeExtra: caller asked for no extra copy
+            setRegU32(env.ctx, 29, K_STACK_ADDR);
+            // A plausible destination and a non-zero size in the o32
+            // stack-argument slots above the caller-reserved save area.
+            // Zero argument registers must not fall through to them.
+            writeGuestU32(env.rdram.data(), K_STACK_ADDR + 0x10u, kStackDestAddr);
+            writeGuestU32(env.rdram.data(), K_STACK_ADDR + 0x14u, kStackSize);
+
+            ps2_syscalls::sceSifSendCmd(env.rdram.data(), &env.ctx, &env.runtime);
+
+            const std::array<uint8_t, kStackSize> zeros{};
+            t.IsTrue(std::memcmp(env.rdram.data() + kStackDestAddr, zeros.data(), zeros.size()) == 0,
+                     "zero argument registers should not fall through to the stack destination");
+        });
+
+        tc.Run("ps2_stubs::sceSifSendCmd skips the copy when the argument registers are zero", [](TestCase &t)
+        {
+            TestEnv env;
+
+            constexpr uint32_t kSrcAddr = 0x00041000u;
+            constexpr uint32_t kStackDestAddr = 0x00041200u;
+            constexpr uint32_t kStackSize = 8u;
+
+            std::array<uint8_t, kStackSize> payload{};
+            for (size_t i = 0; i < payload.size(); ++i)
+            {
+                payload[i] = static_cast<uint8_t>(0xC0u + i);
+            }
+            std::memcpy(env.rdram.data() + kSrcAddr, payload.data(), payload.size());
+            std::memset(env.rdram.data() + kStackDestAddr, 0, payload.size());
+
+            setRegU32(env.ctx, 7, kSrcAddr);      // srcAddr ($a3)
+            setRegU32(env.ctx, 8, 0u);            // dstAddr: caller asked for no extra copy
+            setRegU32(env.ctx, 9, 0u);            // size: caller asked for no extra copy
+            setRegU32(env.ctx, 29, K_STACK_ADDR);
+            // A plausible destination and a non-zero size in the o32
+            // stack-argument slots above the caller-reserved save area.
+            // Zero argument registers must not fall through to them.
+            writeGuestU32(env.rdram.data(), K_STACK_ADDR + 0x10u, kStackDestAddr);
+            writeGuestU32(env.rdram.data(), K_STACK_ADDR + 0x14u, kStackSize);
+
+            ps2_stubs::sceSifSendCmd(env.rdram.data(), &env.ctx, &env.runtime);
+
+            const std::array<uint8_t, kStackSize> zeros{};
+            t.IsTrue(std::memcmp(env.rdram.data() + kStackDestAddr, zeros.data(), zeros.size()) == 0,
+                     "zero argument registers should not fall through to the stack destination");
+        });
     });
 }


### PR DESCRIPTION
## Problem

`sceSifSendCmd` takes six integer arguments: command id, packet, packet size,
source, destination, size. Both implementations read the fifth and sixth from
`$sp+0x10` and `$sp+0x14` — the o32 stack-argument slots, immediately above the
16-byte caller-reserved save area. On the EE those two arguments arrive in
`$t0`/`$t1` (GPRs 8 and 9), so the reads pick up whatever the caller left in its
own frame.

Both outcomes are silent. If the stale words look like a pointer and a non-zero
size, and the caller passed a source, the runtime copies the guest's payload to an
address it never named. If they are zero, an extra-data copy the guest asked for
is skipped. No observed failure is attributed to this; it is a latent bug.

## Fix

`ps2_syscalls::sceSifSendCmd` (`Kernel/Syscalls/RPC.cpp`) and
`ps2_stubs::sceSifSendCmd` (`Kernel/Stubs/SIF.cpp`) now read destination and size
with `getRegU32(ctx, 8)` and `getRegU32(ctx, 9)`.

Bare reads, not the registers-first-with-stack-fallback shape of
`decodeGsTrailingArgs2`/`decodeGsTrailingArgs3`. Most callers ask for no extra
payload, so an all-zero register group is the ordinary call here. A fallback shape
reads that as "no register arguments" and, so long as the o32 slots are not
themselves all zero, takes those stale words instead. Usually that is harmless:
such a caller normally passes a null source, and neither implementation copies
without one. But a caller passing a live source with a zero destination and zero
length gets a copy to whatever those words name, unless the guard on the decoded
destination or size stops it. Bare reads see zero, skip the copy, and are correct.
Both helpers sit in `Kernel/Stubs/GS.cpp`'s anonymous namespace and were never
callable from either site touched here, so this declines a shape, not a helper.

Both definitions are fixed rather than one deleted; the name is in
`PS2_SYSCALL_LIST` and `PS2_STUB_LIST` (`ps2xRuntime/include/ps2_call_list.h`).
Leaving the stub on the old decode keeps a trap for the next reader, which is how
I found this.

## Calling convention

- `Ps2VarArgCursor::readWordAtSlot`, `Kernel/Stubs/Helpers/Support.h` — your own
  comment states the convention: "EE calls use eight integer argument registers
  (a0-a3, t0-t3 / r4-r11)".
- `sceGifPkRefLoadImage`, `Kernel/Stubs/GS.cpp` — decodes eight arguments from
  GPRs 4-11 before touching the stack.
- `sceMcGetDir` and `sceMcGetInfo`, `Kernel/Stubs/MemoryCard.cpp` — these read
  their trailing arguments with `readStackU32(rdram, ctx, 16)`, and `sceMcGetDir`
  with `readStackU32(rdram, ctx, 20)` as well: character for character the construct
  this change removes from `Kernel/Stubs/SIF.cpp`. Both were converted to bare
  `getRegU32(ctx, 8)`, plus `getRegU32(ctx, 9)` for the sixth argument, with no
  stack fallback (#179, merged).

## Testing

New cases in `ps2xTest/src/ps2_sif_rpc_tests.cpp`. Both shapes below are added for
each implementation; neither function had any coverage before.

- `… copies to the register-supplied destination`: a real destination and size in
  GPRs 8 and 9; a different but also-valid destination and size at the o32 stack
  offsets, so the two reads are separately distinguishable. Asserts the payload
  lands whole at the register-named destination and the stack-named one is
  untouched.
- `… skips the copy when the argument registers are zero`: GPRs 8 and 9 zero, a
  live source in `$a3`, a plausible destination and a non-zero size at the o32
  offsets. Asserts the stack-named destination stays zero — the only address either
  decode shape could copy to. The live source is required: with a null source the
  copy is refused whatever the decode produced, so a fallback shape would pass.

Build and run, using the repo's own CI configure line:

```
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_C_FLAGS=-msse4.1 -DCMAKE_CXX_FLAGS=-msse4.1
cmake --build build --config Release
./build/ps2xTest/ps2x_tests
```

That configure line is the repository's own CI line, published as-is. On a newer
GCC the build needs `-DCMAKE_CXX_FLAGS="-msse4.1 -include cstdint"` instead: the
vendored `elfio` header uses `uint16_t` without including `<cstdint>`. That is a
toolchain issue in a fetched dependency, unrelated to this change.

The suite passes on this branch. Each mutation below was applied on top of it,
rebuilt and re-run; every case not named in a row stayed green for that row.

| Mutation | Cases that fail |
|---|---|
| `ps2_syscalls::sceSifSendCmd` put back on the stack reads | both syscall cases |
| `ps2_stubs::sceSifSendCmd` put back on the stack reads | both stub cases |
| Either function: only one of the two reads, destination or size, moved back to the stack | that function's `copies to the register-supplied destination` |
| Either function rewritten to prefer the registers and fall back to the o32 slots | that function's `skips the copy when the argument registers are zero` |

Reverting either implementation to the stack reads is the fail-before evidence:
its cases fail, and pass again once the register reads are restored. The
prefer-registers-with-fallback row is why the zero case is a test rather than a
remark.

## Risk and not in scope

- The stub definition is unreachable through name resolution. Every name-to-handler
  path checks the syscall list first and returns on a hit — `resolveStubTarget` and
  the stub emitter in `ps2xRecomp/src/lib/ps2_recompiler.cpp`,
  `emitRelocationCallIfAvailable` in `ps2xRecomp/src/lib/control_flow_emitter.cpp`,
  `resolveHandlerByName` in `ps2xRuntime/src/lib/game_overrides.cpp` — so generated
  code always reaches the syscall version. It is still a public symbol via
  `PS2_STUB_LIST(PS2_DECLARE_STUB)`, so an out-of-tree override could call it, and
  one that depends on the old stack decode will see different behaviour.
- I did not remove the duplicate symbol or its call-list entry on your behalf.
  Happy to send a follow-up dropping the duplicate if you would rather have one.
- `SifRegisterRpc` in `Kernel/Syscalls/RPC.cpp` has the same shape: four arguments
  from `$a0`-`$a3`, then `cfunc`/`cbuf`/`qd` from `0x10`/`0x14`/`0x18`. I left it
  alone because its stack decode is pinned by existing `ps2xTest` cases, so changing
  it means rewriting those, and I would rather ask first. It is in the issue I am
  opening alongside this, with related decode questions.
- #186 (open) fixes the same class of bug in `sceGsSetDefDBuff`; its scope note names
  `SIF.cpp` as a `readStackU32` caller it did not audit, and this is that follow-up
  for one of the sites. #186 adopts `decodeGsTrailingArgs3` there, because
  `sceGsSetDefDBuffDc` already decodes the identical three arguments with it and
  that helper reproduces the previous stack reads exactly when the register group is
  all zero. Here the all-zero group is the ordinary call, so it would reproduce the
  wrong decode. Whether the fallbacks are wanted at all is one of the issue's
  questions.
