### PR TITLE
Honor DMAC scratchpad address selectors

### DIFF
--- a/ps2xRuntime/src/lib/ps2_memory.cpp
+++ b/ps2xRuntime/src/lib/ps2_memory.cpp
@@ -46,6 +46,13 @@ namespace
         return Ps2AddressInRange(addr, PS2_IO_BASE, PS2_IO_SIZE);
     }
 
+    inline uint32_t canonicalDmacAddress(uint32_t address)
+    {
+        if ((address & 0x80000000u) != 0u)
+            return PS2_SCRATCHPAD_BASE + (address & (PS2_SCRATCHPAD_SIZE - 1u));
+        return address;
+    }
+
     inline uint64_t *gsRegPtr(GSRegisters &gs, uint32_t addr)
     {
         // Support both 64-bit base offsets and +4 dword aliases.
@@ -1288,6 +1295,7 @@ bool PS2Memory::writeIORegister(uint32_t address, uint32_t value)
                 {
                     if (qwCount == 0)
                         return;
+                    srcAddr = canonicalDmacAddress(srcAddr);
                     const bool scratch = isScratchpad(srcAddr);
                     PendingTransfer pt;
                     pt.fromScratchpad = scratch;
@@ -1322,9 +1330,9 @@ bool PS2Memory::writeIORegister(uint32_t address, uint32_t value)
                     {
                         const uint64_t bytes64 = static_cast<uint64_t>(qwCount) * 16ull;
                         uint32_t bytes = (bytes64 > 0xFFFFFFFFull) ? 0xFFFFFFFFu : static_cast<uint32_t>(bytes64);
+                        srcAddr = canonicalDmacAddress(srcAddr);
                         const bool scratch = isScratchpad(srcAddr);
-                        uint32_t src = 0;
-                        src = translateAddress(srcAddr);
+                        uint32_t src = translateAddress(srcAddr);
                         const uint8_t *base2;
                         uint32_t maxSz2;
                         if (scratch)
@@ -1355,9 +1363,9 @@ bool PS2Memory::writeIORegister(uint32_t address, uint32_t value)
 
                     auto appendCompactVif1TagData = [&](uint32_t localTagAddr, uint32_t qwCount)
                     {
-                        uint32_t tagPhys = 0u;
+                        localTagAddr = canonicalDmacAddress(localTagAddr);
                         const bool tagScratch = isScratchpad(localTagAddr);
-                        tagPhys = translateAddress(localTagAddr);
+                        const uint32_t tagPhys = translateAddress(localTagAddr);
 
                         const uint8_t *localBase = tagScratch ? m_scratchpad : m_rdram;
                         const uint32_t localMax = tagScratch ? PS2_SCRATCHPAD_SIZE : PS2_RAM_SIZE;
@@ -1375,11 +1383,12 @@ bool PS2Memory::writeIORegister(uint32_t address, uint32_t value)
                     while (tagsProcessed < kMaxChainTags)
                     {
                         const uint32_t currentTagAddr = tagAddr;
-                        const bool tagInSPR = isScratchpad(tagAddr);
+                        const uint32_t canonicalTagAddr = canonicalDmacAddress(tagAddr);
+                        const bool tagInSPR = isScratchpad(canonicalTagAddr);
                         uint32_t physTag = 0;
                         try
                         {
-                            physTag = translateAddress(tagAddr);
+                            physTag = translateAddress(canonicalTagAddr);
                         }
                         catch (...)
                         {
@@ -1405,7 +1414,9 @@ bool PS2Memory::writeIORegister(uint32_t address, uint32_t value)
                         uint16_t tagQwc = static_cast<uint16_t>(tag & 0xFFFF);
                         uint32_t id = static_cast<uint32_t>((tag >> 28) & 0x7);
                         const bool irq = ((tag >> 31) & 0x1ull) != 0ull;
-                        uint32_t addr = static_cast<uint32_t>((tag >> 32) & 0x7FFFFFFF);
+                        // The upper address bit is the DMAtag SPR selector. Keep it
+                        // attached so later tag/payload resolution uses scratchpad.
+                        uint32_t addr = static_cast<uint32_t>(tag >> 32);
                         lastTagUpper = static_cast<uint32_t>((tag >> 16) & 0xFFFFu);
                         ++tagsProcessed;
 

--- a/ps2xTest/src/ps2_memory_tests.cpp
+++ b/ps2xTest/src/ps2_memory_tests.cpp
@@ -40,12 +40,13 @@ namespace
         std::memcpy(dst.data() + pos, &value, sizeof(uint64_t));
     }
 
-    uint64_t makeDmaTag(uint16_t qwc, uint8_t id, uint32_t addr, bool irq = false)
+    uint64_t makeDmaTag(uint16_t qwc, uint8_t id, uint32_t addr, bool irq = false, bool spr = false)
     {
         return static_cast<uint64_t>(qwc) |
                (static_cast<uint64_t>(id & 0x7u) << 28) |
                (irq ? (1ull << 31) : 0ull) |
-               (static_cast<uint64_t>(addr & 0x7FFFFFFFu) << 32);
+               (static_cast<uint64_t>(addr & 0x7FFFFFFFu) << 32) |
+               (spr ? (1ull << 63) : 0ull);
     }
 
     void writeDmaTag(uint8_t *rdram, uint32_t tagAddr, uint64_t tagLo)
@@ -1047,6 +1048,71 @@ void register_ps2_memory_tests()
                 }
             }
             t.IsTrue(contentOk, "scratchpad GIF DMA packet bytes should match scratchpad source");
+        });
+
+        tc.Run("GIF DMA mode0 honors the MADR SPR selector", [](TestCase &t)
+        {
+            PS2Memory mem;
+            t.IsTrue(mem.initialize(), "PS2Memory initialize should succeed");
+
+            constexpr uint32_t kGifCh = 0x1000A000u;
+            constexpr uint32_t kRawSprMadr = 0x80898080u;
+            constexpr uint32_t kScratchOffset = 0x80u;
+
+            uint8_t *scratch = mem.getScratchpad();
+            for (uint32_t i = 0; i < 16u; ++i)
+                scratch[kScratchOffset + i] = static_cast<uint8_t>(0xB0u + i);
+
+            std::vector<std::vector<uint8_t>> captured;
+            mem.setGifPacketCallback([&](const uint8_t *data, uint32_t sizeBytes)
+            {
+                captured.emplace_back(data, data + sizeBytes);
+            });
+
+            t.IsTrue(mem.writeIORegister(kGifCh + 0x10u, kRawSprMadr), "write SPR-selected MADR should succeed");
+            t.IsTrue(mem.writeIORegister(kGifCh + 0x20u, 1u), "write QWC should succeed");
+            t.IsTrue(mem.writeIORegister(kGifCh + 0x00u, 0x100u), "write CHCR STR should succeed");
+
+            mem.processPendingTransfers();
+
+            t.Equals(captured.size(), static_cast<size_t>(1u), "SPR-selected MADR should emit one packet");
+            t.Equals(captured[0].size(), static_cast<size_t>(16u), "SPR-selected MADR should emit one qword");
+            t.IsTrue(std::equal(captured[0].begin(), captured[0].end(), scratch + kScratchOffset),
+                     "SPR-selected MADR should read scratchpad bytes");
+        });
+
+        tc.Run("GIF DMA chain follows SPR-selected NEXT tags", [](TestCase &t)
+        {
+            PS2Memory mem;
+            t.IsTrue(mem.initialize(), "PS2Memory initialize should succeed");
+
+            constexpr uint32_t kGifCh = 0x1000A000u;
+            constexpr uint32_t kFirstTag = 0x00022100u;
+            constexpr uint32_t kRawSprTarget = 0x00898F00u;
+            constexpr uint32_t kScratchTagOffset = 0x0F00u;
+
+            uint8_t *rdram = mem.getRDRAM();
+            uint8_t *scratch = mem.getScratchpad();
+            writeDmaTag(rdram, kFirstTag, makeDmaTag(0u, 2u, kRawSprTarget, false, true));
+            writeDmaTag(scratch, kScratchTagOffset, makeDmaTag(1u, 7u, 0u));
+            for (uint32_t i = 0; i < 16u; ++i)
+                scratch[kScratchTagOffset + 16u + i] = static_cast<uint8_t>(0xD0u + i);
+
+            std::vector<std::vector<uint8_t>> captured;
+            mem.setGifPacketCallback([&](const uint8_t *data, uint32_t sizeBytes)
+            {
+                captured.emplace_back(data, data + sizeBytes);
+            });
+
+            t.IsTrue(mem.writeIORegister(kGifCh + 0x30u, kFirstTag), "write TADR should succeed");
+            t.IsTrue(mem.writeIORegister(kGifCh + 0x00u, 0x104u), "write CHCR STR|CHAIN should succeed");
+
+            mem.processPendingTransfers();
+
+            t.Equals(captured.size(), static_cast<size_t>(1u), "SPR-selected NEXT should emit one packet");
+            t.Equals(captured[0].size(), static_cast<size_t>(16u), "SPR-selected NEXT should emit one qword");
+            t.IsTrue(std::equal(captured[0].begin(), captured[0].end(), scratch + kScratchTagOffset + 16u),
+                     "SPR-selected NEXT should read the scratchpad tag payload");
         });
 
         tc.Run("GIF DMA chain can source tags and payload from 0xF000 scratchpad alias", [](TestCase &t)


### PR DESCRIPTION
## Summary
- preserve bit 31 as the DMAC SPR selector for MADR and DMAtag ADDR values
- canonicalize SPR-selected addresses to the 16 KiB scratchpad only when resolving transfer memory
- cover direct GIF MADR transfers and chained NEXT tags targeting SPR

## Why
DMAC addresses use bit 31 to select scratchpad memory on non-SPR channels. Masking the DMAtag address to 31 bits discarded that selector, while raw bit-31 MADR values were treated as ordinary guest aliases. Both cases could source data from RDRAM instead of SPR.

## Testing
- 427/427 ps2x_tests passed (Release)