### PR TITLE
Fix synthetic SIF RPC server memory aliasing

### DIFF
--- a/ps2xRuntime/src/lib/Kernel/Syscalls/Helpers/State.h
+++ b/ps2xRuntime/src/lib/Kernel/Syscalls/Helpers/State.h
@@ -162,6 +162,7 @@ struct RpcServerState
 {
     uint32_t sid = 0;
     uint32_t sd_ptr = 0; // PS2 address
+    bool synthetic = false;
 };
 
 struct RpcClientState

--- a/ps2xRuntime/src/lib/Kernel/Syscalls/RPC.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Syscalls/RPC.cpp
@@ -278,6 +278,7 @@ namespace ps2_syscalls
         client->hdr.mode = mode;
 
         uint32_t serverPtr = 0;
+        bool serverIsSynthetic = false;
         {
             std::lock_guard<std::mutex> lock(g_rpc_mutex);
             client->hdr.rpc_id = g_rpc_next_id++;
@@ -285,6 +286,7 @@ namespace ps2_syscalls
             if (it != g_rpc_servers.end())
             {
                 serverPtr = it->second.sd_ptr;
+                serverIsSynthetic = it->second.synthetic;
             }
             g_rpc_clients[clientPtr] = {};
             g_rpc_clients[clientPtr].sid = rpcId;
@@ -303,16 +305,25 @@ namespace ps2_syscalls
                     dummy->sid = static_cast<int>(rpcId);
                 }
                 std::lock_guard<std::mutex> lock(g_rpc_mutex);
-                g_rpc_servers[rpcId] = {rpcId, serverPtr};
+                g_rpc_servers[rpcId] = {rpcId, serverPtr, true};
+                serverIsSynthetic = true;
             }
         }
 
         if (serverPtr)
         {
-            t_SifRpcServerData *sd = reinterpret_cast<t_SifRpcServerData *>(getMemPtr(rdram, serverPtr));
             client->server = serverPtr;
-            client->buf = sd ? sd->buf : 0;
-            client->cbuf = sd ? sd->cbuf : 0;
+            if (serverIsSynthetic)
+            {
+                client->buf = 0;
+                client->cbuf = 0;
+            }
+            else
+            {
+                t_SifRpcServerData *sd = reinterpret_cast<t_SifRpcServerData *>(getMemPtr(rdram, serverPtr));
+                client->buf = sd ? sd->buf : 0;
+                client->cbuf = sd ? sd->cbuf : 0;
+            }
         }
         else
         {
@@ -476,25 +487,29 @@ namespace ps2_syscalls
         client->hdr.mode = mode;
 
         uint32_t sid = 0u;
+        bool serverIsSynthetic = false;
         {
             std::lock_guard<std::mutex> lock(g_rpc_mutex);
             auto &state = g_rpc_clients[clientPtr];
             state.busy = true;
             state.last_rpc = rpcNum;
             sid = state.sid;
-            if (sid != 0u)
+            const auto serverIt = g_rpc_servers.find(sid);
+            if (serverIt != g_rpc_servers.end())
             {
-                const auto serverIt = g_rpc_servers.find(sid);
-                if (serverIt != g_rpc_servers.end() &&
-                    serverIt->second.sd_ptr != 0u)
+                if (sid != 0u && serverIt->second.sd_ptr != 0u)
                 {
                     client->server = serverIt->second.sd_ptr;
+                }
+                if (serverIt->second.sd_ptr == client->server)
+                {
+                    serverIsSynthetic = serverIt->second.synthetic;
                 }
             }
         }
 
         const uint32_t serverPtr = client->server;
-        auto *server = serverPtr
+        auto *server = serverPtr && !serverIsSynthetic
                            ? reinterpret_cast<t_SifRpcServerData *>(getMemPtr(rdram, serverPtr))
                            : nullptr;
         if (server)
@@ -777,7 +792,7 @@ namespace ps2_syscalls
                 }
             }
 
