### PR TITLE
Delay and coalesce GIF DMA completion interrupts

### DIFF
--- a/ps2xRuntime/include/ps2_syscalls.h
+++ b/ps2xRuntime/include/ps2_syscalls.h
@@ -26,7 +26,8 @@ namespace ps2_syscalls
     void DisableDmacHandler(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime);
 
     bool dispatchNumericSyscall(uint32_t syscallNumber, uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime);
-    void dispatchDmacHandlersForCause(uint8_t *rdram, PS2Runtime *runtime, uint32_t cause);
+    void dispatchDmacHandlersForCause(uint8_t *rdram, PS2Runtime *runtime, uint32_t cause,
+                                      uint64_t delayCycles = 0);
     void initializeGuestKernelState(uint8_t *rdram, PS2Runtime *runtime);
     void TODO(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime, uint32_t encodedSyscallId);
     uint64_t GetCurrentVSyncTick(PS2Runtime *runtime);

--- a/ps2xRuntime/include/runtime/ee_scheduler.h
+++ b/ps2xRuntime/include/runtime/ee_scheduler.h
@@ -327,6 +327,8 @@ public:
     int setIrqHandlerEnabled(bool dmac, int id, bool enabled);
     int setIrqCauseEnabled(bool dmac, uint32_t cause, bool enabled);
     void dispatchIrq(bool dmac, uint32_t cause);
+    void scheduleDmacIrq(uint32_t cause, uint64_t delayCycles);
+    [[nodiscard]] uint64_t currentEeCycle() const noexcept;
     void setVSyncFlag(uint32_t flagAddress, uint32_t tickAddress);
     [[nodiscard]] uint64_t currentVSyncTick() const noexcept;
     uint32_t setGsVSyncCallback(uint32_t callback, uint32_t gp, uint32_t sp);

--- a/ps2xRuntime/include/runtime/ps2_memory.h
+++ b/ps2xRuntime/include/runtime/ps2_memory.h
@@ -261,6 +261,12 @@ struct JumpTable
 class PS2Memory
 {
 public:
+    struct DmacCompletion
+    {
+        uint32_t cause = 0;
+        uint64_t delayCycles = 0;
+    };
+
     PS2Memory();
     ~PS2Memory();
 
@@ -344,7 +350,7 @@ public:
     void processVIF1Data(uint32_t srcPhysAddr, uint32_t sizeBytes);
     void processVIF1Data(const uint8_t *data, uint32_t sizeBytes);
     void processPendingTransfers();
-    std::vector<uint32_t> consumeCompletedDmacCauses();
+    std::vector<DmacCompletion> consumeCompletedDmacCauses();
 
     int pollDmaRegisters();
 
@@ -416,13 +422,14 @@ public:
         bool fromScratchpad = false;
         uint32_t srcAddr = 0;
         uint32_t qwc = 0;
+        uint32_t dmaTagCount = 0;
         std::vector<uint8_t> chainData;
     };
     std::vector<PendingTransfer> m_pendingGifTransfers;
     std::vector<PendingTransfer> m_pendingVif0Transfers;
     std::vector<PendingTransfer> m_pendingVif1Transfers;
     std::mutex m_completedDmacMutex;
-    std::vector<uint32_t> m_completedDmacCauses;
+    std::vector<DmacCompletion> m_completedDmacCauses;
 
     struct CodeRegion
     {
@@ -449,7 +456,7 @@ public:
     };
 
     std::array<EeTimer, 4> m_eeTimers{};
-    void queueCompletedDmacCause(uint32_t cause);
+    void queueCompletedDmacCause(uint32_t cause, uint64_t delayCycles = 0);
 };
 
 #endif // PS2_MEMORY_H

