### PR TITLE
Support profile-defined SJRMT UNI storage

### DIFF
--- a/ps2xIOP/src/module_factories.h
+++ b/ps2xIOP/src/module_factories.h
@@ -21,6 +21,8 @@ namespace ps2x::iop::detail
         uint32_t dispatcherFunctionAddress = 0u;
         uint32_t rpcServerPoolBase = 0u;
         uint32_t rpcServerStride = 0u;
+        uint32_t sjrmtUniDataOffset = 0u;
+        uint32_t sjrmtUniCapacity = 0u;
     };
 
     enum class TsnddrvProtocolVariant

--- a/ps2xIOP/src/modules/cri_dtx.cpp
+++ b/ps2xIOP/src/modules/cri_dtx.cpp
@@ -602,7 +602,21 @@ namespace ps2x::iop::detail
                         workAddress = argument0;
                         workSize = argument1 != 0u ? argument1 : argument2;
                     }
-                    workSize = normalizeSjrmtCapacity(workSize);
+                    if (command == 34u && m_bindings.sjrmtUniCapacity != 0u)
+                    {
+                        const uint32_t dataAddress = workAddress + m_bindings.sjrmtUniDataOffset;
+                        if (dataAddress < workAddress)
+                        {
+                            output[0] = 0u;
+                            break;
+                        }
+                        workAddress = dataAddress;
+                        workSize = m_bindings.sjrmtUniCapacity;
+                    }
+                    else
+                    {
+                        workSize = normalizeSjrmtCapacity(workSize);
+                    }
 
                     std::lock_guard<std::mutex> lock(m_mutex);
                     const uint32_t handle = allocateUrpcHandleLocked();

--- a/ps2xTest/CMakeLists.txt
+++ b/ps2xTest/CMakeLists.txt
@@ -67,6 +67,7 @@ target_include_directories(ps2_test_lib PRIVATE
     ${CMAKE_SOURCE_DIR}/ps2xAnalyzer/include
     ${CMAKE_SOURCE_DIR}/ps2xRuntime/include
     ${CMAKE_SOURCE_DIR}/ps2xRuntime/src/lib
+    ${CMAKE_SOURCE_DIR}/ps2xIOP/src
 )
 
 target_link_libraries(ps2_test_lib PRIVATE

--- a/ps2xTest/src/ps2_iop_tests.cpp
+++ b/ps2xTest/src/ps2_iop_tests.cpp
@@ -1,4 +1,5 @@
 #include "MiniTest.h"
+#include "module_factories.h"
 #include "ps2x/iop/iop_subsystem.h"
 
 #include <algorithm>
@@ -608,6 +609,61 @@ void register_ps2_iop_tests()
             }
             t.Equals(metricValue(*service, "sjrmt_objects"), uint64_t{0},
                      "reset should clear CRI object maps");
+        });
+
+        tc.Run("CRI DTX maps profile-defined SJRMT UNI storage", [](TestCase &t)
+        {
+            FakeIopHost host(0x10000u);
+            auto service = ps2x::iop::detail::createCriDtxService(
+                host,
+                {
+                    .serviceName = "test CRI DTX",
+                    .sid = kSyntheticSid,
+                    .urpcObjectBase = 0x3000u,
+                    .urpcObjectLimit = 0x3400u,
+                    .urpcObjectStride = 0x20u,
+                    .urpcFunctionTableBase = 0x3500u,
+                    .urpcObjectTableBase = 0x3600u,
+                    .dispatcherFunctionAddress = 0x3700u,
+                    .rpcServerPoolBase = 0x3800u,
+                    .rpcServerStride = 0x40u,
+                    .sjrmtUniDataOffset = 0x100u,
+                    .sjrmtUniCapacity = 0x4000u,
+                });
+
+            constexpr uint32_t kSendAddress = 0x2000u;
+            constexpr uint32_t kReceiveAddress = 0x2100u;
+            constexpr uint32_t kUniWorkAddress = 0x4000u;
+            constexpr uint32_t kUniMetadataBytes = 0x100u;
+            constexpr uint32_t kRequestedBytes = 0xA00u;
+
+            host.writeWord(kSendAddress + 0u, 1u);
+            host.writeWord(kSendAddress + 4u, kUniWorkAddress);
+            host.writeWord(kSendAddress + 8u, kUniMetadataBytes);
+
+            RpcRequest request{};
+            request.sid = kSyntheticSid;
+            request.function = 0x422u;
+            request.send = {kSendAddress, 12u};
+            request.receive = {kReceiveAddress, sizeof(uint32_t)};
+            t.IsTrue(service->handleRpc(request).handled,
+                     "SJRMT_UNI_CREATE should be handled");
+            const uint32_t handle = host.readWord(kReceiveAddress);
+            t.IsTrue(handle != 0u, "SJRMT_UNI_CREATE should return a handle");
+
+            host.writeWord(kSendAddress + 0u, handle);
+            host.writeWord(kSendAddress + 4u, 0u);
+            host.writeWord(kSendAddress + 8u, kRequestedBytes);
+            request.function = 0x426u;
+            request.receive.size = 2u * sizeof(uint32_t);
+            t.IsTrue(service->handleRpc(request).handled,
+                     "SJRMT_GET_CHUNK should be handled");
+            t.Equals(host.readWord(kReceiveAddress),
+                     kUniWorkAddress + kUniMetadataBytes,
+                     "the first audio chunk should begin after profile metadata");
+            t.Equals(host.readWord(kReceiveAddress + sizeof(uint32_t)),
+                     kRequestedBytes,
+                     "the configured audio ring should accept a larger chunk");
         });
 
         tc.Run("reset closes profile-owned host file handles", [](TestCase &t)


### PR DESCRIPTION
## Summary
- add optional profile fields for the SJRMT UNI payload offset and ring capacity
- preserve the existing 256-byte normalization when a profile does not opt in
- validate the profile-defined layout with a direct CRI DTX RPC test

## Why
X-Men Legends initializes SJRMT UNI with a work area whose first `0x100` bytes are metadata and whose following `0x4000` bytes form the audio ring. Treating the whole request as the existing normalized 256-byte ring aliases metadata and payload storage. Keeping the layout profile-defined avoids changing established profiles while supporting this observed CRI variant.

## Test plan
- `cmake --build out/sjrmt-test --config Release --target ps2x_tests -- /m:1`
- `out/sjrmt-test/ps2xTest/Release/ps2x_tests.exe`
- 426 passed, 0 failed