### PR TITLE
Return true after queueing a guest syscall override

### DIFF
--- a/ps2xRuntime/src/lib/Kernel/Syscalls/System.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Syscalls/System.cpp
@@ -440,6 +440,11 @@ namespace ps2_syscalls
             parent.r[2] = completed.r[2];
         };
         scheduler.invokeCurrent(std::move(invocation));
+        // The invocation is queued and the caller must not fall through to the
+        // built-in handler. Falling off the end of a non-void function here was
+        // undefined behaviour: whatever happened to be in the return register
+        // decided whether the built-in ran as well as the guest's override.
+        return true;
     }
 
     static bool tryResolveGuestSyscallMirrorAddr(uint32_t syscallIndex, uint32_t &guestAddr)


### PR DESCRIPTION
`dispatchSyscallOverride` returns `bool`, and its caller uses that to decide whether the built-in handler still needs to run. The success path, the one that actually queues the guest's handler as an invocation falls off the end of the function without returning.

That is undefined behaviour, and the practical failure mode is unpleasant: whatever happens to be in the return register decides whether the built-in syscall runs *in addition to* the guest's override. A game that overrides a syscall can get the effect applied twice, or not at all, depending on the build.

One-line fix.