--- a/ps2xRuntime/src/lib/Kernel/EeScheduler.cpp
+++ b/ps2xRuntime/src/lib/Kernel/EeScheduler.cpp
@@ -1288,9 +1288,30 @@ void EeScheduler::scheduleDmacIrq(uint32_t cause, uint64_t delayCycles)
 {
     assertExecutor();
     const uint64_t delay = std::max<uint64_t>(delayCycles, 1u);
-    scheduleEvent(m_eeCycle + delay,
-                  std::chrono::steady_clock::now() + eeCyclesToHostDuration(delay),
-                  EeEvent{EeEventType::Dmac, cause, 0u});
+    const uint64_t deadlineCycle = m_eeCycle + delay;
+    const auto hostDeadline = std::chrono::steady_clock::now() + eeCyclesToHostDuration(delay);
+    {
+        std::lock_guard lock(m_eventMutex);
+        // Each DMAC cause is a latched status bit, not a queue of completions.
+        const auto pending = std::find_if(m_deadlines.begin(), m_deadlines.end(),
+                                          [cause](const ScheduledEvent &item)
+                                          {
+                                              return item.event.type == EeEventType::Dmac &&
+                                                     item.event.id == cause;
+                                          });
+        if (pending != m_deadlines.end())
+        {
+            return;
+        }
+        m_deadlines.push_back(ScheduledEvent{
+            deadlineCycle,
+            hostDeadline,
+            EeEvent{EeEventType::Dmac, cause, 0u},
+            ++m_eventSequence,
+        });
+        updateNextDeadline();
+    }
+    m_eventCv.notify_one();
 }
 
 uint64_t EeScheduler::currentEeCycle() const noexcept

--- a/ps2xRuntime/src/lib/Kernel/EeScheduler.cpp
+++ b/ps2xRuntime/src/lib/Kernel/EeScheduler.cpp
@@ -1284,6 +1284,20 @@ void EeScheduler::dispatchIrq(bool dmac, uint32_t cause)
     }
 }
 
+void EeScheduler::scheduleDmacIrq(uint32_t cause, uint64_t delayCycles)
+{
+    assertExecutor();
+    const uint64_t delay = std::max<uint64_t>(delayCycles, 1u);
+    scheduleEvent(m_eeCycle + delay,
+                  std::chrono::steady_clock::now() + eeCyclesToHostDuration(delay),
+                  EeEvent{EeEventType::Dmac, cause, 0u});
+}
+
+uint64_t EeScheduler::currentEeCycle() const noexcept
+{
+    return m_eeCycle;
+}
+
 void EeScheduler::setVSyncFlag(uint32_t flagAddress, uint32_t tickAddress)
 {
     assertExecutor();
@@ -1901,6 +1915,7 @@ void EeScheduler::processEvent(const EeEvent &event)
         dispatchIrq(false, 3u);
         break;
     case EeEventType::Dmac:
+        dispatchIrq(true, event.id);
         break;
     case EeEventType::Alarm:
     {

--- a/ps2xRuntime/src/lib/Kernel/Stubs/Helpers/Support.h
+++ b/ps2xRuntime/src/lib/Kernel/Stubs/Helpers/Support.h
@@ -1379,20 +1379,20 @@ namespace
         mem.writeIORegister(channelBase + 0x00u, chcr);
         mem.processPendingTransfers();
 
-        std::vector<uint32_t> completedCauses = mem.consumeCompletedDmacCauses();
+        std::vector<PS2Memory::DmacCompletion> completedCauses = mem.consumeCompletedDmacCauses();
         if (completedCauses.empty() && (mem.readIORegister(channelBase + 0x00u) & 0x100u) == 0u)
         {
             if (channelBase == 0x10008000u)
             {
-                completedCauses.push_back(0u);
+                completedCauses.push_back({0u, 0u});
             }
             else if (channelBase == 0x10009000u)
             {
-                completedCauses.push_back(1u);
+                completedCauses.push_back({1u, 0u});
             }
             else if (channelBase == 0x1000A000u)
             {
-                completedCauses.push_back(2u);
+                completedCauses.push_back({2u, 0u});
             }
         }
 
@@ -1431,9 +1431,10 @@ namespace
             }
         }
 
-        for (const uint32_t completedCause : completedCauses)
+        for (const PS2Memory::DmacCompletion completion : completedCauses)
         {
-            ps2_syscalls::dispatchDmacHandlersForCause(rdram, runtime, completedCause);
+            ps2_syscalls::dispatchDmacHandlersForCause(rdram, runtime, completion.cause,
+                                                       completion.delayCycles);
         }
 
         return 0;

--- a/ps2xRuntime/src/lib/Kernel/Syscalls/Interrupt.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Syscalls/Interrupt.cpp
@@ -65,9 +65,13 @@ namespace ps2_syscalls
         }
     }
 
