### PR TITLE
Don't promote a whole function because of an indirect call

### DIFF
--- a/ps2xRecomp/src/lib/control_flow_analyzer.cpp
+++ b/ps2xRecomp/src/lib/control_flow_analyzer.cpp
@@ -385,7 +385,14 @@ namespace ps2recomp
                         }
                     }
                 }
-                if (!foundTable)
+                // Only an unresolved computed *jump* can land on an arbitrary
+                // instruction of this function and therefore force every address to
+                // become an entry point. JALR is a call: it transfers control to
+                // another function and comes back to the instruction after the delay
+                // slot, which is already queued as a resume target above. Treating a
+                // call like a jump here promotes the whole function for what is
+                // usually just a function pointer or virtual dispatch.
+                if (!foundTable && jrInst->function != SPECIAL_JALR)
                 {
                     needsIndirectFallback = true;
                 }

--- a/ps2xTest/src/code_generator_tests.cpp
+++ b/ps2xTest/src/code_generator_tests.cpp
@@ -529,7 +529,7 @@ void register_code_generator_tests()
                   "unresolved JR should not pretend it has a resolved local jump table");
     });
 
-    tc.Run("unresolved JALR marks internal labels as indirect fallback resume entries", [](TestCase &t) {
+    tc.Run("unresolved JALR resumes after the call without promoting the function", [](TestCase &t) {
         Function func;
         func.name = "unresolved_jalr_fallback";
         func.start = 0x3200;
@@ -548,10 +548,21 @@ void register_code_generator_tests()
         CodeGenerator gen({}, {});
         CodeGenerator::AnalysisResult analysis = gen.collectInternalBranchTargets(func, instructions);
 
-        t.IsTrue(analysis.indirectFallbackEntryPoints.contains(0x320Cu),
-                 "unresolved JALR should register internal labels as resumable entries for the owning function");
+        // JALR is a call: it returns past the delay slot, so 0x320C is the only
+        // address in this function that has to be reachable from outside.
+        t.IsTrue(analysis.resumeEntryPoints.contains(0x320Cu),
+                 "unresolved JALR should mark its return pc as resumable");
         t.IsTrue(analysis.entryPoints.contains(0x320Cu),
-                 "unresolved JALR fallback targets should still emit labels in the owner");
+                 "unresolved JALR resume pc should still emit a label in the owner");
+
+        // Both sets feed the same owner resume-target list, so the return pc is
+        // registered either way; what must not happen is the whole-function
+        // promotion reserved for jumps that could land anywhere.
+        t.IsFalse(analysis.indirectFallbackEntryPoints.contains(0x3210u),
+                  "an indirect call must not promote unrelated instructions to entry points");
+        t.IsFalse(analysis.indirectFallbackEntryPoints.contains(0x3200u),
+                  "an indirect call must not promote the function start to a fallback entry");
+
         t.IsFalse(analysis.jumpTableTargets.contains(0x3204u),
                   "unresolved JALR should not pretend it has a resolved local jump table");
     });


### PR DESCRIPTION
When a computed jump cannot be resolved to a jump table, every instruction in the function becomes an entry point, because the jump could land on any of them. That fallback was also being applied to JALR.

JALR is not a jump but a call: it transfers control to another function and returns to the instruction after the delay slot. That return address is already queued as a resume target a few lines above, so nothing else in the function needs to be reachable from outside.

Indirect calls are ordinary code — function pointers, virtual dispatch, callbacks — so the fallback fires constantly on real games. Classifying every warned site on Dragon Quest VIII (NTSC-U) by decoding the instruction out of the ELF:

| kind | sites |
|---|---|
| JALR (indirect call) | 2,210 |
| JR (computed jump) | 212 |

with `jalr $t9` alone accounting for 1,874. Split by whether the function contains a genuine computed jump at all:

| | functions | promoted entries |
|---|---|---|
| only indirect calls | 1,078 | 160,100 (84.3%) |
| at least one computed jump | 204 | 29,776 |

This restricts the fallback to JR. Measured on the same binary:

| metric | before | after |
|---|---|---|
| promoted fallback entries | 189,876 | 1,688 |
| registered table entries | 156,783 | 75,386 |
| `register_functions.cpp` | 13 MB | 6.0 MB |
| total generated output | 180 MB | 163 MB |
| largest function file | 1.2 MB | 756 KB |

I checked this did not silently drop anything needed: all 2,210 indirect-call sites were re-examined for their return-address resume entry (`addr + 8`) in the regenerated output. 42 lack one, and all 42 are inside a region of interleaved rodata where the "function" is a carving from string and float data and the return address falls outside its bounds. No real code lost an entry point.

All 11,492 generated translation units still pass `clang++ -std=c++20 -fsyntax-only`.