### PR TITLE
Warn instead of aborting when no function covers the ELF entry point

### DIFF
--- a/ps2xRecomp/src/lib/function_table_emitter.cpp
+++ b/ps2xRecomp/src/lib/function_table_emitter.cpp
@@ -95,9 +95,25 @@ namespace ps2recomp
             }
             if (entryTarget.empty())
             {
-                throw std::runtime_error("No entry function name available for registration.");
+                // Not every toolchain points e_entry at code. Metrowerks CodeWarrior
+                // for PS2 emits a crt0 data table there, so no function covers the
+                // address and no name resolves. Registering a synthesized name would
+                // reference a definition that was never emitted, so skip the entry
+                // instead - the real start address comes from configuration - and
+                // keep emitting the rest of the table rather than aborting after the
+                // per-function sources were already written.
+                if (cg.m_reporter)
+                {
+                    std::ostringstream oss;
+                    oss << "No function covers the ELF entry point; skipping its table registration. "
+                        << "Set the entry explicitly if the runtime should start here.";
+                    cg.m_reporter->warning("function-table", oss.str());
+                }
             }
-            addEntry(cg.m_bootstrapInfo.entry, entryTarget);
+            else
+            {
+                addEntry(cg.m_bootstrapInfo.entry, entryTarget);
+            }
         }
 
         for (const auto &[address, name] : normalFunctions)


### PR DESCRIPTION
Not every toolchain points `e_entry` at an instruction. Metrowerks CodeWarrior for PS2 emits a crt0 data table there — scratchpad addresses and size words — with the first real instruction some way past it. No function covers the entry address, so neither `entryName` nor `getFunctionName()` resolves and `FunctionTableEmitter::emit` throws:

```
No entry function name available for registration.
```

That happens after every per-function source has already been written, but before `register_functions.cpp`, `ps2_recompiled_functions.h` and `ps2_recompiled_stubs.h` are generated — leaving an output directory that looks complete and is not.

This skips the entry registration with a warning instead of aborting.

I considered synthesizing a name (`entry_%08X`) but that emits a function-table reference to a definition that was never generated, which then fails at link time. For a binary shaped like this the start address has to come from configuration regardless, so recording the situation and continuing seemed the more useful behaviour.

Concretely, on Dragon Quest VIII (NTSC-U) the header entry is `0x00100008`, which is 33 words of crt0 data; the first instruction is at `0x0010008C`. The run now completes and reports:

```
[warning] function-table - No function covers the ELF entry point; skipping its
table registration. Set the entry explicitly if the runtime should start here.
```