-    void dispatchDmacHandlersForCause(uint8_t *, PS2Runtime *runtime, uint32_t cause)
+    void dispatchDmacHandlersForCause(uint8_t *, PS2Runtime *runtime, uint32_t cause,
+                                      uint64_t delayCycles)
     {
-        runtime->eeScheduler().dispatchIrq(true, cause);
+        if (delayCycles != 0u)
+            runtime->eeScheduler().scheduleDmacIrq(cause, delayCycles);
+        else
+            runtime->eeScheduler().dispatchIrq(true, cause);
     }
 
     uint64_t GetCurrentVSyncTick(PS2Runtime *runtime)

--- a/ps2xRuntime/src/lib/Kernel/Syscalls/Interrupt.h
+++ b/ps2xRuntime/src/lib/Kernel/Syscalls/Interrupt.h
@@ -4,7 +4,8 @@
 
 namespace ps2_syscalls
 {
-    void dispatchDmacHandlersForCause(uint8_t *rdram, PS2Runtime *runtime, uint32_t cause);
+    void dispatchDmacHandlersForCause(uint8_t *rdram, PS2Runtime *runtime, uint32_t cause,
+                                      uint64_t delayCycles);
     uint64_t GetCurrentVSyncTick(PS2Runtime *runtime);
     void WaitVSyncTick(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime, int fixedResult);
     void SetVSyncFlag(uint8_t *rdram, R5900Context *ctx, PS2Runtime *runtime);

--- a/ps2xRuntime/src/lib/ps2_memory.cpp
+++ b/ps2xRuntime/src/lib/ps2_memory.cpp
@@ -12,6 +12,20 @@
 
 namespace
 {
+    constexpr uint64_t gifDmacCompletionCycles(uint64_t qwc, uint64_t tagCount)
+    {
+        constexpr uint64_t kBusCyclesPerQword = 2u;
+        constexpr uint64_t kCyclesPerTag = 2u;
+        constexpr uint64_t kTerminalCycles = 16u;
+        // Generated guest code accounts time in coarse checkpoints. Keep short
+        // GIF transfers asynchronous long enough for chained packet producers
+        // to reach a checkpoint before their completion handler can run.
+        constexpr uint64_t kMinimumCompletionCycles = 1024u;
+        const uint64_t transferCycles =
+            qwc * kBusCyclesPerQword + tagCount * kCyclesPerTag + kTerminalCycles;
+        return std::max(transferCycles, kMinimumCompletionCycles);
+    }
+
     inline void inRange(uint32_t offset, size_t bytes, size_t regionSize, const char *op, uint32_t address)
     {
         if (static_cast<uint64_t>(offset) + static_cast<uint64_t>(bytes) > static_cast<uint64_t>(regionSize))
@@ -1509,6 +1523,7 @@ bool PS2Memory::writeIORegister(uint32_t address, uint32_t value)
                         pt.fromScratchpad = false;
                         pt.srcAddr = 0;
                         pt.qwc = 0;
+                        pt.dmaTagCount = static_cast<uint32_t>(tagsProcessed);
                         pt.chainData = std::move(chainBuf);
                         if (channelBase == 0x1000A000)
                         {
@@ -1562,17 +1577,22 @@ bool PS2Memory::writeIORegister(uint32_t address, uint32_t value)
 void PS2Memory::processPendingTransfers()
 {
     const bool hadGif = !m_pendingGifTransfers.empty();
+    uint64_t gifTransferQwc = 0u;
+    uint64_t gifDmaTagCount = 0u;
     for (size_t idx = 0; idx < m_pendingGifTransfers.size(); ++idx)
     {
         auto &p = m_pendingGifTransfers[idx];
+        gifDmaTagCount += p.dmaTagCount;
         if (!p.chainData.empty())
         {
+            gifTransferQwc += (p.chainData.size() + 15u) / 16u;
             m_seenGifCopy = true;
             m_gifCopyCount.fetch_add(1, std::memory_order_relaxed);
             submitGifPacket(GifPathId::Path3, p.chainData.data(), static_cast<uint32_t>(p.chainData.size()), false);
         }
         else if (p.qwc > 0)
         {
+            gifTransferQwc += p.qwc;
             const uint64_t bytes64 = static_cast<uint64_t>(p.qwc) * 16ull;
             uint32_t sizeBytes = (bytes64 > 0xFFFFFFFFull) ? 0xFFFFFFFFu : static_cast<uint32_t>(bytes64);
             uint32_t srcPhys = 0;
@@ -1768,7 +1788,7 @@ void PS2Memory::processPendingTransfers()
     if (hadGif)
     {
         raiseDStatChannel(2u); // GIF channel
-        queueCompletedDmacCause(2u);
+        queueCompletedDmacCause(2u, gifDmacCompletionCycles(gifTransferQwc, gifDmaTagCount));
         m_ioRegisters[GIF_CHANNEL + 0x00] &= ~0x100u;
         m_ioRegisters[GIF_CHANNEL + 0x20] = 0;
     }
@@ -1788,16 +1808,16 @@ void PS2Memory::processPendingTransfers()
     }
 }
 
-void PS2Memory::queueCompletedDmacCause(uint32_t cause)
+void PS2Memory::queueCompletedDmacCause(uint32_t cause, uint64_t delayCycles)
 {
     std::lock_guard<std::mutex> lock(m_completedDmacMutex);
-    m_completedDmacCauses.push_back(cause);
+    m_completedDmacCauses.push_back(DmacCompletion{cause, delayCycles});
 }
 
-std::vector<uint32_t> PS2Memory::consumeCompletedDmacCauses()
+std::vector<PS2Memory::DmacCompletion> PS2Memory::consumeCompletedDmacCauses()
 {
     std::lock_guard<std::mutex> lock(m_completedDmacMutex);
-    std::vector<uint32_t> causes;
+    std::vector<DmacCompletion> causes;
     causes.swap(m_completedDmacCauses);
     return causes;
 }
@@ -2072,7 +2092,9 @@ bool PS2Memory::tryProcessNativeGifImageUploadChain(GS &gs, uint32_t tadr, uint3
     else
         dstat &= ~(1u << 31u);
     m_ioRegisters[D_STAT] = dstat;
-    queueCompletedDmacCause(2u);
+    const uint64_t transferredQwc = 5u + 1u + imageQwc;
+    const uint64_t dmaTagCount = (payloadTag.id == 7u) ? 3u : 4u;
+    queueCompletedDmacCause(2u, gifDmacCompletionCycles(transferredQwc, dmaTagCount));
     return true;
 }
 
@@ -2152,7 +2174,7 @@ bool PS2Memory::tryProcessNativeGifPackedChain(GS &gs, uint32_t tadr, uint32_t c
     else
         dstat &= ~(1u << 31u);
     m_ioRegisters[D_STAT] = dstat;
-    queueCompletedDmacCause(2u);
+    queueCompletedDmacCause(2u, gifDmacCompletionCycles(tag.qwc, 1u));
     return true;
 }
 

--- a/ps2xRuntime/src/lib/ps2_runtime.cpp
+++ b/ps2xRuntime/src/lib/ps2_runtime.cpp
@@ -1445,9 +1445,10 @@ void PS2Runtime::handleBreak(uint8_t *rdram, R5900Context *ctx)
 
 void PS2Runtime::drainCompletedDmacHandlers(uint8_t *rdram)
 {
-    for (uint32_t cause : m_memory.consumeCompletedDmacCauses())
+    for (const PS2Memory::DmacCompletion completion : m_memory.consumeCompletedDmacCauses())
     {
-        ps2_syscalls::dispatchDmacHandlersForCause(rdram, this, cause);
+        ps2_syscalls::dispatchDmacHandlersForCause(rdram, this, completion.cause,
+                                                   completion.delayCycles);
     }
 }
 

--- a/ps2xTest/src/ps2_memory_tests.cpp
+++ b/ps2xTest/src/ps2_memory_tests.cpp
@@ -1006,6 +1006,49 @@ void register_ps2_memory_tests()
             t.Equals(mem.gifCopyCount(), 1ull, "GIF DMA should increment gifCopyCount");
             t.IsTrue((mem.readIORegister(kGifCh + 0x00u) & 0x100u) == 0u, "GIF CHCR STR bit should be cleared after drain");
             t.Equals(mem.readIORegister(kGifCh + 0x20u), 0u, "GIF QWC should be cleared after drain");
+
+            const std::vector<PS2Memory::DmacCompletion> completions =
+                mem.consumeCompletedDmacCauses();
+            t.Equals(completions.size(), static_cast<size_t>(1u),
+                     "GIF DMA should queue one completion");
+            if (!completions.empty())
+            {
+                t.Equals(completions[0].cause, 2u,
+                         "GIF DMA completion should identify the GIF channel");
+                t.Equals(completions[0].delayCycles, 1024ull,
+                         "short GIF DMA should use the minimum asynchronous completion delay");
+            }
+        });
+
+        tc.Run("GIF DMA completion delay scales beyond the asynchronous floor", [](TestCase &t)
+        {
+            PS2Memory mem;
+            t.IsTrue(mem.initialize(), "PS2Memory initialize should succeed");
+
+            constexpr uint32_t kGifCh = 0x1000A000u;
+            constexpr uint32_t kSrc = 0x00024000u;
+            constexpr uint32_t kQwc = 600u;
+
+            uint8_t *rdram = mem.getRDRAM();
+            std::memset(rdram + kSrc, 0, kQwc * 16u);
+
+            t.IsTrue(mem.writeIORegister(kGifCh + 0x10u, kSrc), "write MADR should succeed");
+            t.IsTrue(mem.writeIORegister(kGifCh + 0x20u, kQwc), "write QWC should succeed");
+            t.IsTrue(mem.writeIORegister(kGifCh + 0x00u, 0x100u), "write CHCR STR should succeed");
+
+            mem.processPendingTransfers();
+
+            const std::vector<PS2Memory::DmacCompletion> completions =
+                mem.consumeCompletedDmacCauses();
+            t.Equals(completions.size(), static_cast<size_t>(1u),
+                     "large GIF DMA should queue one completion");
+            if (!completions.empty())
+            {
+                t.Equals(completions[0].cause, 2u,
+                         "large GIF DMA completion should identify the GIF channel");
+                t.Equals(completions[0].delayCycles, 1216ull,
+                         "large GIF DMA delay should include payload and terminal cycles");
+            }
         });
 
         tc.Run("GIF DMA can source from scratchpad", [](TestCase &t)

--- a/ps2xTest/src/ps2_runtime_interrupt_tests.cpp
+++ b/ps2xTest/src/ps2_runtime_interrupt_tests.cpp
@@ -65,6 +65,9 @@ namespace
     constexpr uint32_t kDelayedDmacWaitPc = 0x00160600u;
     constexpr uint32_t kDelayedDmacResumePc = 0x00160610u;
     constexpr uint32_t kDelayedDmacHandlerPc = 0x00160620u;
+    constexpr uint32_t kCoalescedDmacWaitPc = 0x00160700u;
+    constexpr uint32_t kCoalescedDmacResumePc = 0x00160710u;
+    constexpr uint32_t kCoalescedDmacHandlerPc = 0x00160720u;
 
     constexpr uint32_t kTimer2Count = 0x10001000u;
     constexpr uint32_t kTimer2Mode = 0x10001010u;
@@ -88,6 +91,10 @@ namespace
     std::atomic<bool> g_timer2Resumed{false};
     uint64_t g_delayedDmacStartCycle = 0u;
     uint64_t g_delayedDmacHandlerCycle = 0u;
+    uint32_t g_coalescedDmacCalls = 0u;
+    uint32_t g_independentDmacCalls = 0u;
+    uint64_t g_coalescedDmacStartCycle = 0u;
+    uint64_t g_coalescedDmacHandlerCycle = 0u;
 
     void setRegU32(R5900Context &ctx, int reg, uint32_t value)
     {
@@ -326,6 +333,44 @@ namespace
         ctx->pc = 0u;
         runtime->requestStop();
     }
+    void schedulerCoalescedDmacHandler(uint8_t *, R5900Context *ctx, PS2Runtime *runtime)
+    {
+        const uint32_t cause = getRegU32(ctx, 4);
+        if (cause == 8u)
+        {
+            ++g_coalescedDmacCalls;
+            if (g_coalescedDmacHandlerCycle == 0u)
+            {
+                g_coalescedDmacHandlerCycle = runtime->eeScheduler().currentEeCycle();
+            }
+        }
+        else if (cause == 9u)
+        {
+            ++g_independentDmacCalls;
+            runtime->eeScheduler().signalSemaphore(g_testSemaphoreId, true);
+        }
+        ctx->pc = 0u;
+    }
+
+    void schedulerCoalescedDmacWait(uint8_t *, R5900Context *ctx, PS2Runtime *runtime)
+    {
+        EeScheduler &scheduler = runtime->eeScheduler();
+        g_testSemaphoreId = scheduler.createSemaphore(0, 1, 0u, 0u);
+        scheduler.addIrqHandler(true, 8u, kCoalescedDmacHandlerPc, true, 0u, 0u, 0u);
+        scheduler.addIrqHandler(true, 9u, kCoalescedDmacHandlerPc, true, 0u, 0u, 0u);
+        g_coalescedDmacStartCycle = scheduler.currentEeCycle();
+        scheduler.scheduleDmacIrq(8u, 1024u);
+        scheduler.scheduleDmacIrq(8u, 2048u);
+        scheduler.scheduleDmacIrq(9u, 3072u);
+        ctx->pc = kCoalescedDmacResumePc;
+        scheduler.waitSemaphore(g_testSemaphoreId);
+    }
+
+    void schedulerCoalescedDmacResume(uint8_t *, R5900Context *ctx, PS2Runtime *runtime)
+    {
+        ctx->pc = 0u;
+        runtime->requestStop();
+    }
 }
 
 void register_ps2_runtime_interrupt_tests()
@@ -519,6 +564,31 @@ void register_ps2_runtime_interrupt_tests()
                      "scheduled DMAC IRQ should run its handler before resuming the waiter");
             t.IsTrue(g_delayedDmacHandlerCycle >= g_delayedDmacStartCycle + 1024u,
                      "DMAC handler must not run before its requested EE cycle deadline");
+        });
+
+        tc.Run("pending DMAC causes coalesce independently", [](TestCase &t)
+        {
+            TestEnv env;
+            env.runtime.registerFunction(kCoalescedDmacWaitPc, schedulerCoalescedDmacWait);
+            env.runtime.registerFunction(kCoalescedDmacResumePc, schedulerCoalescedDmacResume);
+            env.runtime.registerFunction(kCoalescedDmacHandlerPc, schedulerCoalescedDmacHandler);
+
+            g_coalescedDmacCalls = 0u;
+            g_independentDmacCalls = 0u;
+            g_coalescedDmacStartCycle = 0u;
+            g_coalescedDmacHandlerCycle = 0u;
+            R5900Context mainContext{};
+            mainContext.pc = kCoalescedDmacWaitPc;
+            env.runtime.eeScheduler().reset(env.rdram.data(), mainContext);
+            env.runtime.eeScheduler().run();
+
+            t.Equals(g_coalescedDmacCalls, 1u,
+                     "multiple pending completions for one DMAC cause should dispatch once");
+            t.Equals(g_independentDmacCalls, 1u,
+                     "a pending completion for another DMAC cause should remain independent");
+            t.IsTrue(g_coalescedDmacHandlerCycle >= g_coalescedDmacStartCycle + 1024u &&
+                         g_coalescedDmacHandlerCycle < g_coalescedDmacStartCycle + 2048u,
+                     "coalescing should preserve the earliest completion deadline");
         });
 
         tc.Run("iSignalSema defers selection until IRQ return", [](TestCase &t)

--- a/ps2xTest/src/ps2_runtime_interrupt_tests.cpp
+++ b/ps2xTest/src/ps2_runtime_interrupt_tests.cpp
@@ -62,6 +62,9 @@ namespace
     constexpr uint32_t kTimer2WaitPc = 0x00160500u;
     constexpr uint32_t kTimer2ResumePc = 0x00160510u;
     constexpr uint32_t kTimer2HandlerPc = 0x00160520u;
+    constexpr uint32_t kDelayedDmacWaitPc = 0x00160600u;
+    constexpr uint32_t kDelayedDmacResumePc = 0x00160610u;
+    constexpr uint32_t kDelayedDmacHandlerPc = 0x00160620u;
 
     constexpr uint32_t kTimer2Count = 0x10001000u;
     constexpr uint32_t kTimer2Mode = 0x10001010u;
@@ -83,6 +86,8 @@ namespace
     uint64_t g_vsyncTick = 0;
     uint64_t g_vsyncCsr = 0;
     std::atomic<bool> g_timer2Resumed{false};
+    uint64_t g_delayedDmacStartCycle = 0u;
+    uint64_t g_delayedDmacHandlerCycle = 0u;
 
     void setRegU32(R5900Context &ctx, int reg, uint32_t value)
     {
@@ -294,6 +299,33 @@ namespace
         ctx->pc = 0u;
         runtime->requestStop();
     }
+
+    void schedulerDelayedDmacHandler(uint8_t *, R5900Context *ctx, PS2Runtime *runtime)
+    {
+        g_dispatchTrace.push_back(2);
+        g_delayedDmacHandlerCycle = runtime->eeScheduler().currentEeCycle();
+        runtime->eeScheduler().signalSemaphore(g_testSemaphoreId, true);
+        ctx->pc = 0u;
+    }
+
+    void schedulerDelayedDmacWait(uint8_t *, R5900Context *ctx, PS2Runtime *runtime)
+    {
+        g_dispatchTrace.push_back(1);
+        EeScheduler &scheduler = runtime->eeScheduler();
+        g_testSemaphoreId = scheduler.createSemaphore(0, 1, 0u, 0u);
+        scheduler.addIrqHandler(true, 8u, kDelayedDmacHandlerPc, true, 0u, 0u, 0u);
+        g_delayedDmacStartCycle = scheduler.currentEeCycle();
+        scheduler.scheduleDmacIrq(8u, 1024u);
+        ctx->pc = kDelayedDmacResumePc;
+        scheduler.waitSemaphore(g_testSemaphoreId);
+    }
+
+    void schedulerDelayedDmacResume(uint8_t *, R5900Context *ctx, PS2Runtime *runtime)
+    {
+        g_dispatchTrace.push_back(3);
+        ctx->pc = 0u;
+        runtime->requestStop();
+    }
 }
 
 void register_ps2_runtime_interrupt_tests()
