### PR TITLE
Resolve sibling component paths relative to the current directory

### DIFF
--- a/ps2xAnalyzer/CMakeLists.txt
+++ b/ps2xAnalyzer/CMakeLists.txt
@@ -27,8 +27,8 @@ add_library(ps2_analyzer_lib STATIC ${PS2ANALYZER_LIB_SOURCES})
 
 target_include_directories(ps2_analyzer_lib PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/ps2xRecomp/include
-    ${CMAKE_SOURCE_DIR}/ps2xRuntime/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../ps2xRecomp/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../ps2xRuntime/include
 )
 
 target_link_libraries(ps2_analyzer_lib PUBLIC
@@ -50,7 +50,7 @@ install(TARGETS ps2_analyzer ps2_analyzer_lib
     ARCHIVE DESTINATION lib
 )
 
-include("${CMAKE_SOURCE_DIR}/ps2xRuntime/cmake/ReleaseMode.cmake")
+include("${CMAKE_CURRENT_SOURCE_DIR}/../ps2xRuntime/cmake/ReleaseMode.cmake")
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     EnableFastReleaseMode(ps2_analyzer_lib)

--- a/ps2xRecomp/CMakeLists.txt
+++ b/ps2xRecomp/CMakeLists.txt
@@ -130,7 +130,7 @@ install(DIRECTORY include/
     DESTINATION include
 )
 
-include("${CMAKE_SOURCE_DIR}/ps2xRuntime/cmake/ReleaseMode.cmake")
+include("${CMAKE_CURRENT_SOURCE_DIR}/../ps2xRuntime/cmake/ReleaseMode.cmake")
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     EnableFastReleaseMode(ps2_recomp_lib)


### PR DESCRIPTION
ps2xRecomp and ps2xAnalyzer reach ps2xRuntime through `CMAKE_SOURCE_DIR`, which is the top-level source directory of whatever build is running. That holds only when this repository is itself the top level.

Adding the project to another one with `add_subdirectory()` makes both components look for `ps2xRuntime/cmake/ReleaseMode.cmake` under the consuming project, and configure fails:

```
CMake Error at ps2xRecomp/CMakeLists.txt:133 (include):
CMake Error at ps2xAnalyzer/CMakeLists.txt:53 (include):
```

This switches them to `CMAKE_CURRENT_SOURCE_DIR`-relative paths, matching what ps2xRecomp already does for its ps2xRuntime include directory (line 101) and what ps2xRuntime does for its own cmake include.

Note that `PROJECT_SOURCE_DIR` is not an alternative here: each component calls `project()` itself, so it resolves to the component directory rather than the repository root.

Verified by embedding the project as a submodule and configuring with `-DPS2X_BUILD_RUNTIME=OFF -DPS2X_BUILD_STUDIO=OFF -DPS2X_BUILD_TEST=OFF`, which previously failed at configure time and now succeeds. Standalone builds are unaffected.