-            g_rpc_servers[sid] = {sid, sdPtr};
+            g_rpc_servers[sid] = {sid, sdPtr, false};
             for (auto &entry : g_rpc_clients)
             {
                 if (entry.second.sid == sid)

--- a/ps2xTest/src/ps2_sif_rpc_tests.cpp
+++ b/ps2xTest/src/ps2_sif_rpc_tests.cpp
@@ -319,6 +319,58 @@ void register_ps2_sif_rpc_tests()
 {
     MiniTest::Case("PS2SifRpc", [](TestCase &tc)
     {
+        tc.Run("synthetic RPC server ignores overwritten guest descriptor", [](TestCase &t)
+        {
+            TestEnv env;
+
+            constexpr uint32_t kClientAddr = 0x00022000u;
+            constexpr uint32_t kSendAddr = 0x00022100u;
+            constexpr uint32_t kRecvAddr = 0x00022200u;
+            constexpr uint32_t kVictimAddr = 0x00022300u;
+            constexpr uint32_t kUnknownSid = 0x80000903u;
+
+            SifInitRpc(env.rdram.data(), &env.ctx, &env.runtime);
+
+            setRegU32(env.ctx, 4, kClientAddr);
+            setRegU32(env.ctx, 5, kUnknownSid);
+            setRegU32(env.ctx, 6, 0u);
+            SifBindRpc(env.rdram.data(), &env.ctx, &env.runtime);
+            t.Equals(getRegS32(env.ctx, 2), KE_OK, "SifBindRpc should synthesize an unknown server");
+
+            const SifRpcClientData client = readGuestStruct<SifRpcClientData>(env.rdram.data(), kClientAddr);
+            t.IsTrue(client.server != 0u, "synthetic bind should expose a nonzero server pointer");
+            t.Equals(client.buf, 0u, "synthetic bind should not trust a guest server buffer");
+            t.Equals(client.cbuf, 0u, "synthetic bind should not trust a guest callback buffer");
+
+            SifRpcServerData overwrittenServer{};
+            overwrittenServer.sid = static_cast<int32_t>(kUnknownSid);
+            overwrittenServer.buf = kVictimAddr;
+            writeGuestStruct(env.rdram.data(), client.server, overwrittenServer);
+
+            std::array<uint8_t, 16> payload{};
+            std::array<uint8_t, 16> sentinel{};
+            payload.fill(0u);
+            sentinel.fill(0xA5u);
+            std::memcpy(env.rdram.data() + kSendAddr, payload.data(), payload.size());
+            std::memcpy(env.rdram.data() + kVictimAddr, sentinel.data(), sentinel.size());
+
+            setRegU32(env.ctx, 4, kClientAddr);
+            setRegU32(env.ctx, 5, 1u);
+            setRegU32(env.ctx, 6, 0u);
+            setRegU32(env.ctx, 7, kSendAddr);
+            setRegU32(env.ctx, 8, static_cast<uint32_t>(payload.size()));
+            setRegU32(env.ctx, 9, kRecvAddr);
+            setRegU32(env.ctx, 10, static_cast<uint32_t>(payload.size()));
+            setRegU32(env.ctx, 11, 0u);
+            setRegU32(env.ctx, 29, K_STACK_ADDR);
+            writeGuestU32(env.rdram.data(), K_STACK_ADDR, 0u);
+
+            SifCallRpc(env.rdram.data(), &env.ctx, &env.runtime);
+            t.Equals(getRegS32(env.ctx, 2), KE_OK, "SifCallRpc should complete for a synthetic server");
+            t.IsTrue(std::memcmp(env.rdram.data() + kVictimAddr, sentinel.data(), sentinel.size()) == 0,
+                     "overwritten synthetic descriptor must not redirect the server-buffer copy");
+        });
+
         tc.Run("register bind call updates descriptors and payload", [](TestCase &t)
         {
             TestEnv env;


### PR DESCRIPTION
## Summary
- mark placeholder SIF RPC servers as synthetic in host state
- avoid reading mutable guest-memory fields from synthetic descriptors during bind/call
- preserve normal guest server descriptor behavior for registered RPC servers
- add a regression test that overwrites a placeholder descriptor and verifies it cannot redirect a payload copy into unrelated EE memory

## Why
Placeholder servers are allocated inside EE RDRAM so guest bind loops receive a nonzero server pointer. A game can later reuse that address. `SifCallRpc` previously trusted the overwritten descriptor's `buf` field and copied request data to that stale destination, corrupting unrelated live game objects.

## Testing
- `MINITEST_FILTER=synthetic RPC server ignores`: 1/1 passed
- `MINITEST_FILTER=PS2SifRpc`: 18/18 passed
- integration boot probe: 578 calls to the affected synthetic controller RPC with zero writes to the previously corrupted object