### PR TITLE
Fix VU0 VCLIP semantics

### DIFF
--- a/ps2xRecomp/src/lib/vu_translator.cpp
+++ b/ps2xRecomp/src/lib/vu_translator.cpp
@@ -263,22 +263,9 @@ namespace ps2recomp
                 }
                 case VU0_S2_VCLIPw:
                 {
-                    uint8_t field = inst.function & 0x3;
-                    std::string shuffle_pattern = fmt::format("_MM_SHUFFLE({},{},{},{})", field, field, field, field);
-
                     return fmt::format(
-                        "{{ __m128 fs = ctx->vu0_vf[{}]; "
-                        "__m128 ft = _mm_shuffle_ps(ctx->vu0_vf[{}], ctx->vu0_vf[{}], {}); "
-                        "__m128 neg_ft = _mm_xor_ps(ft, _mm_castsi128_ps(_mm_set1_epi32(0x80000000))); "
-                        "__m128 gt = _mm_cmpgt_ps(fs, ft); "
-                        "__m128 lt = _mm_cmplt_ps(fs, neg_ft); "
-                        "uint32_t gt_mask = (uint32_t)_mm_movemask_ps(gt); "
-                        "uint32_t lt_mask = (uint32_t)_mm_movemask_ps(lt); "
-                        "uint32_t flags = ((lt_mask & 0x1) << 0) | ((gt_mask & 0x1) << 1) | "
-                        "((lt_mask & 0x2) << 1) | ((gt_mask & 0x2) << 2) | "
-                        "((lt_mask & 0x4) << 2) | ((gt_mask & 0x4) << 3); "
-                        "ctx->vu0_clip_flags = ((ctx->vu0_clip_flags << 6) | (flags & 0x3F)) & 0xFFFFFF; }}",
-                        inst.rd, inst.rt, inst.rt, shuffle_pattern);
+                        "ctx->vu0_clip_flags = PS2_VCLIP(ctx->vu0_clip_flags, ctx->vu0_vf[{}], ctx->vu0_vf[{}]);",
+                        inst.rd, inst.rt);
                 }
                 case VU0_S2_VNOP:
                     return fmt::format("// NOP operation, no action needed for VU0");

--- a/ps2xRuntime/include/ps2_runtime_macros.h
+++ b/ps2xRuntime/include/ps2_runtime_macros.h
@@ -141,12 +141,34 @@ static inline uint32_t ps2_plzcw32(uint32_t x)
 #define PS2_PNOR(a, b) _mm_xor_si128(_mm_or_si128((__m128i)(a), (__m128i)(b)), _mm_set1_epi32(0xFFFFFFFF))
 
 // PS2 VU (Vector Unit) operations
+static inline uint32_t ps2_vu_clip(uint32_t previousFlags, __m128 fs, __m128 ft)
+{
+    const __m128i fsBits = _mm_castps_si128(fs);
+    const __m128i ftBits = _mm_castps_si128(ft);
+    const uint32_t wBits = static_cast<uint32_t>(Ps2ExtractEpi32(ftBits, 3));
+    const int32_t clipMagnitude = static_cast<int32_t>(
+        (wBits & 0x7F800000u) != 0u ? (wBits & 0x7FFFFFFFu) : 0x007FFFFFu);
+
+    uint32_t flags = 0u;
+    for (int lane = 0; lane < 3; ++lane)
+    {
+        const uint32_t value = static_cast<uint32_t>(Ps2ExtractEpi32(fsBits, lane));
+        if (static_cast<int32_t>(value) > clipMagnitude)
+            flags |= 1u << (lane * 2);
+        if (static_cast<int32_t>(value ^ 0x80000000u) > clipMagnitude)
+            flags |= 2u << (lane * 2);
+    }
+
+    return ((previousFlags << 6) | flags) & 0x00FFFFFFu;
+}
+
 #define PS2_VADD(a, b) _mm_add_ps((__m128)(a), (__m128)(b))
 #define PS2_VSUB(a, b) _mm_sub_ps((__m128)(a), (__m128)(b))
 #define PS2_VMUL(a, b) _mm_mul_ps((__m128)(a), (__m128)(b))
 #define PS2_VDIV(a, b) _mm_div_ps((__m128)(a), (__m128)(b))
 #define PS2_VMULQ(a, q) _mm_mul_ps((__m128)(a), _mm_set1_ps(q))
 #define PS2_VBLEND(a, b, mask) PS2_BLENDV_PS((__m128)(a), (__m128)(b), (__m128)(mask))
+#define PS2_VCLIP(flags, fs, ft) ps2_vu_clip((uint32_t)(flags), (__m128)(fs), (__m128)(ft))
 
 // Memory access helpers - Hybrid Fast/Slow Path
 // Fast path: Direct RDRAM access (masked).

--- a/ps2xTest/src/code_generator_tests.cpp
+++ b/ps2xTest/src/code_generator_tests.cpp
@@ -1315,6 +1315,26 @@ void register_code_generator_tests()
             t.IsTrue(out.find("ctx->vu0_vf[22]") == std::string::npos, "S2 must not use rs(format) as register index");
         });
 
