### PR TITLE
Make the DECI2 text log limit configurable

### DIFF
--- a/ps2xRuntime/src/lib/Kernel/Syscalls/Deci2.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Syscalls/Deci2.cpp
@@ -2,6 +2,8 @@
 #include "Common.h"
 #include "ps2_runtime.h"
 
+#include <cstdlib>
+
 namespace
 {
     struct Deci2Session
@@ -62,11 +64,37 @@ namespace
         return text;
     }
 
+    // Line cap for DECI2 text output. PS2X_DECI2_LOG_LIMIT overrides it;
+    // 0 means unlimited, for diffing a full boot trace against a reference.
+    static uint32_t deci2TextLogLimit()
+    {
+        static const uint32_t limit = []() -> uint32_t
+        {
+            constexpr uint32_t kDefaultMaxDeci2TextLogs = 256u;
+            const char *env = std::getenv("PS2X_DECI2_LOG_LIMIT");
+            if (!env || *env == '\0')
+            {
+                return kDefaultMaxDeci2TextLogs;
+            }
+
+            char *parseEnd = nullptr;
+            const unsigned long parsed = std::strtoul(env, &parseEnd, 10);
+            if (parseEnd == env || *parseEnd != '\0' || parsed > 0xFFFFFFFFul)
+            {
+                return kDefaultMaxDeci2TextLogs;
+            }
+
+            return static_cast<uint32_t>(parsed);
+        }();
+
+        return limit;
+    }
+
     static void logDeci2Text(const char *prefix, const std::string &text)
     {
-        constexpr uint32_t kMaxDeci2TextLogs = 256u;
+        const uint32_t maxDeci2TextLogs = deci2TextLogLimit();
         const uint32_t logIndex = g_deci2LogCount.fetch_add(1u, std::memory_order_relaxed);
-        if (logIndex >= kMaxDeci2TextLogs)
+        if (maxDeci2TextLogs != 0u && logIndex >= maxDeci2TextLogs)
         {
             return;
         }


### PR DESCRIPTION
`logDeci2Text` stops after 256 lines and then silently drops everything else. That is a sensible default against a game that spams `kputs`, but it makes the runtime unusable as the candidate side of a boot-trace diff: real captures run to many thousands of lines, and a silent truncation partway through looks exactly like the guest stopping.

Adds `PS2X_DECI2_LOG_LIMIT`, with `0` meaning unlimited. Unset or unparseable keeps the existing 256, so nothing changes by default.

Context: some retail games ship a compile-time-stubbed `printf` wrapper whose body was dead-code-eliminated down to a bare `return`, while the shared formatter it used to tail-call is still live and still reaches `kputs` -> DECI2. Redirecting the stub back at the formatter (via `replaceFunction`) turns the runtime into a source of the same trace the real hardware produces, which is a rather good oracle for bring-up, provided the log is not capped.