### PR TITLE
Defer EE time-slice preemption while interrupts are disabled

### DIFF
--- a/ps2xRuntime/src/lib/Kernel/EeScheduler.cpp
+++ b/ps2xRuntime/src/lib/Kernel/EeScheduler.cpp
@@ -36,6 +36,17 @@ namespace
     constexpr uint64_t kAlarmTickMicroseconds = 64u;
     constexpr uint32_t kDebugPublishDispatchInterval = 4096u;
 
+    bool eeInterruptsEnabled(const R5900Context &context)
+    {
+        constexpr uint32_t kStatusIe = 1u << 0u;
+        constexpr uint32_t kStatusExl = 1u << 1u;
+        constexpr uint32_t kStatusErl = 1u << 2u;
+        constexpr uint32_t kStatusEie = 1u << 16u;
+        const uint32_t status = context.cop0_status;
+        return (status & (kStatusIe | kStatusEie)) == (kStatusIe | kStatusEie) &&
+               (status & (kStatusExl | kStatusErl)) == 0u;
+    }
+
     constexpr uint64_t microsecondsToEeCycles(uint64_t microseconds)
     {
         return (microseconds * EeScheduler::kEeClockHz + 999999ull) / 1000000ull;
@@ -362,6 +373,12 @@ bool EeScheduler::checkpointDue(uint32_t cycles) noexcept
         return true;
     }
 
+    const GuestThread *running = currentThread();
+    if (m_rescheduleRequested && running != nullptr && eeInterruptsEnabled(running->activeContext()))
+    {
+        return true;
+    }
+
     const uint64_t nextEventCycle = m_nextDeadlineCycle.load(std::memory_order_acquire);
     if (nextEventCycle != 0u && m_eeCycle >= nextEventCycle)
     {
@@ -374,9 +391,12 @@ bool EeScheduler::checkpointDue(uint32_t cycles) noexcept
         return false;
     }
 
-    const GuestThread *running = currentThread();
     if (running != nullptr && hasReadyAtOrAbovePriority(running->currentPriority))
     {
+        if (!eeInterruptsEnabled(running->activeContext()))
+        {
+            return false;
+        }
         m_rescheduleRequested = true;
         m_timeSliceExpired = true;
         return true;
@@ -1726,6 +1746,10 @@ void EeScheduler::applyPendingPreemption()
     }
     GuestThread *self = currentThread();
     assert(self != nullptr);
+    if (!eeInterruptsEnabled(self->activeContext()))
+    {
+        return;
+    }
     enqueueReady(*self, !m_timeSliceExpired);
     m_currentThreadId = 0;
     m_rescheduleRequested = false;

--- a/ps2xTest/src/ps2_runtime_kernel_tests.cpp
+++ b/ps2xTest/src/ps2_runtime_kernel_tests.cpp
@@ -832,6 +832,35 @@ void register_ps2_runtime_kernel_tests()
             t.IsTrue(trace == expected, "higher priority should run before the starter continues");
         });
 
+        tc.Run("time-slice preemption waits until EE interrupts are enabled", [](TestCase &t)
+        {
+            constexpr uint32_t kStatusIe = 1u << 0u;
+            constexpr uint32_t kStatusEie = 1u << 16u;
+
+            TestEnv env;
+            EeScheduler &ee = env.runtime.eeScheduler();
+            ee.reset(env.rdram.data(), env.ctx);
+            ee.bindMainContextForSyscall(env.ctx, env.rdram.data());
+
+            int oldPriority = 0;
+            t.Equals(ee.changePriority(EeScheduler::kMainThreadId, 5, false, oldPriority), 0,
+                     "the running main thread should accept a schedulable priority");
+            const int peer = ee.createThread(EeThreadCreateParams{0u, K_SCHED_HIGH, 0x24000u, 0x800u,
+                                                                  0u, 5, 0u});
+            t.Equals(ee.startThread(peer, 0u, env.ctx, false), KE_OK,
+                     "the same-priority peer should become ready");
+
+            R5900Context *current = ee.currentContext();
+            t.IsTrue(current != nullptr, "the main thread should remain the active context");
+            current->cop0_status = kStatusIe;
+            t.IsFalse(ee.checkpointDue(static_cast<uint32_t>(EeScheduler::kDefaultTimeSliceCycles)),
+                      "DI must defer synthetic time-slice preemption");
+
+            current->cop0_status |= kStatusEie;
+            t.IsTrue(ee.checkpointDue(1u),
+                     "EI must make the deferred time-slice preemption due immediately");
+        });
+
         tc.Run("semaphore waiters are FIFO and signal transfers one token directly", [](TestCase &t)
         {
             TestEnv env;


### PR DESCRIPTION
## Summary
- gate synthetic EE scheduler preemption on Status.IE/EIE and EXL/ERL
- keep deferred reschedules pending so the first checkpoint after `EI` can service them
- add a regression test covering a same-priority time-slice expiry across `DI`/`EI`

## Why
PS2 software uses `DI`/`EI` around critical list and allocator mutations. The runtime's interrupt dispatch observes those bits, but synthetic time-slice preemption did not. That allowed a ready peer to run during an intentionally transient list state and consume partially updated pointers.

## Testing
- clean Release build from upstream `main`
- `ps2x_tests`: 426 passed, 0 failed
- runtime validation through 1,500 rendered frames: the previously reproducible invalid list lookup and downstream indirect-branch corruption no longer occur