+        tc.Run("VU0 VCLIP emits the PS2 clip helper", [](TestCase &t) {
+            Instruction inst{};
+            inst.opcode = OPCODE_COP2;
+            inst.rs = COP2_CO | 0xF;
+            inst.rt = 20;
+            inst.rd = 12;
+            inst.function = 0x3C;
+            inst.vectorInfo.vectorField = 0xF;
+
+            const uint32_t upper = (VU0_S2_VCLIPw >> 2) & 0x1F;
+            const uint32_t lower = VU0_S2_VCLIPw & 0x3;
+            inst.raw = (upper << 6) | lower;
+
+            CodeGenerator gen({}, {});
+            const std::string out = gen.translateInstruction(inst);
+
+            t.IsTrue(out.find("PS2_VCLIP(ctx->vu0_clip_flags, ctx->vu0_vf[12], ctx->vu0_vf[20])") != std::string::npos,
+                     "VCLIP should use the runtime helper with Fs from rd and Ft from rt");
+        });
+
         tc.Run("VU0 S2 VI memory ops use rd as VI base register", [](TestCase &t) {
             Instruction inst{};
             inst.opcode = OPCODE_COP2;

--- a/ps2xTest/src/ps2_vu_tests.cpp
+++ b/ps2xTest/src/ps2_vu_tests.cpp
@@ -75,10 +75,52 @@ namespace
         m[10] = 1.0f;
         m[15] = 1.0f;
     }
+
+    float floatFromBits(uint32_t bits)
+    {
+        float value = 0.0f;
+        std::memcpy(&value, &bits, sizeof(value));
+        return value;
+    }
 }
 
 void register_ps2_vu_tests()
 {
+    MiniTest::Case("PS2VU0ClipSemantics", [](TestCase &tc)
+    {
+        tc.Run("ClipFlagsUsePositiveThenNegativeBitsPerAxis", [](TestCase &t)
+        {
+            const __m128 positiveNegativePositive = _mm_set_ps(0.0f, 3.0f, -3.0f, 3.0f);
+            const __m128 negativePositiveNegative = _mm_set_ps(0.0f, -3.0f, 3.0f, -3.0f);
+            const __m128 limit = _mm_set_ps(2.0f, 0.0f, 0.0f, 0.0f);
+
+            t.IsTrue(PS2_VCLIP(0u, positiveNegativePositive, limit) == 0x19u,
+                     "VCLIP should assign positive X/Y/Z to bits 0/2/4 and negative values to bits 1/3/5");
+            t.IsTrue(PS2_VCLIP(0u, negativePositiveNegative, limit) == 0x26u,
+                     "VCLIP should preserve the negative X/Y/Z bit ordering");
+        });
+
+        tc.Run("ClipUsesAbsoluteWAndPreservesFlagHistory", [](TestCase &t)
+        {
+            const __m128 value = _mm_set_ps(0.0f, 1.0f, -3.0f, 3.0f);
+            const __m128 negativeLimit = _mm_set_ps(-2.0f, 0.0f, 0.0f, 0.0f);
+            const uint32_t previous = 0x123456u;
+            const uint32_t expected = ((previous << 6) | 0x09u) & 0x00FFFFFFu;
+
+            t.IsTrue(PS2_VCLIP(previous, value, negativeLimit) == expected,
+                     "VCLIP should compare against abs(W) and retain four generations of six-bit flags");
+        });
+
+        tc.Run("ClipTreatsDenormalWAsMaximumDenormal", [](TestCase &t)
+        {
+            const __m128 value = _mm_set_ps(0.0f, 0.0f, 0.0f, floatFromBits(0x00800000u));
+            const __m128 denormalLimit = _mm_set_ps(floatFromBits(0x80000001u), 0.0f, 0.0f, 0.0f);
+
+            t.IsTrue(PS2_VCLIP(0u, value, denormalLimit) == 0x01u,
+                     "VCLIP should classify the smallest normal value beyond a denormal W limit");
+        });
+    });
+
     MiniTest::Case("PS2VU0Math", [](TestCase &tc)
     {
         tc.Run("MulVector_componentwise", [](TestCase &t)


### PR DESCRIPTION
## Summary
- implement VCLIP using the R5900/VU bit-level comparison rules
- preserve the 24-bit history with positive/negative bits in hardware order
- use bs(Ft.w) and the hardware denormal threshold behavior
- emit the shared helper from generated COP2 code
- add generator and semantic regression tests

## Why
The existing host-float comparison reverses each positive/negative flag pair and does not reproduce VU denormal handling. The incorrect clip flags broke Alchemy/Intrinsic Graphics frustum decisions in X-Men Legends.

## Testing
- VCLIP code-generation regression passes
- positive/negative axis ordering passes
- negative W and history preservation pass
- denormal W threshold behavior passes
- X-Men Legends proceeds through the affected Alchemy visibility path