### PR TITLE
Complete zero-QWC terminal DMA chains

### DIFF
--- a/ps2xRuntime/src/lib/ps2_memory.cpp
+++ b/ps2xRuntime/src/lib/ps2_memory.cpp
@@ -1317,6 +1317,7 @@ bool PS2Memory::writeIORegister(uint32_t address, uint32_t value)
                     const bool tieEnabled = (chcr & (1u << 7)) != 0u;
                     const int kMaxChainTags = 4096;
                     std::vector<uint8_t> chainBuf;
+                    bool chainEnded = false;
 
                     auto appendData = [&](uint32_t srcAddr, uint32_t qwCount)
                     {
@@ -1493,7 +1494,10 @@ bool PS2Memory::writeIORegister(uint32_t address, uint32_t value)
                         if (irq && tieEnabled)
                             endChain = true;
                         if (endChain)
+                        {
+                            chainEnded = true;
                             break;
+                        }
                     }
 
                     m_ioRegisters[channelBase + 0x30] = tagAddr;
@@ -1503,7 +1507,7 @@ bool PS2Memory::writeIORegister(uint32_t address, uint32_t value)
                     chcr = (chcr & 0x0000FFFFu) | (lastTagUpper << 16);
                     m_ioRegisters[channelBase + 0x00] = chcr;
 
-                    if (!chainBuf.empty())
+                    if (!chainBuf.empty() || chainEnded)
                     {
                         PendingTransfer pt;
                         pt.fromScratchpad = false;

--- a/ps2xTest/src/ps2_memory_tests.cpp
+++ b/ps2xTest/src/ps2_memory_tests.cpp
@@ -1739,6 +1739,37 @@ void register_ps2_memory_tests()
             t.IsTrue((dstatCleared & kSummaryBit) == 0u, "summary bit should clear after status clear");
         });
 
+        tc.Run("GIF DMA zero-QWC END still completes the channel", [](TestCase &t)
+        {
+            PS2Memory mem;
+            t.IsTrue(mem.initialize(), "PS2Memory initialize should succeed");
+
+            constexpr uint32_t kGifCh = 0x1000A000u;
+            constexpr uint32_t kDStat = 0x1000E010u;
+            constexpr uint32_t kTag = 0x00027600u;
+
+            uint8_t *rdram = mem.getRDRAM();
+            writeDmaTag(rdram, kTag, makeDmaTag(0u, 7u, 0u, false));
+
+            uint32_t callbackCount = 0u;
+            mem.setGifPacketCallback([&](const uint8_t *, uint32_t)
+            {
+                ++callbackCount;
+            });
+
+            t.IsTrue(mem.writeIORegister(kGifCh + 0x30u, kTag), "write GIF TADR should succeed");
+            t.IsTrue(mem.writeIORegister(kGifCh + 0x00u, 0x104u), "write GIF CHCR STR|CHAIN should succeed");
+
+            mem.processPendingTransfers();
+
+            const uint32_t chcr = mem.readIORegister(kGifCh + 0x00u);
+            t.Equals(callbackCount, 0u, "zero-QWC chain must not submit an empty GIF packet");
+            t.Equals(chcr & 0x100u, 0u, "zero-QWC END should clear GIF STR");
+            t.Equals(chcr & 0x70000000u, 0x70000000u, "GIF CHCR should expose the terminal END tag id");
+            t.IsTrue((mem.readIORegister(kDStat) & (1u << 2u)) != 0u,
+                     "zero-QWC END should raise the GIF D_STAT channel bit");
+        });
+
         tc.Run("DMAC D_CTRL DMAE gates GIF DMA start", [](TestCase &t)
         {
             PS2Memory mem;


### PR DESCRIPTION
## Summary
- complete terminal GIF DMA chains even when their END tag has zero QWC
- avoid submitting an empty GIF packet while still clearing CHCR.STR and raising D_STAT
- add a regression test covering the terminal tag state and interrupt

## Why
A zero-QWC END tag currently leaves the channel active forever because no pending transfer is queued when the accumulated payload is empty. The terminal tag is still a completed DMA operation and needs the normal completion bookkeeping.

## Testing
- 426/426 ps2x_tests passed (Release)