### PR TITLE
Support configurable callable entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Main fields in `config.toml`:
 * `general.patch_syscalls`: apply configured patches to `SYSCALL` instructions (`false` recommended).
 * `general.patch_cop0`: apply configured patches to COP0 instructions.
 * `general.patch_cache`: apply configured patches to CACHE instructions.
+* `general.resume_entry_points_file`: optional text file containing extra callable guest addresses, one per line.
+* `general.entry_point_pointer_ranges`: optional static-data ranges to scan for clustered pointers to decoded guest code. Each range requires `source_start` and `source_end`; `target_start`/`target_end`, `window_words`, and `minimum_code_pointers` constrain validation. This is useful for vtables and callback tables in stripped ELFs.
 * `general.stubs`: names to force as stubs. Also accepts `handler@0xADDRESS` to bind a stripped function address directly to a runtime syscall/stub handler. Includes generic handlers `ret0`, `ret1`, `reta0`.
 * `general.skip`: names to force as skipped wrappers.
 * `patches.instructions`: raw instruction replacements by address.

--- a/ps2xRecomp/include/ps2recomp/types.h
+++ b/ps2xRecomp/include/ps2recomp/types.h
@@ -172,6 +172,16 @@ namespace ps2recomp
         std::string calleeName;
     };
 
+    struct EntryPointPointerRange
+    {
+        uint32_t sourceStart = 0;
+        uint32_t sourceEnd = 0;
+        uint32_t targetStart = 0;
+        uint32_t targetEnd = UINT32_MAX;
+        uint32_t windowWords = 8;
+        uint32_t minimumCodePointers = 2;
+    };
+
     // Recompiler configuration
     struct RecompilerConfig
     {
@@ -184,6 +194,8 @@ namespace ps2recomp
         bool patchSyscalls = false;
         bool patchCop0 = true;
         bool patchCache = true;
+        std::string resumeEntryPointsPath;
+        std::vector<EntryPointPointerRange> entryPointPointerRanges;
         std::vector<std::string> skipFunctions;
         std::unordered_map<uint32_t, std::string> patches;
         std::vector<std::string> stubImplementations;

--- a/ps2xRecomp/src/lib/config_manager.cpp
+++ b/ps2xRecomp/src/lib/config_manager.cpp
@@ -64,6 +64,74 @@ namespace ps2recomp
             config.patchSyscalls = toml::find_or<bool>(general, "patch_syscalls", config.patchSyscalls);
             config.patchCop0 = toml::find_or<bool>(general, "patch_cop0", config.patchCop0);
             config.patchCache = toml::find_or<bool>(general, "patch_cache", config.patchCache);
+            config.resumeEntryPointsPath = toml::find_or<std::string>(general, "resume_entry_points_file", "");
+
+            if (general.contains("entry_point_pointer_ranges") &&
+                general.at("entry_point_pointer_ranges").is_array())
+            {
+                const auto parseAddress = [](const toml::value &node, const std::string &field)
+                {
+                    const auto &value = node.at(field);
+                    if (value.is_string())
+                    {
+                        const std::string text = toml::find<std::string>(node, field);
+                        size_t consumed = 0;
+                        const unsigned long parsed = std::stoul(text, &consumed, 0);
+                        if (consumed != text.size() || parsed > std::numeric_limits<uint32_t>::max())
+                        {
+                            throw std::out_of_range(field + " is not a 32-bit address");
+                        }
+                        return static_cast<uint32_t>(parsed);
+                    }
+                    if (value.is_integer())
+                    {
+                        const int64_t parsed = toml::find<int64_t>(node, field);
+                        if (parsed < 0 || static_cast<uint64_t>(parsed) > std::numeric_limits<uint32_t>::max())
+                        {
+                            throw std::out_of_range(field + " is not a 32-bit address");
+                        }
+                        return static_cast<uint32_t>(parsed);
+                    }
+                    throw std::invalid_argument(field + " must be an integer or address string");
+                };
+
+                for (const auto &rangeNode : general.at("entry_point_pointer_ranges").as_array())
+                {
+                    if (!rangeNode.is_table() || !rangeNode.contains("source_start") ||
+                        !rangeNode.contains("source_end"))
+                    {
+                        throw std::invalid_argument(
+                            "entry_point_pointer_ranges entries require source_start and source_end");
+                    }
+
+                    EntryPointPointerRange range;
+                    range.sourceStart = parseAddress(rangeNode, "source_start");
+                    range.sourceEnd = parseAddress(rangeNode, "source_end");
+                    if (rangeNode.contains("target_start"))
+                    {
+                        range.targetStart = parseAddress(rangeNode, "target_start");
+                    }
+                    if (rangeNode.contains("target_end"))
+                    {
+                        range.targetEnd = parseAddress(rangeNode, "target_end");
+                    }
+                    range.windowWords = static_cast<uint32_t>(std::clamp<int64_t>(
+                        toml::find_or<int64_t>(rangeNode, "window_words", range.windowWords), 1, 4096));
+                    range.minimumCodePointers = static_cast<uint32_t>(std::clamp<int64_t>(
+                        toml::find_or<int64_t>(
+                            rangeNode, "minimum_code_pointers", range.minimumCodePointers),
+                        1,
+                        range.windowWords));
+
+                    if (range.sourceStart >= range.sourceEnd || range.targetStart >= range.targetEnd ||
+                        (range.sourceStart & 3u) != 0u || (range.sourceEnd & 3u) != 0u)
+                    {
+                        throw std::invalid_argument(
+                            "entry_point_pointer_ranges addresses must form aligned, non-empty ranges");
+                    }
+                    config.entryPointPointerRanges.push_back(range);
+                }
+            }
 
             if (general.contains("stubs") && general.at("stubs").is_array())
             {
@@ -274,6 +342,30 @@ namespace ps2recomp
         general["patch_syscalls"] = config.patchSyscalls;
         general["patch_cop0"] = config.patchCop0;
         general["patch_cache"] = config.patchCache;
+        general["resume_entry_points_file"] = config.resumeEntryPointsPath;
+        if (!config.entryPointPointerRanges.empty())
+        {
+            toml::array pointerRanges;
+            for (const auto &range : config.entryPointPointerRanges)
+            {
+                const auto addressString = [](uint32_t address)
+                {
+                    std::ostringstream stream;
+                    stream << "0x" << std::hex << address;
+                    return stream.str();
+                };
+
+                toml::table rangeNode;
+                rangeNode["source_start"] = addressString(range.sourceStart);
+                rangeNode["source_end"] = addressString(range.sourceEnd);
+                rangeNode["target_start"] = addressString(range.targetStart);
+                rangeNode["target_end"] = addressString(range.targetEnd);
+                rangeNode["window_words"] = static_cast<int64_t>(range.windowWords);
+                rangeNode["minimum_code_pointers"] = static_cast<int64_t>(range.minimumCodePointers);
+                pointerRanges.push_back(rangeNode);
+            }
+            general["entry_point_pointer_ranges"] = pointerRanges;
+        }
         general["skip"] = config.skipFunctions;
         general["stubs"] = config.stubImplementations;
         data["general"] = general;

--- a/ps2xRecomp/src/lib/ps2_recompiler.cpp
+++ b/ps2xRecomp/src/lib/ps2_recompiler.cpp
@@ -1883,6 +1883,147 @@ namespace ps2recomp
             }
         }
 
