### PR TITLE
Set the x86 SIMD baseline that the code already requires

### DIFF
--- a/ps2xRuntime/CMakeLists.txt
+++ b/ps2xRuntime/CMakeLists.txt
@@ -552,6 +552,9 @@ if(PS2X_IS_VITA)
     endif()
 endif()
 
+# PUBLIC, so recompiled game code linking against ps2_runtime inherits it.
+EnableX86SimdBaseline(ps2_runtime)
+
 if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     EnableFastReleaseMode(ps2_runtime)
     EnableFastReleaseMode(ps2EntryRunner)

--- a/ps2xRuntime/cmake/ReleaseMode.cmake
+++ b/ps2xRuntime/cmake/ReleaseMode.cmake
@@ -2,6 +2,21 @@ include(CheckIPOSupported)
 
 check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_ERROR)
 
+# SSE4.1 is required to compile, not an optimisation: ps2_runtime.h includes
+# <smmintrin.h> and the recompiler emits SSE4.1-only intrinsics. GCC and Clang
+# default to the SSE2 baseline, so those TUs fail without this. Kept out of
+# EnableFastReleaseMode because it applies to every configuration, not just
+# Release.
+function(EnableX86SimdBaseline TargetName)
+    if(MSVC)
+        return()
+    endif()
+    if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|amd64|i[3-6]86|x86)$")
+        return()
+    endif()
+    target_compile_options(${TargetName} PUBLIC -msse4.1)
+endfunction()
+
 function(EnableFastReleaseMode TargetName)
     message("> Enabling optimization for: ${TargetName}")
     if(MSVC)


### PR DESCRIPTION
`ps2_runtime.h` includes `<smmintrin.h>` unconditionally, and the recompiler emits SSE4.1-only intrinsics (`_mm_blendv_ps` and friends) for the COP2/FPU select idioms. SSE4.1 is a hard requirement of the codebase, not a tuning option.

Nothing sets it for GCC or Clang. MSVC does not need it, its intrinsics are not gated behind a target feature; and the only place any x86 feature is named is `/arch:AVX2` inside `EnableFastReleaseMode`, which is MSVC-only *and* only applied for `Release`/`RelWithDebInfo`. GCC and Clang default to the plain `x86-64` baseline, which is SSE2, so on a stock Linux or macOS toolchain the affected translation units fail:

```
error: always_inline function "_mm_blendv_ps" requires target feature "sse4.1"
```

Adds `EnableX86SimdBaseline()` and applies it to `ps2_runtime` in **every** configuration rather than from inside `EnableFastReleaseMode`; a Debug build needs it just as much. `PUBLIC`, so recompiled game code linking against `ps2_runtime` inherits it; that code is where most of the SSE4.1 intrinsics actually are. Guarded on `CMAKE_SYSTEM_PROCESSOR` so ARM builds are unaffected.

Found while linking a fully recompiled retail binary (~11.5k translation units, ~160 of which use SSE4.1 intrinsics) against `ps2_runtime` on Fedora with clang.