@@ -465,6 +497,28 @@ void register_ps2_runtime_interrupt_tests()
                      "the dispatcher should run wait, IRQ frame, then the resumed base context in exact order");
             t.Equals(g_lastIntcArg.load(std::memory_order_relaxed), 0xCAFEu,
                      "the IRQ frame should receive its registered argument");
+        });
+
+        tc.Run("scheduled DMAC IRQ waits for its EE cycle deadline", [](TestCase &t)
+        {
+            TestEnv env;
+            env.runtime.registerFunction(kDelayedDmacWaitPc, schedulerDelayedDmacWait);
+            env.runtime.registerFunction(kDelayedDmacResumePc, schedulerDelayedDmacResume);
+            env.runtime.registerFunction(kDelayedDmacHandlerPc, schedulerDelayedDmacHandler);
+
+            g_dispatchTrace.clear();
+            g_delayedDmacStartCycle = 0u;
+            g_delayedDmacHandlerCycle = 0u;
+            R5900Context mainContext{};
+            mainContext.pc = kDelayedDmacWaitPc;
+            env.runtime.eeScheduler().reset(env.rdram.data(), mainContext);
+            env.runtime.eeScheduler().run();
+
+            const std::vector<int> expected{1, 2, 3};
+            t.IsTrue(g_dispatchTrace == expected,
+                     "scheduled DMAC IRQ should run its handler before resuming the waiter");
+            t.IsTrue(g_delayedDmacHandlerCycle >= g_delayedDmacStartCycle + 1024u,
+                     "DMAC handler must not run before its requested EE cycle deadline");
         });
 
         tc.Run("iSignalSema defers selection until IRQ return", [](TestCase &t)


### PR DESCRIPTION
## Summary
- Schedule GIF DMA completion interrupts on the EE scheduler instead of dispatching them synchronously.
- Model completion latency from transferred QWC and DMA-tag count, with a minimum delay for the runtime's coarse generated-code checkpoints.
- Coalesce multiple pending completions for the same DMAC cause while preserving events for other channels.
- Preserve the existing immediate completion behavior for non-GIF DMA channels.

The transfer-rate terms follow the same broad timing shape used by PCSX2 (2 bus cycles per QW, 2 cycles per tag, plus terminal latency). The 1024-cycle floor keeps short transfers asynchronous in PS2Recomp's current 32-cycle checkpoint model; without it, completion handlers can overtake guest packet producers.

A DMAC cause behaves as one latched status bit rather than a queue. If another completion is scheduled while the same cause is already pending, the first event remains authoritative and only one handler dispatch occurs.

## Validation
- `PS2RuntimeInterrupt`: **12 passed, 0 failed**, including delayed-deadline and same-cause coalescing regressions.
- X-Men Legends regression: a startup/reset completion and the first ring-buffer completion no longer dispatch as two queued GIF interrupts. The game now submits its own previously skipped texture packet and reaches a clean, complete 3D title scene without a game-specific texture repair.
- Runtime framebuffer checkpoint at the settled title is deterministic across the original discovery run and the final first-pending implementation (`0799F698202E3F23F195F04C21996D2431B2169CBA3C0C2AD86E2D769B6FF363`).