### PR TITLE
Preserve framebuffer rows in interlaced presentation

### DIFF
--- a/ps2xRuntime/src/lib/gs/gs_cpu_backend.cpp
+++ b/ps2xRuntime/src/lib/gs/gs_cpu_backend.cpp
@@ -409,33 +409,6 @@ namespace
             static_cast<uint8_t>((pmode64 >> 8) & 0xFFu)};
     }
 
-    struct GSSmode2State
-    {
-        bool interlaced = false;
-        bool frameMode = true;
-    };
-
-    GSSmode2State decodeSMode2(uint64_t smode2)
-    {
-        return {(smode2 & 0x1ull) != 0ull, ((smode2 >> 1) & 0x1ull) != 0ull};
-    }
-
-    void applyFieldPresentation(std::vector<uint8_t> &pixels, uint32_t width, uint32_t height, bool oddField)
-    {
-        if (pixels.empty() || width == 0u || height < 2u)
-            return;
-        const std::vector<uint8_t> source = pixels;
-        for (uint32_t y = 0; y < height; ++y)
-        {
-            uint32_t sourceY = ((y >> 1u) << 1u) + (oddField ? 1u : 0u);
-            if (sourceY >= height)
-                sourceY = height - 1u;
-            std::memcpy(pixels.data() + y * kHostFrameWidth * 4u,
-                        source.data() + sourceY * kHostFrameWidth * 4u,
-                        width * 4u);
-        }
-    }
-
     void normalizePresentationAlpha(std::vector<uint8_t> &pixels, uint32_t width, uint32_t height)
     {
         for (uint32_t y = 0; y < height; ++y)
@@ -1775,9 +1748,6 @@ PresentationFrame GSCpuBackend::PresentFromLocalMemory(const GSPresentationReque
 {
     PresentationFrame result{};
     const GSPmodeState pmode = decodePmode(request.pmode);
-    const GSSmode2State smode2 = decodeSMode2(request.smode2);
-    const bool fieldMode = smode2.interlaced && !smode2.frameMode;
-    const bool oddField = (request.vsyncTick & 1ull) != 0ull;
     const GSFrameReg displayFrame1 = decodeDisplayFrame(request.dispfb1);
     const GSFrameReg displayFrame2 = decodeDisplayFrame(request.dispfb2);
     const GSDisplayReadOrigin origin1 = decodeDisplayReadOrigin(request.dispfb1);
@@ -1870,8 +1840,6 @@ PresentationFrame GSCpuBackend::PresentFromLocalMemory(const GSPresentationReque
                     dst[3] = pmode.amod ? dst[3] : src[3];
                 }
             normalizePresentationAlpha(result.pixels, result.width, result.height);
-            if (fieldMode)
-                applyFieldPresentation(result.pixels, result.width, result.height, oddField);
             result.displayFbp = displayFrame1.fbp;
             result.sourceFbp = selected1.fbp;
             return result;
@@ -1885,8 +1853,6 @@ PresentationFrame GSCpuBackend::PresentFromLocalMemory(const GSPresentationReque
     GSFrameReg selected = displayFrame;
     if (!copySource(displayFrame, origin, result.width, result.height, true, false, selected, result.pixels, result.usedPreferred))
         return {};
-    if (fieldMode)
-        applyFieldPresentation(result.pixels, result.width, result.height, oddField);
     normalizePresentationAlpha(result.pixels, result.width, result.height);
     result.displayFbp = displayFrame.fbp;
     result.sourceFbp = selected.fbp;

--- a/ps2xTest/src/ps2_gs_tests.cpp
+++ b/ps2xTest/src/ps2_gs_tests.cpp
@@ -1681,7 +1681,7 @@ void register_ps2_gs_tests()
                      "single-circuit presentation should normalize the last row alpha");
         });
 
-        tc.Run("latched host presentation line-doubles interlaced field output", [](TestCase &t)
+        tc.Run("latched host presentation preserves interlaced framebuffer rows", [](TestCase &t)
         {
             std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
             GSRegisters regs{};
@@ -1732,12 +1732,14 @@ void register_ps2_gs_tests()
             const uint32_t row2 = pixelAtRow(2u);
             const uint32_t row3 = pixelAtRow(3u);
 
-            t.Equals(row0, row1,
-                     "field presentation should duplicate the active field into the next scanline");
-            t.Equals(row2, row3,
-                     "field presentation should duplicate later field scanlines as well");
-            t.IsTrue(row0 != row2,
-                     "field presentation should still preserve different source content across field rows");
+            t.Equals(row0, kLine0,
+                     "interlaced presentation should preserve the first framebuffer row");
+            t.Equals(row1, kLine1,
+                     "interlaced presentation should preserve the second framebuffer row");
+            t.Equals(row2, kLine2,
+                     "interlaced presentation should preserve the third framebuffer row");
+            t.Equals(row3, kLine3,
+                     "interlaced presentation should preserve the fourth framebuffer row");
         });
 
         tc.Run("GIF PACKED A+D writes DISPFB1 and DISPLAY1 privileged registers", [](TestCase &t)


### PR DESCRIPTION
## Summary
- preserve all decoded framebuffer rows when SMODE2 selects interlaced field mode
- remove the presentation-time parity selection and line duplication
- update the GS presentation regression test to require four distinct source rows

## Why
The host presentation buffer already contains a complete 640x448 framebuffer. The previous path selected only even or odd source rows, duplicated each selected row, and alternated parity every VSync. That discarded half the vertical detail and made static content oscillate vertically by one source row.

A true deinterlacer can be added separately if a title supplies field-separated content. The current parity bob is destructive for games that render a complete framebuffer while using interlaced output mode.

## Validation
- Windows Release build succeeds
- full current test suite passes: 425/425
- X-Men Legends legal/title/menu frames changed from 224/224 duplicated adjacent row pairs to 0/224
- the game's 1-pixel vertical vibration stopped, menu text retained full detail, and both edge icons stopped clipping between fields