### PR TITLE
fix(gs): advance the vertex queue on non-drawing (ADC) vertex kicks

### DIFF
--- a/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
@@ -2271,9 +2271,6 @@ void GS::vertexKick(bool drawing)
         }
     });
 
-    if (!drawing)
-        return;
-
     int needed = 0;
     switch (m_prim.type)
     {
@@ -2305,8 +2302,13 @@ void GS::vertexKick(bool drawing)
     if (m_vtxCount < needed)
         return;
 
-    m_rasterizer.drawPrimitive(this);
-    recordDrawDebugEventUnlocked(needed);
+    // A non-drawing kick (XYZ3/XYZF3, or the ADC bit of a PACKED vertex)
+    // suppresses only the drawing kick; the vertex queue still advances.
+    if (drawing)
+    {
+        m_rasterizer.drawPrimitive(this);
+        recordDrawDebugEventUnlocked(needed);
+    }
 
     switch (m_prim.type)
     {

--- a/ps2xTest/src/ps2_gs_tests.cpp
+++ b/ps2xTest/src/ps2_gs_tests.cpp
@@ -3153,6 +3153,494 @@ void register_ps2_gs_tests()
                      "triangle fan quad should light at least one framebuffer row");
         });
 
+        tc.Run("GS TRISTRIP XYZ3 vertex advances the queue window", [](TestCase &t)
+        {
+            std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
+            GS gs;
+            gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
+
+            constexpr uint64_t kFrame =
+                (0ull << 0) |
+                (1ull << 16) |
+                (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
+            constexpr uint64_t kScissor =
+                (0ull << 0) |
+                (63ull << 16) |
+                (0ull << 32) |
+                (63ull << 48);
+            constexpr uint64_t kTest = (1ull << 17); // ZTST = ALWAYS, alpha test off
+            constexpr uint64_t kPrim = static_cast<uint64_t>(GS_PRIM_TRISTRIP);
+
+            gs.writeRegister(GS_REG_FRAME_1, kFrame);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
+            gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
+            gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, kTest);
+            gs.writeRegister(GS_REG_PRIM, kPrim);
+
+            auto makeRgbaq = [](uint8_t c) -> uint64_t
+            {
+                return static_cast<uint64_t>(c) |
+                       (static_cast<uint64_t>(c) << 8) |
+                       (static_cast<uint64_t>(c) << 16) |
+                       (0x3F800000ull << 32); // q = 1.0f
+            };
+            auto makeXyz = [](uint16_t x, uint16_t y) -> uint64_t
+            {
+                return (static_cast<uint64_t>(x) * 16ull) |
+                       ((static_cast<uint64_t>(y) * 16ull) << 16);
+            };
+
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x11));
+            gs.writeRegister(GS_REG_XYZ2, makeXyz(4u, 4u));
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x22));
+            gs.writeRegister(GS_REG_XYZ2, makeXyz(4u, 16u));
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x33));
+            gs.writeRegister(GS_REG_XYZ2, makeXyz(20u, 4u));
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x44));
+            gs.writeRegister(GS_REG_XYZ3, makeXyz(20u, 28u)); // ADC: vertex kick only, no drawing kick
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x55));
+            gs.writeRegister(GS_REG_XYZ2, makeXyz(36u, 16u));
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x66));
+            gs.writeRegister(GS_REG_XYZ2, makeXyz(36u, 44u));
+
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 6u, 6u), 0x00333333u,
+                     "the first triangle (V1,V2,V3) should draw regardless of the ADC fix");
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 25u, 12u), 0x00555555u,
+                     "the second triangle should be (V3,V4,V5), formed after the ADC kick advances the queue");
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 10u, 12u), 0x00000000u,
+                     "the stale triangle (V2,V3,V4) must not be drawn");
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 33u, 20u), 0x00666666u,
+                     "the strip should stay in phase: the third triangle is (V4,V5,V6)");
+        });
+
+        tc.Run("GS TRISTRIP PACKED ADC vertex advances the queue window", [](TestCase &t)
+        {
+            std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
+            GS gs;
+            gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
+
+            constexpr uint64_t kFrame =
+                (0ull << 0) |
+                (1ull << 16) |
+                (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
+            constexpr uint64_t kScissor =
+                (0ull << 0) |
+                (63ull << 16) |
+                (0ull << 32) |
+                (63ull << 48);
+            constexpr uint64_t kTest = (1ull << 17); // ZTST = ALWAYS, alpha test off
+            constexpr uint64_t kPrim = static_cast<uint64_t>(GS_PRIM_TRISTRIP);
+
+            gs.writeRegister(GS_REG_FRAME_1, kFrame);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
+            gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
+            gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, kTest);
+            gs.writeRegister(GS_REG_PRIM, kPrim);
+
+            struct PackedVertex
+            {
+                uint16_t x;
+                uint16_t y;
+                uint8_t color;
+                bool adc;
+            };
+            const PackedVertex verts[6] = {
+                {4u, 4u, 0x11u, false},
+                {4u, 16u, 0x22u, false},
+                {20u, 4u, 0x33u, false},
+                {20u, 28u, 0x44u, true}, // ADC: vertex kick only, no drawing kick
+                {36u, 16u, 0x55u, false},
+                {36u, 44u, 0x66u, false},
+            };
+
+            std::vector<uint8_t> packet;
+            appendU64(packet, makeGifTag(6u, GIF_FMT_PACKED, 2u, true));
+            appendU64(packet, 0x01ull | (0x05ull << 4)); // REGS = {0x01 RGBAQ, 0x05 XYZ}
+            for (const PackedVertex &v : verts)
+            {
+                const uint64_t rgbaqLo = static_cast<uint64_t>(v.color) |
+                                         (static_cast<uint64_t>(v.color) << 32);
+                const uint64_t rgbaqHi = static_cast<uint64_t>(v.color);
+                appendU64(packet, rgbaqLo);
+                appendU64(packet, rgbaqHi);
+
+                const uint64_t xyzLo = (static_cast<uint64_t>(v.x) * 16ull) |
+                                       ((static_cast<uint64_t>(v.y) * 16ull) << 32);
+                const uint64_t xyzHi = v.adc ? (1ull << 47) : 0ull; // bit 47 of the high half is the ADC bit
+                appendU64(packet, xyzLo);
+                appendU64(packet, xyzHi);
+            }
+
+            gs.processGIFPacket(packet.data(), static_cast<uint32_t>(packet.size()));
+
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 6u, 6u), 0x00333333u,
+                     "the first triangle (V1,V2,V3) should draw regardless of the ADC fix");
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 25u, 12u), 0x00555555u,
+                     "the second triangle should be (V3,V4,V5), formed after the ADC kick advances the queue");
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 10u, 12u), 0x00000000u,
+                     "the stale triangle (V2,V3,V4) must not be drawn");
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 33u, 20u), 0x00666666u,
+                     "the strip should stay in phase: the third triangle is (V4,V5,V6)");
+        });
+
+        tc.Run("GS LINESTRIP XYZ3 vertex advances the queue window", [](TestCase &t)
+        {
+            std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
+            GS gs;
+            gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
+
+            constexpr uint64_t kFrame =
+                (0ull << 0) |
+                (1ull << 16) |
+                (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
+            constexpr uint64_t kScissor =
+                (0ull << 0) |
+                (63ull << 16) |
+                (0ull << 32) |
+                (63ull << 48);
+            constexpr uint64_t kTest = (1ull << 17); // ZTST = ALWAYS, alpha test off
+            constexpr uint64_t kPrim = static_cast<uint64_t>(GS_PRIM_LINESTRIP);
+
+            gs.writeRegister(GS_REG_FRAME_1, kFrame);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
+            gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
+            gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, kTest);
+            gs.writeRegister(GS_REG_PRIM, kPrim);
+
+            auto makeRgbaq = [](uint8_t c) -> uint64_t
+            {
+                return static_cast<uint64_t>(c) |
+                       (static_cast<uint64_t>(c) << 8) |
+                       (static_cast<uint64_t>(c) << 16) |
+                       (0x3F800000ull << 32); // q = 1.0f
+            };
+            auto makeXyz = [](uint16_t x, uint16_t y) -> uint64_t
+            {
+                return (static_cast<uint64_t>(x) * 16ull) |
+                       ((static_cast<uint64_t>(y) * 16ull) << 16);
+            };
+
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x11));
+            gs.writeRegister(GS_REG_XYZ2, makeXyz(4u, 4u));
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x22));
+            gs.writeRegister(GS_REG_XYZ2, makeXyz(4u, 20u));
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x33));
+            gs.writeRegister(GS_REG_XYZ3, makeXyz(30u, 4u)); // ADC: vertex kick only, no drawing kick
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x44));
+            gs.writeRegister(GS_REG_XYZ2, makeXyz(30u, 40u));
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x55));
+            gs.writeRegister(GS_REG_XYZ2, makeXyz(54u, 40u));
+
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 4u, 10u), 0x00222222u,
+                     "the first segment (V1,V2) should draw regardless of the ADC fix");
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 30u, 30u), 0x00444444u,
+                     "the second segment should be (V3,V4), formed after the ADC kick advances the queue");
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 42u, 40u), 0x00555555u,
+                     "the third segment should be (V4,V5): the advance must leave exactly one vertex in the queue");
+
+            uint32_t litCount = 0u;
+            for (uint32_t y = 6u; y <= 18u; ++y)
+            {
+                for (uint32_t x = 8u; x <= 26u; ++x)
+                {
+                    if (readReferenceFramePSMCT32Pixel(vram, 0u, 1u, x, y) != 0u)
+                        ++litCount;
+                }
+            }
+            t.Equals(litCount, 0u,
+                     "the stale segment (V2,V3) must not be drawn anywhere in the interior of its bounding box");
+        });
+
+        tc.Run("GS TRIFAN XYZF3 vertex advances the queue window and keeps the fan pivot", [](TestCase &t)
+        {
+            std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
+            GS gs;
+            gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
+
+            constexpr uint64_t kFrame =
+                (0ull << 0) |
+                (1ull << 16) |
+                (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
+            constexpr uint64_t kScissor =
+                (0ull << 0) |
+                (63ull << 16) |
+                (0ull << 32) |
+                (63ull << 48);
+            constexpr uint64_t kTest = (1ull << 17); // ZTST = ALWAYS, alpha test off
+            constexpr uint64_t kPrim = static_cast<uint64_t>(GS_PRIM_TRIFAN);
+
+            gs.writeRegister(GS_REG_FRAME_1, kFrame);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
+            gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
+            gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, kTest);
+            gs.writeRegister(GS_REG_PRIM, kPrim);
+
+            auto makeRgbaq = [](uint8_t c) -> uint64_t
+            {
+                return static_cast<uint64_t>(c) |
+                       (static_cast<uint64_t>(c) << 8) |
+                       (static_cast<uint64_t>(c) << 16) |
+                       (0x3F800000ull << 32); // q = 1.0f
+            };
+            auto makeXyzf = [](uint16_t x, uint16_t y) -> uint64_t
+            {
+                return (static_cast<uint64_t>(x) * 16ull) |
+                       ((static_cast<uint64_t>(y) * 16ull) << 16);
+            };
+
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x11));
+            gs.writeRegister(GS_REG_XYZF2, makeXyzf(4u, 4u)); // pivot
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x22));
+            gs.writeRegister(GS_REG_XYZF2, makeXyzf(4u, 30u));
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x33));
+            gs.writeRegister(GS_REG_XYZF2, makeXyzf(14u, 30u));
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x44));
+            gs.writeRegister(GS_REG_XYZF3, makeXyzf(34u, 30u)); // ADC: vertex kick only, no drawing kick
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x55));
+            gs.writeRegister(GS_REG_XYZF2, makeXyzf(44u, 4u));
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x66));
+            gs.writeRegister(GS_REG_XYZF2, makeXyzf(24u, 0u));
+
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 6u, 20u), 0x00333333u,
+                     "the first fan triangle (V1,V2,V3) should draw regardless of the ADC fix");
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 34u, 10u), 0x00555555u,
+                     "the second fan triangle should be (V1,V4,V5): pivot preserved, ADC vertex promoted");
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 22u, 26u), 0x00000000u,
+                     "the stale fan triangle (V1,V3,V4) must not be drawn");
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 24u, 2u), 0x00666666u,
+                     "the third fan triangle should be (V1,V5,V6): the advance must leave exactly two vertices in the queue");
+        });
+
+        tc.Run("GS one-shot primitives consume an XYZ3 vertex without drawing it", [](TestCase &t)
+        {
+            auto makeRgbaq = [](uint8_t c) -> uint64_t
+            {
+                return static_cast<uint64_t>(c) |
+                       (static_cast<uint64_t>(c) << 8) |
+                       (static_cast<uint64_t>(c) << 16) |
+                       (0x3F800000ull << 32); // q = 1.0f
+            };
+            auto makeXyz = [](uint16_t x, uint16_t y) -> uint64_t
+            {
+                return (static_cast<uint64_t>(x) * 16ull) |
+                       ((static_cast<uint64_t>(y) * 16ull) << 16);
+            };
+
+            struct Vertex
+            {
+                uint16_t x;
+                uint16_t y;
+                uint8_t color;
+                bool adc;
+            };
+
+            struct Case
+            {
+                const char *name;
+                GSPrimType prim;
+                std::vector<Vertex> verts;
+                uint16_t lightX;
+                uint16_t lightY;
+                uint32_t lightExpected;
+                uint16_t darkX;
+                uint16_t darkY;
+                uint32_t darkExpected;
+            };
+
+            const std::vector<Case> cases = {
+                {"POINT", GS_PRIM_POINT,
+                 {{8u, 8u, 0x11u, true}, {40u, 8u, 0x22u, false}},
+                 40u, 8u, 0x00222222u,
+                 8u, 8u, 0x00000000u},
+                {"LINE", GS_PRIM_LINE,
+                 {{4u, 4u, 0x11u, false}, {4u, 20u, 0x22u, true},
+                  {40u, 4u, 0x33u, false}, {40u, 20u, 0x44u, false}},
+                 40u, 12u, 0x00444444u,
+                 4u, 12u, 0x00000000u},
+                {"TRIANGLE", GS_PRIM_TRIANGLE,
+                 {{4u, 4u, 0x11u, false}, {4u, 20u, 0x22u, false}, {20u, 4u, 0x33u, true},
+                  {36u, 4u, 0x44u, false}, {36u, 20u, 0x55u, false}, {52u, 4u, 0x66u, false}},
+                 40u, 8u, 0x00666666u,
+                 8u, 8u, 0x00000000u},
+                {"SPRITE", GS_PRIM_SPRITE,
+                 {{4u, 4u, 0x11u, false}, {20u, 20u, 0x22u, true},
+                  {36u, 4u, 0x33u, false}, {52u, 20u, 0x44u, false}},
+                 40u, 10u, 0x00444444u,
+                 8u, 10u, 0x00000000u},
+            };
+
+            for (const Case &c : cases)
+            {
+                std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
+                GS gs;
+                gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
+
+                constexpr uint64_t kFrame =
+                    (0ull << 0) |
+                    (1ull << 16) |
+                    (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+                constexpr uint64_t kZbuf = (1ull << 32);
+                constexpr uint64_t kScissor =
+                    (0ull << 0) |
+                    (63ull << 16) |
+                    (0ull << 32) |
+                    (63ull << 48);
+                constexpr uint64_t kTest = (1ull << 17); // ZTST = ALWAYS, alpha test off
+
+                gs.writeRegister(GS_REG_FRAME_1, kFrame);
+                gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
+                gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
+                gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
+                gs.writeRegister(GS_REG_TEST_1, kTest);
+                gs.writeRegister(GS_REG_PRIM, static_cast<uint64_t>(c.prim));
+
+                for (const Vertex &v : c.verts)
+                {
+                    gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(v.color));
+                    gs.writeRegister(v.adc ? GS_REG_XYZ3 : GS_REG_XYZ2, makeXyz(v.x, v.y));
+                }
+
+                const std::string lightMsg = std::string("GS ") + c.name +
+                                              ": the vertex kicked after the ADC vertex should complete a new primitive";
+                const std::string darkMsg = std::string("GS ") + c.name +
+                                             ": the primitive whose last vertex was ADC must not be drawn";
+
+                t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, c.lightX, c.lightY),
+                         c.lightExpected, lightMsg);
+                t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, c.darkX, c.darkY),
+                         c.darkExpected, darkMsg);
+            }
+        });
+
+        tc.Run("GS TRISTRIP leading XYZ3 vertices do not shift a partial queue", [](TestCase &t)
+        {
+            std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
+            GS gs;
+            gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
+
+            constexpr uint64_t kFrame =
+                (0ull << 0) |
+                (1ull << 16) |
+                (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
+            constexpr uint64_t kScissor =
+                (0ull << 0) |
+                (63ull << 16) |
+                (0ull << 32) |
+                (63ull << 48);
+            constexpr uint64_t kTest = (1ull << 17); // ZTST = ALWAYS, alpha test off
+            constexpr uint64_t kPrim = static_cast<uint64_t>(GS_PRIM_TRISTRIP);
+
+            gs.writeRegister(GS_REG_FRAME_1, kFrame);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
+            gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
+            gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, kTest);
+            gs.writeRegister(GS_REG_PRIM, kPrim);
+
+            auto makeRgbaq = [](uint8_t c) -> uint64_t
+            {
+                return static_cast<uint64_t>(c) |
+                       (static_cast<uint64_t>(c) << 8) |
+                       (static_cast<uint64_t>(c) << 16) |
+                       (0x3F800000ull << 32); // q = 1.0f
+            };
+            auto makeXyz = [](uint16_t x, uint16_t y) -> uint64_t
+            {
+                return (static_cast<uint64_t>(x) * 16ull) |
+                       ((static_cast<uint64_t>(y) * 16ull) << 16);
+            };
+
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x11));
+            gs.writeRegister(GS_REG_XYZ3, makeXyz(4u, 4u));  // ADC: queue still partial, must not shift
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x22));
+            gs.writeRegister(GS_REG_XYZ3, makeXyz(4u, 16u)); // ADC: queue still partial, must not shift
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x33));
+            gs.writeRegister(GS_REG_XYZ2, makeXyz(20u, 4u));
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x44));
+            gs.writeRegister(GS_REG_XYZ2, makeXyz(20u, 28u));
+
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 8u, 8u), 0x00333333u,
+                     "the first triangle (V1,V2,V3) should draw once the queue fills");
+            t.Equals(readReferenceFramePSMCT32Pixel(vram, 0u, 1u, 12u, 18u), 0x00444444u,
+                     "the second triangle should be (V2,V3,V4), not shifted by the two leading ADC kicks");
+        });
+
+        tc.Run("GS ADC vertex kick records no draw debug event", [](TestCase &t)
+        {
+            std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
+            GS gs;
+            gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
+
+            constexpr uint64_t kFrame =
+                (0ull << 0) |
+                (1ull << 16) |
+                (static_cast<uint64_t>(GS_PSM_CT32) << 24);
+            constexpr uint64_t kZbuf = (1ull << 32);
+            constexpr uint64_t kScissor =
+                (0ull << 0) |
+                (63ull << 16) |
+                (0ull << 32) |
+                (63ull << 48);
+            constexpr uint64_t kTest = (1ull << 17); // ZTST = ALWAYS, alpha test off
+            constexpr uint64_t kPrim = static_cast<uint64_t>(GS_PRIM_POINT);
+
+            gs.writeRegister(GS_REG_FRAME_1, kFrame);
+            gs.writeRegister(GS_REG_ZBUF_1, kZbuf);
+            gs.writeRegister(GS_REG_SCISSOR_1, kScissor);
+            gs.writeRegister(GS_REG_XYOFFSET_1, 0ull);
+            gs.writeRegister(GS_REG_TEST_1, kTest);
+            gs.writeRegister(GS_REG_PRIM, kPrim);
+
+            auto makeRgbaq = [](uint8_t c) -> uint64_t
+            {
+                return static_cast<uint64_t>(c) |
+                       (static_cast<uint64_t>(c) << 8) |
+                       (static_cast<uint64_t>(c) << 16) |
+                       (0x3F800000ull << 32); // q = 1.0f
+            };
+            auto makeXyz = [](uint16_t x, uint16_t y) -> uint64_t
+            {
+                return (static_cast<uint64_t>(x) * 16ull) |
+                       ((static_cast<uint64_t>(y) * 16ull) << 16);
+            };
+
+            auto drawEventCount = [](const GS &g) -> uint32_t
+            {
+                uint32_t n = 0u;
+                for (const GSDebugHistoryEntry &entry : g.getDebugHistory())
+                {
+                    if (entry.kind == GSDebugEventKind::Draw)
+                        ++n;
+                }
+                return n;
+            };
+
+            // Draw history is paused by default; un-pause it so draw events are recorded.
+            gs.setDebugHistoryPaused(false);
+            gs.clearDebugHistory();
+
+            // A POINT needs one vertex, so this ADC kick reaches the draw dispatch
+            // with a full queue and is suppressed there rather than earlier.
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x11));
+            gs.writeRegister(GS_REG_XYZ3, makeXyz(8u, 8u));
+            t.Equals(drawEventCount(gs), 0u,
+                     "an ADC vertex kick must not record a draw debug event");
+
+            gs.writeRegister(GS_REG_RGBAQ, makeRgbaq(0x22));
+            gs.writeRegister(GS_REG_XYZ2, makeXyz(40u, 8u));
+            t.Equals(drawEventCount(gs), 1u,
+                     "a drawing vertex kick does record a draw debug event");
+        });
+
         tc.Run("sceGsExecLoadImage and sceGsExecStoreImage roundtrip and free guest packets", [](TestCase &t)
         {
             PS2Runtime runtime;


### PR DESCRIPTION
# fix(gs): advance the vertex queue on non-drawing (ADC) vertex kicks

## Problem

`GS::vertexKick` returns early on a non-drawing kick (`XYZ3`/`XYZF3`, or the
ADC bit of a PACKED vertex), ahead of the queue-fill gate and the per-primitive
queue advance. The caller has already written the vertex into
`m_vtxQueue[m_vtxCount % kMaxVerts]`, so the next vertex lands in a slot the
rasterizer does not read.

For a `TRISTRIP` fed drawing `V1,V2,V3`, non-drawing `V4`, then drawing
`V5,V6`, the current code draws `(V1,V2,V3)`, `(V2,V3,V4)`, `(V3,V4,V6)`. `V5`
reaches no primitive.

## Fix

In `ps2xRuntime/src/lib/ps2_gs_gpu.cpp`: delete the early return and wrap only
the draw dispatch (`m_rasterizer.drawPrimitive` plus the debug-event record) in
`if (drawing)`. The counter increments, the `needed` switch, the queue-fill
gate (`if (m_vtxCount < needed) return;`) and the per-primitive advance switch
stay unconditional, exactly as they already ran for drawing kicks.

Only the draw dispatch is gated: the registers documented as "without Drawing
Kick" still move the queue forward. The advance depends on the primitive type,
not on whether a draw happened, so the per-type advance switch is reused
unchanged.

## Hardware basis

- `XYZ3 : Setting for Vertex Coordinate Values (without Drawing Kick)` — "This
  register sets the coordinate values of the vertex and moves the vertex queue
  a step forward." / "Drawing is not started."
- `XYZF3 : Setting for Vertex Coordinate Values (without Drawing Kick)` — the
  same, plus the Fog coefficient. Neither page is qualified by primitive type.
- Drawing Control — "Because of this, the Drawing Kick is not performed at the
  Vertex Kick, and only the vertex queue is advanced."
- That section's worked TriangleStrip register-setting-order figure
  (`EVIDENCE.md` §1): the fixed rule reproduces it write for write, the current
  rule does not.

## Testing

Tests are added to the `PS2GS` suite in `ps2xTest/src/ps2_gs_tests.cpp`; their
names, and why the framebuffer probes pin which vertices formed each primitive,
are in `EVIDENCE.md` §2 and Axis A.

- The manual figure's own sequence on `TRISTRIP`, via `XYZ2`/`XYZ3` and again
  via a PACKED GIFtag with the ADC bit set.
- `LINESTRIP` and `TRIFAN` (the latter via `XYZF2`/`XYZF3`): the per-type
  advance, the surviving fan pivot, a scan of the interior of the stale
  segment's bounding box, and a further primitive pinning the reset count.
- `POINT`, `LINE`, `TRIANGLE` and `SPRITE`, table driven, light and dark probe
  each.
- Leading `XYZ3` kicks must not shift a partial queue; passing before and after,
  this guards a wrong fix that advances even on a partial queue.
- A non-drawing kick records no draw debug event: `getDebugHistory()` is public
  API, so the record gated alongside the draw call is pinned too.

```
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-msse4.1 -DCMAKE_CXX_FLAGS=-msse4.1
cmake --build build -j 12
./build/ps2xTest/ps2x_tests
```

## Risk and not in scope

- **One-shot draw counts change.** A `TRIANGLE` fed draw, draw, `XYZ3`, draw,
  draw drew one triangle before and draws none now: the ADC kick passes the
  queue-fill gate and resets the count. The one-shot test's `TRIANGLE` row uses
  six vertices and framebuffer probes — a dark probe for the ADC-terminated
  triangle, a light probe for the fresh triangle formed after it.
- **The worked figure covers fewer primitive types than the register pages.**
  Its section is scoped to "When drawing a GS primitive consisting of two or
  more polygons, such as TriangleStrip", so it reaches `TRISTRIP` and
  `TRIFAN`; the primitive-agnostic register pages reach the rest
  (`EVIDENCE.md` §4).
- **Partial queues and the PACKED ADC bit are inferred.** The figure shows only
  the already-full case; the queue-fill gate stays ahead of the advance. The
  manual never names an ADC bit; both ADC call sites compute a `drawing` boolean
  and call the same function.
- **PACKED descriptors `0x0C`, `0x0D` and `0x04` have no dedicated test.** Their
  call sites are unmodified and pass a literal or an identically-computed
  boolean into the same body; `EVIDENCE.md` Axis D argues them.
- **Conflict.** Two open upstream changes touch `GS::vertexKick`: one renames
  the primitive-type switch selector in a register-representation rewrite, the
  other inserts an observability/diagnostics block between the queue-fill
  gate and the draw call. Neither touches the early return; expect a rebase.
- Unchanged: register semantics, every call site, the duplicated per-vertex
  attribute-copy block, and `kMaxVerts`. No runtime toggle or environment gate
  is added, and none exists upstream for this behaviour.

<details>
<summary>Evidence — mutation tables, mirror sweep, and reproduction commands</summary>

# Evidence — GS: advance the vertex queue on non-drawing (ADC) kicks

## 1. Pre-flight

| question | finding |
|---|---|
| Defect present on `main`? | Yes, read from the live tree. `GS::vertexKick(bool drawing)` opened with `++m_vtxCount; ++m_vtxIndex;`, a debug-log probe block, then `if (!drawing) return;` — ahead of the `needed` switch, the `if (m_vtxCount < needed) return;` queue-fill gate, `m_rasterizer.drawPrimitive(this)`, and the per-primitive queue-advance switch at the end of the function. |
| Which sites reach it? | `writeRegister`, in the combined `XYZF2`/`XYZF3` and combined `XYZ2`/`XYZ3` cases; `writeRegisterPacked`, in PACKED descriptors `0x04`, `0x05`, `0x0C` and `0x0D`. Each writes `m_vtxQueue[m_vtxCount % kMaxVerts]` before calling `vertexKick`, which is called from nowhere else. |
| Already addressed in flight? | No. A sweep of the project's open and closed pull requests, plus a targeted search of merged ones, for `vertexKick`, `m_vtxCount` and `m_vtxQueue` found two live PRs touching this function: a register-representation rewrite that renames the primitive-type switch selector inside `vertexKick`'s two switches and leaves `if (!drawing) return;` byte-identical, and one that inserts an observability/diagnostics block between the queue-fill gate and the draw call. Neither repairs the defect, and the `main` read above already includes all merged work. |
| Supported by the manual? | Yes. Every page cited here was rendered to an image and read as an image; `pdftotext` is unreliable for this document. The PR body cites the `XYZ3` and `XYZF3` register pages and the Drawing Control paragraph. That section also carries the worked TriangleStrip register-setting-order figure below. |

The figure is a complete oracle for a TriangleStrip whose non-drawing vertex
arrives on an already-full queue, and says nothing about a partial one:

| write | annotation |
|---|---|
| `XYZ2` (Vertex1) | Vertex Kick |
| `XYZ2` (Vertex2) | Vertex Kick |
| `XYZ2` (Vertex3) | Vertex Kick & Drawing Kick (Vertex1 & Vertex2 & Vertex3) |
| `XYZ3` (Vertex4) | Vertex Kick (No Drawing Kick) |
| `XYZ2` (Vertex5) | Vertex Kick & Drawing Kick (Vertex3 & Vertex4 & Vertex5) |
| `XYZ2` (Vertex6) | Vertex Kick & Drawing Kick (Vertex4 & Vertex5 & Vertex6) |

The fixed rule reproduces this sequence exactly. The unfixed rule draws the
window in place *before* the ADC kick plus the ADC vertex itself, and the vertex
kicked immediately after the ADC vertex lands in a queue slot advanced past what
any rasterizer path reads.

## 2. Tests and mutations

| # | test |
|---|---|
| T1 | `GS TRISTRIP XYZ3 vertex advances the queue window` |
| T2 | `GS TRISTRIP PACKED ADC vertex advances the queue window` |
| T3 | `GS LINESTRIP XYZ3 vertex advances the queue window` |
| T4 | `GS TRIFAN XYZF3 vertex advances the queue window and keeps the fan pivot` |
| T5 | `GS one-shot primitives consume an XYZ3 vertex without drawing it` |
| T6 | `GS TRISTRIP leading XYZ3 vertices do not shift a partial queue` |
| T7 | `GS ADC vertex kick records no draw debug event` |

Each mutation was applied to the *fixed* tree, one at a time, inside
`GS::vertexKick` — except M2, which edits a call site — then restored and
rebuilt by the procedure in §5.

| # | Mutation | Predicted failing test(s) | Observed firing set |
|---|---|---|---|
| M1 | `if (!drawing && m_prim.type == GS_PRIM_TRISTRIP) return;` at the top of the `needed` block | T1 (T2 also fails; nothing else) | **Confirmed exactly.** T1 and T2 fail; every other test passes. |
| M2 | In the PACKED `XYZ` descriptor (`0x05`), `vertexKick(!adk)` → `vertexKick(true)` | T2 only, and only its "must stay dark" probe | **Confirmed exactly.** Only T2 fails, and only on its (10,12) "the stale triangle (V2,V3,V4) must not be drawn" assertion; its three "must light" probes stay correct. This is the concrete demonstration that a test set asserting only "the right thing appeared" would have let this escape. |
| M3 | `if (!drawing && m_prim.type == GS_PRIM_LINESTRIP) return;` | T3 | **Confirmed exactly.** Only T3 fails. |
| M4 | `if (!drawing && m_prim.type == GS_PRIM_TRIFAN) return;` | T4 | **Confirmed exactly.** Only T4 fails. |
| M5 | `if (!drawing && m_prim.type == GS_PRIM_<X>) return;` for each of `POINT`, `LINE`, `TRIANGLE`, `SPRITE` | T5, with the matching row's sub-case named in the failure | **Confirmed exactly, for all four types.** Each of the four one-line mutations was applied and run separately; each time, only T5 fails, and only the matching primitive's two assertions (light and dark) are named in the failure output. No other test is affected by any of the four. |
| M6 | `if (m_vtxCount < needed)` → `if (drawing && m_vtxCount < needed)` | T6 only | **Confirmed exactly.** Only T6 fails ("the first triangle (V1,V2,V3) should draw once the queue fills"); every other test, including T1–T5, still passes. |
| M7 | Delete `if (m_vtxCount < needed) return;` entirely | T2, T3, T5, T6 fail; T1 alone does not catch it | **Prediction not met in full; recorded as observed.** T1 does not fail, as predicted. T3 and T6 fail, as predicted. T4 does not fail, and was not predicted to. T5 fails, but only on its `LINE`, `TRIANGLE` and `SPRITE` sub-cases — the `POINT` sub-case (`needed = 1`) is unaffected, because removing a gate that only ever matters when `m_vtxCount < needed` has no effect for a primitive whose `needed` is 1 and whose count is always ≥ 1 after the pre-increment. T7 is unaffected for the same `needed = 1` reason. **T2 was predicted to fail and does not**: both its register-path sibling T1 and its PACKED-path self pass. This mutation is a much larger behavioural change than reverting the shipped fix would be — it also changes when drawing kicks fire on an *under-filled* queue, not only the ADC path — and it fails a number of unrelated pre-existing tests elsewhere in the suite, which is expected for a mutation this broad. The unmet T2 prediction does not change what the row shows: T1 alone is an insufficient regression guard for this mutation. |

Reverting this change outright — restoring `if (!drawing) return;` — fails T1,
T2, T3, T4 and T5; nothing else in the suite fails. T6 passes, because it guards
a plausible wrong fix rather than this defect. T7 passes, because the restored
early return sits above the draw dispatch, so no draw debug event is recorded
under either rule.

## 3. Mirror sweep

**Axis A — kick kind.** The fixture's `PRIM` write leaves `iip = 0` (flat
shading), so a lit pixel's colour names the vertex that held the newest queue
slot at draw time. A framebuffer probe therefore pins which vertices formed the
primitive.

| property | asserted by |
|---|---|
| drawing kicks draw | every test's control or "must light" probe |
| non-drawing kicks do not draw | T1 at (10,12); T2 at (10,12); T3's bounding-box interior scan; T4 at (22,26); every row of T5 |
| no framebuffer dark probe | T6, for the reason in Axis F; T7, whose probe is a draw-event count, for the reason in Axis G |

**Axis B — primitive class.**

| type | status |
|---|---|
| `TRISTRIP` | T1, T2, T6 |
| `LINESTRIP` | T3 |
| `TRIFAN` | T4 |
| `POINT`, `LINE`, `TRIANGLE`, `SPRITE` | T5, all four rows, both directions each; `POINT` again by T7, whose probe is a draw-event count rather than a framebuffer read |
| `m_prim.type == 7` (reachable, since the field is masked with `& 0x7`) | Closed by proof rather than by test. Both before and after this change, control reaches `default: return;` in the `needed` switch; the only statements between the old return point and the new one are the `needed` switch's own assignments, which are dead on the `default` arm, so no state differs between the two return points for this case. |

**Axis C — queue fill at the moment of a non-drawing kick.**

| state | asserted by |
|---|---|
| `m_vtxCount >= needed` (queue full, must advance) | T1–T5 |
| `m_vtxCount < needed` (queue partial, must not advance) | T6; M6 is the direct demonstration that T6 catches a violation of this |

**Axis D — entry path into `vertexKick`.**

| path | status |
|---|---|
| `writeRegister` `XYZ2`/`XYZ3` | T1, T3, T5, T6, T7 |
| `writeRegister` `XYZF2`/`XYZF3` | T4 |
| `writeRegisterPacked` `0x05` (`XYZ`, ADC bit) | T2, both ADC=0 and ADC=1 vertices |
| `writeRegisterPacked` `0x04` (`XYZF`, ADC bit) | Closed by proof for this change rather than by test. Case `0x04` differs from `0x05` only in how it extracts `z` and `fog`; both end by computing `adk` identically and calling `vertexKick(!adk)`, and this change touches neither line. `vertexKick` receives a single `bool` and cannot observe which descriptor called it, so the `0x05` cell exercises the changed code identically to what `0x04` would. |
| `writeRegisterPacked` `0x0C`/`0x0D` (always non-drawing) | Closed by proof: both call `vertexKick(false)` as an unmodified literal, reaching the same body already covered by the `drawing == false` cells of T1–T5. |

**Axis E — per-type advance, one half at a time.** The advance has two halves
per primitive type: which queue slots move, and what the vertex count resets to.
A probe that pins one may leave the other free — an ADC vertex kicked
immediately after a drawing kick sits where the two rules coincide, so a test
shaped that way pins the shift and leaves the count free. Each cell below is
asserted by a named test, with the mutation that makes it fail, or closed by
proof.

| primitive | half | status |
|---|---|---|
| `POINT` | slot shift | Closed by proof: the one-shot arm contains no queue assignment at all, so there is no slot movement to pin. With the count reset to zero, the caller's next `m_vtxQueue[m_vtxCount % kMaxVerts]` write lands in `q[0]`, the slot a fresh primitive is built from. |
| `POINT` | `count -> 0` | Asserted by T5's `POINT` row, both directions; mutation E1. |
| `LINE` | slot shift | Closed by proof: same arm, same argument as `POINT`. |
| `LINE` | `count -> 0` | Asserted by T5's `LINE` row; mutation E1. |
| `TRIANGLE` | slot shift | Closed by proof: same arm, same argument as `POINT`. |
| `TRIANGLE` | `count -> 0` | Asserted by T5's `TRIANGLE` row; mutation E1. |
| `SPRITE` | slot shift | Closed by proof: same arm, same argument as `POINT`. |
| `SPRITE` | `count -> 0` | Asserted by T5's `SPRITE` row; mutation E1. |
| `LINESTRIP` | `q[0] <- q[1]` | Asserted by T3's second-segment probe; mutation E2. |
| `LINESTRIP` | `count -> 1` | Asserted by T3's third-segment probe — one kick past the second-segment probe that pins the shift; mutation E3. |
| `TRISTRIP` | `q[0] <- q[1]` | Asserted by T1, T2 and T6; mutation E4. |
| `TRISTRIP` | `q[1] <- q[2]` | Asserted by T1, T2 and T6; mutation E5. |
| `TRISTRIP` | `count -> 2` | Asserted by T1, T2 and T6; mutation E6. |
| `TRIFAN` | `q[1] <- q[2]`, pivot `q[0]` untouched | Asserted by T4's second-triangle probe, reachable only if the pivot survived and the newest slot advanced; mutation E7. |
| `TRIFAN` | `count -> 2` | Asserted by T4's third-triangle probe — one kick past the second-triangle probe that pins the shift; mutation E8. |
| `m_prim.type == 7` | both halves | Closed by proof, and unreachable in the strict sense: the `needed` switch returns on its `default` arm before the advance switch is reached, so the advance switch's own `default` arm is dead for every input. |

| # | Mutation | Observed firing set |
|---|---|---|
| E1 | one-shot arm, `m_vtxCount = 0;` -> `m_vtxCount = 1;` | T5, naming its `POINT` light and dark assertions, its `LINE` light assertion, its `TRIANGLE` light assertion and its `SPRITE` dark assertion — at least one direction for each of `POINT`, `LINE`, `TRIANGLE` and `SPRITE`. The unrelated pre-existing `GS TEXA expands CT24 alpha and honors AEM for black texels` also fails, since this mutation changes drawing for every one-shot primitive in the suite. |
| E2 | `LINESTRIP` arm, delete `m_vtxQueue[0] = m_vtxQueue[1];` | T3 alone. |
| E3 | `LINESTRIP` arm, `m_vtxCount = 1;` -> `m_vtxCount = 0;` | T3 alone, on its third-segment probe. That probe is why the row is here: without it this mutation fires nothing anywhere in the suite, because T3's ADC vertex sits immediately after a drawing kick, where the correct and mutated rules emit identical geometry. |
| E4 | `TRISTRIP` arm, delete `m_vtxQueue[0] = m_vtxQueue[1];` | T1, T2, T6. |
| E5 | `TRISTRIP` arm, delete `m_vtxQueue[1] = m_vtxQueue[2];` | T1, T2, T6. |
| E6 | `TRISTRIP` arm, `m_vtxCount = 2;` -> `m_vtxCount = 1;` | T1, T2, T6. |
| E7 | `TRIFAN` arm, delete `m_vtxQueue[1] = m_vtxQueue[2];` | T4, plus the unrelated pre-existing `GS triangle fan subpixel quad fills rows without interior holes`. |
| E8 | `TRIFAN` arm, `m_vtxCount = 2;` -> `m_vtxCount = 1;` | T4, on its third-triangle probe, plus that same unrelated fan test. Without the third-triangle probe T4 does not fire and only the unrelated test does. |

**Axis F — assertion direction.**

| test | directions asserted | why |
|---|---|---|
| T1–T5 | both | M2 is the empirical justification for keeping both: only the "did not appear" half of T2 flips under it. |
| T6 | positive only | Under M6 the wrong thing does not appear either, so the failure mode is a disappearance and the test is shaped to catch a disappearance. |
| T7 | both | On a draw-event count rather than a framebuffer read. |

**Axis G — the statements the `if (drawing)` block gates.** The block gates
`m_rasterizer.drawPrimitive(this)` and `recordDrawDebugEventUnlocked(needed)`;
each half needs its own probe. Making the draw call unconditional fires the
"must stay dark" framebuffer probes of T1, T2, T3, T4 and every row of T5, which
is also what shows those probes are live. Moving
`recordDrawDebugEventUnlocked(needed)` below the block, so every non-drawing
kick records a spurious draw event, writes only to the debug history, which
`getDebugHistory()` exposes as public API and which defaults to paused. Every
framebuffer probe in the suite is blind to it; T7 is the probe for that half.

| # | Mutation | Observed firing set |
|---|---|---|
| G1 | move `recordDrawDebugEventUnlocked(needed);` out of the `if (drawing)` block, below it | T7 alone, on both of its assertions. Nothing else in the suite moves; without T7 this mutation fires nothing at all. |

## 4. What stays open

- **Primitive counts differ between the two rules** — for a one-shot primitive
  the draw count changes: a `TRIANGLE` fed draw, draw, `XYZ3`, draw, draw
  produces one draw under the unfixed rule and none under the fixed one. The
  drawing kicks after the ADC vertex land in a reset, freshly counting queue and
  never reach three vertices again, so vertex and primitive counters do
  distinguish the two rules.
- **Worked figure, primitive-type scope** — its section is scoped to "When
  drawing a GS primitive consisting of two or more polygons, such as
  TriangleStrip", and says of the figure "In this example, only the 2nd triangle
  is not drawn". The figure therefore reaches `TRISTRIP` and `TRIFAN`.
- **What reaches the remaining primitive types** — the manual keeps Polygon and
  Line as separate categories ("A LineStrip is a series of continuous lines that
  share endpoints"; "The GS draws primitives, such as Polygon or Line, to the
  frame buffer"). `LINESTRIP`, `POINT`, `LINE`, `TRIANGLE` and `SPRITE` rest on
  the register pages, which are not qualified by primitive type.
- **How far "a step forward" goes for each primitive type is inferred** — it is
  this runtime's own existing per-type advance rule, reused unchanged from the
  drawing-kick path. The figure above is the manual's only worked example of the
  resulting window.
- **Whether this is the only vertex-queue defect in the file** — not established
  either way by this work.
- **The PACKED `XYZF` path is argued, not tested** — Axis D closes `0x04` by
  proof from the call sites, and no dedicated test exercises it.
- **The manual does not document the PACKED ADC bit** — it describes the `XYZ3`
  and `XYZF3` registers and the Drawing Control section, and names no ADC bit.
  Treating the PACKED ADC bit as the same non-drawing kick rests on the call
  sites, which compute the same `drawing` boolean and call the same function.
- **No capture, replay, or title-specific evidence is part of this change** —
  fixing rendering in a shipped title is not claimed.

## 5. Commands

Configure, build, run:

```
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-msse4.1 -DCMAKE_CXX_FLAGS=-msse4.1
cmake --build build -j 12
./build/ps2xTest/ps2x_tests
```

Duplicate-name check against the full `PS2GS` suite. The harness registers cases
through `std::map::operator[]`, so a repeated name silently replaces the earlier
case instead of reporting a collision. This prints one line per name that occurs
more than once, and prints nothing when every name is distinct:

```
grep -o 'tc\.Run("[^"]*"' ps2xTest/src/ps2_gs_tests.cpp | sort | uniq -d
```

Verified: prints nothing on this tree, and prints the offending name when a name
is duplicated on purpose.

For each mutation row above: apply the stated one-line edit to
`ps2xRuntime/src/lib/ps2_gs_gpu.cpp`, run `cmake --build build -j 12`, rerun
`./build/ps2xTest/ps2x_tests`, then restore with

```
git checkout ps2xRuntime/src/lib/ps2_gs_gpu.cpp
touch ps2xRuntime/src/lib/ps2_gs_gpu.cpp
```

before rebuilding. A `cp`-style restore that does not update the source file's
mtime leaves ninja believing the tree is unchanged, silently keeping the
previous mutation live in the built archive. That reads as a false "nothing
failed" for the *next* mutation rather than the one actually applied. Checking
that ninja names `ps2xRuntime/src/lib/ps2_gs_gpu.cpp`'s object file in its output
on every build — mutation, restore, and the final rebuild alike — guards against
this.

</details>
