### PR TITLE
Start the main thread with COP0 Status.IE set

### DIFF
--- a/ps2xRuntime/include/ps2_runtime.h
+++ b/ps2xRuntime/include/ps2_runtime.h
@@ -150,10 +150,10 @@ struct alignas(16) R5900Context
 
         // Reset COP0 registers
         cop0_random = 47; // Start at maximum value
-        // cop0_status = 0x400000; // BEV set, ERL clear, kernel mode
-        // 0x00400000 = BEV (Boot Exception Vectors).
-        // 0x00000000 = Normal mode (after BIOS handoff).
-        cop0_status = 0x00000000;
+        // Status as the EE kernel leaves it at handoff. IE (bit 0) and EIE
+        // (bit 16) are separate enables and guest code reads both; libkernel's
+        // StartThread refuses to run while IE is clear.
+        cop0_status = 0x00010001; // EIE | IE
         cop0_prid = 0x00002e20; // CPU ID for R5900
 
         in_delay_slot = false;

--- a/ps2xRuntime/src/lib/ps2_runtime.cpp
+++ b/ps2xRuntime/src/lib/ps2_runtime.cpp
@@ -491,7 +491,9 @@ PS2Runtime::PS2Runtime()
     }
 #endif
 
-    std::memset(&m_cpuContext, 0, sizeof(m_cpuContext));
+    // Assign rather than memset: R5900Context's constructor zeroes itself and
+    // then applies the COP0 reset values, which a memset here would discard.
+    m_cpuContext = R5900Context{};
 
     // R0 is always zero in MIPS
     m_cpuContext.r[0] = _mm_set1_epi32(0);


### PR DESCRIPTION
Guest code reads COP0 `Status` to decide whether interrupts are enabled, and two different bits are involved:

| bit | name | who sets it |
|---|---|---|
| 0 | `IE` | the architectural MIPS interrupt enable. The kernel sets it once during boot and normally leaves it set |
| 16 | `EIE` | the EE-specific enable that `ei` / `di` toggle |

We never execute the boot ROM, so nothing set either one, and `R5900Context` started with `Status` at 0.

That is not cosmetic. libkernel's `StartThread` opens with

```
mfc0  $v0, Status
xori  $v0, $v0, 1
andi  $v0, $v0, 1     ; -> 1 when IE is clear
```

and returns -1 when that is true: its "you must call `iStartThread` from an interrupt handler" guard. With `Status` at zero the guard fires every time, so **every `StartThread` fails**.

Dragon Quest VIII (SLUS-21207) hits this during boot. It creates its CD streaming thread, gets -1, prints `Can't start thread for streaming.` and then deadlocks every guest thread, none runnable, `EeScheduler::waitForEvent` in 10 of 10 stack samples. Nothing in the runtime logs anything, because from its point of view the guest asked a question and got an answer.

`EIE` matters for the matching reason: `DIntr` reports whether it was set so the caller knows whether to pair it with an `EIntr`. Starting at zero makes `DIntr` always answer "already disabled", so the re-enable never happens.

Two changes, both needed:

- `R5900Context`'s constructor sets `Status` to `EIE | IE` instead of 0. `BEV` is deliberately left clear — that selects the boot exception vectors, which is the pre-handoff state, not this one.
- `PS2Runtime`'s constructor no longer `memset`s `m_cpuContext`. `R5900Context` already zeroes itself before applying its reset values, so the memset only threw them away. Threads created later were unaffected, because `EeScheduler::startThread` assigns `R5900Context{}`, which is why this presented as "the main thread cannot start threads" rather than something more obviously global.

Verified on a fully recompiled retail binary: before, the streaming thread never starts; after, it does and boot proceeds to the next stage.