### PR TITLE
Fix R5900 SQRT.S source register

### DIFF
--- a/ps2xRecomp/src/lib/fpu_translator.cpp
+++ b/ps2xRecomp/src/lib/fpu_translator.cpp
@@ -58,7 +58,7 @@ namespace ps2recomp
                                    "else ctx->f[{}] = ctx->f[{}] / ctx->f[{}];",
                                    ft, fd, fs, fd, fs, ft);
             case COP1_S_SQRT:
-                return fmt::format("ctx->f[{}] = FPU_SQRT_S(ctx->f[{}]);", fd, fs);
+                return fmt::format("ctx->f[{}] = FPU_SQRT_S(ctx->f[{}]);", fd, ft);
             case COP1_S_ABS:
                 return fmt::format("ctx->f[{}] = FPU_ABS_S(ctx->f[{}]);", fd, fs);
             case COP1_S_MOV:

--- a/ps2xTest/src/code_generator_tests.cpp
+++ b/ps2xTest/src/code_generator_tests.cpp
@@ -892,6 +892,22 @@ void register_code_generator_tests()
             t.IsTrue(ctc1Code.find("ignored") == std::string::npos, "CTC1 FCR31 should not be ignored");
         });
 
+        tc.Run("SQRT.S reads the ft source register", [](TestCase &t) {
+            CodeGenerator gen({}, {});
+
+            Instruction sqrt{};
+            sqrt.opcode = OPCODE_COP1;
+            sqrt.rs = COP1_S;
+            sqrt.rt = 4;
+            sqrt.rd = 9;
+            sqrt.sa = 2;
+            sqrt.function = COP1_S_SQRT;
+
+            const std::string generated = gen.translateInstruction(sqrt);
+            t.IsTrue(generated.find("ctx->f[2] = FPU_SQRT_S(ctx->f[4]);") != std::string::npos,
+                     "SQRT.S should read ft, not the otherwise-unused fs field");
+        });
+
         tc.Run("VU CFC2/CTC2 access VI registers directly", [](TestCase& t)
             {
                 CodeGenerator gen({}, {});


### PR DESCRIPTION
## Summary
- emit R5900 SQRT.S from the encoded t source register
- add a code-generation regression test with distinct s and t fields

## Why
The current translator reads s, but the R5900 SQRT.S fd, ft encoding uses t; s is otherwise unused. This produced valid but incorrect camera normalization in X-Men Legends and left its animated title-level view matrix effectively broken.

## Testing
- focused CodeGenerator test passes
- regenerated X-Men Legends camera code now takes both square roots from the computed operands
- runtime verification reaches the title level with an animated, nonidentity view matrix and renders the Cerebro chamber