+        if (!m_config.resumeEntryPointsPath.empty())
+        {
+            std::ifstream manifest(m_config.resumeEntryPointsPath);
+            if (!manifest)
+            {
+                m_reporter.error(
+                    "resume-entry-manifest",
+                    "Unable to open " + m_config.resumeEntryPointsPath);
+            }
+            else
+            {
+                size_t importedTargets = 0u;
+                size_t lineNumber = 0u;
+                std::string line;
+                while (std::getline(manifest, line))
+                {
+                    ++lineNumber;
+                    const size_t comment = line.find('#');
+                    if (comment != std::string::npos)
+                    {
+                        line.erase(comment);
+                    }
+                    line.erase(std::remove_if(line.begin(), line.end(), [](unsigned char character)
+                                              { return std::isspace(character) != 0; }),
+                               line.end());
+                    if (line.empty())
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        size_t consumed = 0u;
+                        const unsigned long parsed = std::stoul(line, &consumed, 0);
+                        if (consumed != line.size() || parsed > std::numeric_limits<uint32_t>::max())
+                        {
+                            throw std::out_of_range("entry point is not a 32-bit address");
+                        }
+
+                        const uint32_t target = static_cast<uint32_t>(parsed);
+                        const Function *owner = findContainingFunction(target);
+                        if (!owner)
+                        {
+                            std::ostringstream msg;
+                            msg << "Ignoring address 0x" << std::hex << target
+                                << " on line " << std::dec << lineNumber
+                                << "; it is not decoded guest code";
+                            m_reporter.warning("resume-entry-manifest", msg.str());
+                            continue;
+                        }
+                        if (owner->start != target)
+                        {
+                            m_resumeEntryTargetsByOwner[owner->start].push_back(target);
+                            ++importedTargets;
+                        }
+                    }
+                    catch (const std::exception &exception)
+                    {
+                        std::ostringstream msg;
+                        msg << "Ignoring line " << lineNumber << ": " << exception.what();
+                        m_reporter.warning("resume-entry-manifest", msg.str());
+                    }
+                }
+
+                std::ostringstream msg;
+                msg << "imported " << importedTargets << " validated resume entry point(s)";
+                m_reporter.progress(msg.str());
+            }
+        }
+
+        for (const auto &range : m_config.entryPointPointerRanges)
+        {
+            const size_t wordCount = static_cast<size_t>((range.sourceEnd - range.sourceStart) / 4u);
+            std::vector<uint32_t> targets(wordCount, 0u);
+            std::vector<const Function *> owners(wordCount, nullptr);
+            std::vector<size_t> prefixCodePointers(wordCount + 1u, 0u);
+
+            for (size_t index = 0; index < wordCount; ++index)
+            {
+                const uint32_t address = range.sourceStart + static_cast<uint32_t>(index * 4u);
+                try
+                {
+                    const uint32_t target = m_elfParser->readWord(address);
+                    if ((target & 3u) == 0u && target >= range.targetStart && target < range.targetEnd)
+                    {
+                        if (const Function *owner = findContainingFunction(target))
+                        {
+                            targets[index] = target;
+                            owners[index] = owner;
+                        }
+                    }
+                }
+                catch (const std::exception &exception)
+                {
+                    std::ostringstream msg;
+                    msg << "Unable to read pointer source 0x" << std::hex << address
+                        << ": " << exception.what();
+                    m_reporter.warning("entry-point-pointer-range", msg.str());
+                }
+                prefixCodePointers[index + 1u] =
+                    prefixCodePointers[index] + static_cast<size_t>(owners[index] != nullptr);
+            }
+
+            std::vector<int32_t> qualifyingWindowCoverage(wordCount + 1u, 0);
+            for (size_t start = 0; start < wordCount; ++start)
+            {
+                const size_t end = std::min(wordCount, start + static_cast<size_t>(range.windowWords));
+                const size_t codePointerCount = prefixCodePointers[end] - prefixCodePointers[start];
+                if (codePointerCount >= range.minimumCodePointers)
+                {
+                    ++qualifyingWindowCoverage[start];
+                    --qualifyingWindowCoverage[end];
+                }
+            }
+
+            size_t validatedPointers = 0u;
+            size_t importedTargets = 0u;
+            int32_t activeWindows = 0;
+            for (size_t index = 0; index < wordCount; ++index)
+            {
+                activeWindows += qualifyingWindowCoverage[index];
+                if (activeWindows <= 0 || owners[index] == nullptr)
+                {
+                    continue;
+                }
+
+                ++validatedPointers;
+                if (owners[index]->start != targets[index])
+                {
+                    m_resumeEntryTargetsByOwner[owners[index]->start].push_back(targets[index]);
+                    ++importedTargets;
+                }
+            }
+
+            std::ostringstream msg;
+            msg << "validated " << validatedPointers << " clustered code pointer(s) in 0x"
+                << std::hex << range.sourceStart << "-0x" << range.sourceEnd
+                << "; imported " << std::dec << importedTargets << " internal entry point(s)";
+            m_reporter.progress(msg.str());
+        }
+
         size_t totalTargets = 0u;
         for (auto it = m_resumeEntryTargetsByOwner.begin(); it != m_resumeEntryTargetsByOwner.end();)
         {

--- a/ps2xTest/src/ps2_recompiler_tests.cpp
+++ b/ps2xTest/src/ps2_recompiler_tests.cpp
@@ -155,6 +155,80 @@ static bool writeMinimalMipsElfWithJalFallbackTarget(const std::filesystem::path
     return writer.save(elfPath.string());
 }
 
+static bool writeMinimalMipsElfWithCallbackTable(const std::filesystem::path &elfPath)
+{
+    ELFIO::elfio writer;
+    writer.create(ELFIO::ELFCLASS32, ELFIO::ELFDATA2LSB);
+    writer.set_os_abi(ELFIO::ELFOSABI_NONE);
+    writer.set_type(ELFIO::ET_EXEC);
+    writer.set_machine(ELFIO::EM_MIPS);
+    writer.set_entry(0x00100000u);
+
+    ELFIO::section *text = writer.sections.add(".text");
+    text->set_type(ELFIO::SHT_PROGBITS);
+    text->set_flags(ELFIO::SHF_ALLOC | ELFIO::SHF_EXECINSTR);
+    text->set_addr_align(4);
+    text->set_address(0x00100000u);
+    const std::array<uint32_t, 8> textWords = {
+        0x27BDFFF0u, // addiu $sp, $sp, -16
+        0x00000000u, // nop
+        0x27BDFFF0u, // interior callback entry
+        0x00000000u, // nop
+        0x03E00008u, // jr $ra
+        0x00000000u, // nop
+        0x03E00008u, // jr $ra
+        0x00000000u  // nop
+    };
+    text->set_data(reinterpret_cast<const char *>(textWords.data()),
+                   static_cast<ELFIO::Elf_Word>(textWords.size() * sizeof(uint32_t)));
+
+    ELFIO::section *data = writer.sections.add(".data");
+    data->set_type(ELFIO::SHT_PROGBITS);
+    data->set_flags(ELFIO::SHF_ALLOC | ELFIO::SHF_WRITE);
+    data->set_addr_align(4);
+    data->set_address(0x00200000u);
+    const std::array<uint32_t, 4> callbackWords = {
+        0x00100000u,
+        0x00100008u,
+        0u,
+        0u
+    };
+    data->set_data(reinterpret_cast<const char *>(callbackWords.data()),
+                   static_cast<ELFIO::Elf_Word>(callbackWords.size() * sizeof(uint32_t)));
+
+    ELFIO::section *strtab = writer.sections.add(".strtab");
+    strtab->set_type(ELFIO::SHT_STRTAB);
+    strtab->set_addr_align(1);
+
+    ELFIO::section *symtab = writer.sections.add(".symtab");
+    symtab->set_type(ELFIO::SHT_SYMTAB);
+    symtab->set_info(1);
+    symtab->set_link(strtab->get_index());
+    symtab->set_addr_align(4);
+    symtab->set_entry_size(writer.get_default_entry_size(ELFIO::SHT_SYMTAB));
+
+    ELFIO::symbol_section_accessor symbols(writer, symtab);
+    ELFIO::string_section_accessor strings(strtab);
+    symbols.add_symbol(strings, "", 0, 0,
+                       ELFIO::STB_LOCAL, ELFIO::STT_NOTYPE, 0, ELFIO::SHN_UNDEF);
+    symbols.add_symbol(strings, "merged_callbacks", text->get_address(), text->get_size(),
+                       ELFIO::STB_GLOBAL, ELFIO::STT_FUNC, 0, text->get_index());
+
+    ELFIO::segment *textSegment = writer.segments.add();
+    textSegment->set_type(ELFIO::PT_LOAD);
+    textSegment->set_flags(ELFIO::PF_R | ELFIO::PF_X);
+    textSegment->set_align(0x1000);
+    textSegment->add_section_index(text->get_index(), text->get_addr_align());
+
+    ELFIO::segment *dataSegment = writer.segments.add();
+    dataSegment->set_type(ELFIO::PT_LOAD);
+    dataSegment->set_flags(ELFIO::PF_R | ELFIO::PF_W);
+    dataSegment->set_align(0x1000);
+    dataSegment->add_section_index(data->get_index(), data->get_addr_align());
+
+    return writer.save(elfPath.string());
+}
+
 static bool writeMinimalMipsElfWithInitializer(const std::filesystem::path &elfPath,
                                                const std::string &functionName,
                                                uint32_t initializerTarget)
@@ -836,6 +910,101 @@ void register_ps2_recompiler_tests()
 
             std::error_code removeError;
             std::filesystem::remove(configPath, removeError);
+        });
+
+        tc.Run("config manager parses callable entry point sources", [](TestCase &t) {
+            const auto uniqueSuffix = std::to_string(
+                static_cast<unsigned long long>(std::chrono::steady_clock::now().time_since_epoch().count()));
+            const std::filesystem::path configPath =
+                std::filesystem::temp_directory_path() / ("ps2recomp-entry-points-" + uniqueSuffix + ".toml");
+
+            std::ofstream configFile(configPath);
+            t.IsTrue(static_cast<bool>(configFile), "temp config file should be writable");
+            if (!configFile)
+            {
+                return;
+            }
+
+            configFile << "[general]\n";
+            configFile << "input = \"dummy.elf\"\n";
+            configFile << "output = \"out\"\n";
+            configFile << "resume_entry_points_file = \"entries.txt\"\n";
+            configFile << "entry_point_pointer_ranges = [\n";
+            configFile << "  { source_start = \"0x200000\", source_end = 0x200020, "
+                          "target_start = \"0x100000\", target_end = \"0x180000\", "
+                          "window_words = 6, minimum_code_pointers = 3 }\n";
+            configFile << "]\n";
+            configFile.close();
+
+            ConfigManager manager(configPath.string());
+            RecompilerConfig config = manager.loadConfig();
+
+            t.Equals(config.resumeEntryPointsPath, std::string{"entries.txt"},
+                     "resume entry manifest path should parse");
+            t.Equals(config.entryPointPointerRanges.size(), static_cast<size_t>(1),
+                     "one pointer range should parse");
+            if (!config.entryPointPointerRanges.empty())
+            {
+                const EntryPointPointerRange &range = config.entryPointPointerRanges.front();
+                t.Equals(range.sourceStart, 0x00200000u, "source start should parse");
+                t.Equals(range.sourceEnd, 0x00200020u, "source end should parse");
+                t.Equals(range.targetStart, 0x00100000u, "target start should parse");
+                t.Equals(range.targetEnd, 0x00180000u, "target end should parse");
+                t.Equals(range.windowWords, 6u, "window size should parse");
+                t.Equals(range.minimumCodePointers, 3u, "minimum pointer count should parse");
+            }
+
+            std::error_code removeError;
+            std::filesystem::remove(configPath, removeError);
+        });
+
+        tc.Run("clustered callback pointers register interior callable entries", [](TestCase &t) {
+            const std::string uniqueSuffix =
+                std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+            const std::filesystem::path tempRoot =
+                std::filesystem::temp_directory_path() / ("ps2recomp-callback-table-" + uniqueSuffix);
+            const std::filesystem::path elfPath = tempRoot / "callbacks.elf";
+            const std::filesystem::path configPath = tempRoot / "callbacks.toml";
+            const std::filesystem::path outputPath = tempRoot / "output";
+            std::filesystem::create_directories(tempRoot);
+
+            const bool elfWritten = writeMinimalMipsElfWithCallbackTable(elfPath);
+            std::ofstream configFile(configPath);
+            if (configFile)
+            {
+                configFile << "[general]\n";
+                configFile << "input = \"" << elfPath.generic_string() << "\"\n";
+                configFile << "output = \"" << outputPath.generic_string() << "\"\n";
+                configFile << "entry_point_pointer_ranges = [\n";
+                configFile << "  { source_start = \"0x200000\", source_end = \"0x200010\", "
+                              "target_start = \"0x100000\", target_end = \"0x100020\", "
+                              "window_words = 4, minimum_code_pointers = 2 }\n";
+                configFile << "]\n";
+            }
+            configFile.close();
+
+            t.IsTrue(elfWritten && std::filesystem::exists(configPath),
+                     "callback-table regression inputs should be generated");
+            if (elfWritten && std::filesystem::exists(configPath))
+            {
+                PS2Recompiler recompiler(configPath.string());
+                t.IsTrue(recompiler.initialize(), "callback-table config should initialize");
+                t.IsTrue(recompiler.recompile(), "callback-table fixture should recompile");
+                recompiler.generateOutput();
+                t.Equals(recompiler.reportCounters().additionalEntryPoints, static_cast<size_t>(1u),
+                         "one interior callback entry should be registered");
+
+                const std::filesystem::path registrationPath = outputPath / "register_functions.cpp";
+                std::ifstream registrationFile(registrationPath);
+                const std::string registration(
+                    (std::istreambuf_iterator<char>(registrationFile)),
+                    std::istreambuf_iterator<char>());
+                t.IsTrue(registration.find("// 0x100008") != std::string::npos,
+                         "generated function table should expose the interior callback entry");
+            }
+
+            std::error_code removeError;
+            std::filesystem::remove_all(tempRoot, removeError);
         });
 
         tc.Run("elf parser ignores STT_FUNC symbols in non-executable sections", [](TestCase &t) {


### PR DESCRIPTION
## Summary
- add an optional `resume_entry_points_file` manifest for known callable interior PCs
- add opt-in `entry_point_pointer_ranges` scanning for clustered function pointers in stripped binaries
- validate every imported target against decoded executable instructions and register it through its owning function wrapper
- document the configuration and cover parsing plus end-to-end generated registration

## Why
Stripped PS2 ELFs and analysis maps can merge callback implementations into a larger discovered function. Their data tables still contain the real callable PCs, but indirect runtime dispatch cannot reach those interior addresses unless the recompiler exposes them as resume entries. This keeps the heuristic narrowly opt-in and range-bounded while allowing projects to supply exact manifests when available.

## Testing
- Release build: `cmake --build out/build --config Release --target ps2x_tests -- /m:4 /nodeReuse:false`
- `ps2x_tests.exe`: 427 passed, 0 failed