### PR TITLE
Support GIF IMAGE2 transfers

### DIFF
--- a/ps2xRuntime/include/runtime/gs/gs_types.h
+++ b/ps2xRuntime/include/runtime/gs/gs_types.h
@@ -38,7 +38,7 @@ enum GSGifFormat : uint8_t
     GIF_FMT_PACKED = 0,
     GIF_FMT_REGLIST = 1,
     GIF_FMT_IMAGE = 2,
-    GIF_FMT_DISABLED = 3,
+    GIF_FMT_IMAGE2 = 3,
 };
 
 enum GSRegId : uint8_t

--- a/ps2xRuntime/src/lib/gs/gs_frontend.cpp
+++ b/ps2xRuntime/src/lib/gs/gs_frontend.cpp
@@ -725,7 +725,7 @@ void GS::processGIFPacket(const uint8_t *data, uint32_t sizeBytes)
             if ((nloop * nreg) & 1)
                 offset += 8;
         }
-        else if (flg == GIF_FMT_IMAGE)
+        else if (flg == GIF_FMT_IMAGE || flg == GIF_FMT_IMAGE2)
         {
             uint32_t imageBytes = nloop * 16;
             if (offset + imageBytes > sizeBytes)
@@ -860,7 +860,7 @@ bool GS::tryProcessNativeImageUploadPacket(const uint8_t *data, uint32_t sizeByt
     const uint64_t imageTagLo = loadLE64(data + offset);
     const uint8_t imageFlg = static_cast<uint8_t>((imageTagLo >> 58u) & 0x3u);
     const uint32_t imageNloop = static_cast<uint32_t>(imageTagLo & 0x7FFFu);
-    if (imageFlg != GIF_FMT_IMAGE || imageNloop == 0u)
+    if ((imageFlg != GIF_FMT_IMAGE && imageFlg != GIF_FMT_IMAGE2) || imageNloop == 0u)
         return false;
 
     offset += 16u;

--- a/ps2xRuntime/src/lib/ps2_debug_panel.cpp
+++ b/ps2xRuntime/src/lib/ps2_debug_panel.cpp
@@ -255,8 +255,8 @@ namespace
             return "REGLIST";
         case GIF_FMT_IMAGE:
             return "IMAGE";
-        case GIF_FMT_DISABLED:
-            return "DISABLED";
+        case GIF_FMT_IMAGE2:
+            return "IMAGE2";
         default:
             return "?";
         }

--- a/ps2xRuntime/src/lib/ps2_memory.cpp
+++ b/ps2xRuntime/src/lib/ps2_memory.cpp
@@ -1999,7 +1999,8 @@ bool PS2Memory::tryProcessNativeGifImageUploadChain(GS &gs, uint32_t tadr, uint3
         return false;
 
     const uint64_t imageTagLo = loadScalar<uint64_t>(imageGifTag, 0u, 16u, "native gif image tag", imageTagDmaAddr + 16u);
-    if (gifTagFlg(imageTagLo) != GIF_FMT_IMAGE)
+    const uint8_t imageFormat = gifTagFlg(imageTagLo);
+    if (imageFormat != GIF_FMT_IMAGE && imageFormat != GIF_FMT_IMAGE2)
         return false;
 
     const uint32_t imageQwc = gifTagNloop(imageTagLo);

--- a/ps2xRuntime/src/lib/vu/ps2_vu1_core.cpp
+++ b/ps2xRuntime/src/lib/vu/ps2_vu1_core.cpp
@@ -879,7 +879,7 @@ void VU1Interpreter::progressXgkick()
                 tagBytes += static_cast<uint64_t>(nloop) * nreg * 16u;
             else if (format == 1u)
                 tagBytes += ((static_cast<uint64_t>(nloop) * nreg + 1u) & ~1ull) * 8u;
-            else if (format == 2u)
+            else if (format == GIF_FMT_IMAGE || format == GIF_FMT_IMAGE2)
                 tagBytes += static_cast<uint64_t>(nloop) * 16u;
             else
             {

--- a/ps2xTest/src/ps2_gs_tests.cpp
+++ b/ps2xTest/src/ps2_gs_tests.cpp
@@ -2169,6 +2169,49 @@ void register_ps2_gs_tests()
             t.IsTrue(same, "GIF IMAGE transfer should write payload bytes into GS VRAM");
         });
 
+        tc.Run("GIF IMAGE2 packet writes host-to-local data into GS VRAM", [](TestCase &t)
+        {
+            std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
+            GS gs;
+            gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
+
+            const uint64_t bitblt =
+                (static_cast<uint64_t>(1u) << 16) |
+                (static_cast<uint64_t>(1u) << 48);
+            gs.writeRegister(GS_REG_BITBLTBUF, bitblt);
+            gs.writeRegister(GS_REG_TRXPOS, 0ull);
+            gs.writeRegister(GS_REG_TRXREG, (4ull << 0) | (1ull << 32));
+            gs.writeRegister(GS_REG_TRXDIR, 0ull);
+
+            std::vector<uint8_t> packet;
+            appendU64(packet, makeGifTag(1u, GIF_FMT_IMAGE2, 0u, true));
+            appendU64(packet, 0ull);
+            const uint8_t payload[16] = {
+                0x71u, 0x72u, 0x73u, 0x74u,
+                0x75u, 0x76u, 0x77u, 0x78u,
+                0x79u, 0x7Au, 0x7Bu, 0x7Cu,
+                0x7Du, 0x7Eu, 0x7Fu, 0x80u,
+            };
+            packet.insert(packet.end(), payload, payload + sizeof(payload));
+
+            gs.processGIFPacket(packet.data(), static_cast<uint32_t>(packet.size()));
+
+            bool same = true;
+            for (uint32_t x = 0; x < 4u && same; ++x)
+            {
+                const uint32_t off = referenceAddrPSMCT32(0u, 1u, x, 0u);
+                for (uint32_t c = 0; c < 4u; ++c)
+                {
+                    if (vram[off + c] != payload[x * 4u + c])
+                    {
+                        same = false;
+                        break;
+                    }
+                }
+            }
+            t.IsTrue(same, "IMAGE2 payload should be handled like IMAGE");
+        });
+
         tc.Run("GIF load-image packet uses native upload fast path", [](TestCase &t)
         {
             std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);

--- a/ps2xTest/src/ps2_vu1_tests.cpp
+++ b/ps2xTest/src/ps2_vu1_tests.cpp
@@ -1202,6 +1202,49 @@ void register_ps2_vu1_tests()
             }
         });
 
+        tc.Run("XGKICK accepts IMAGE2 GIF tags", [](TestCase &t)
+        {
+            PS2Memory mem;
+            t.IsTrue(mem.initialize(), "PS2Memory initialize should succeed");
+
+            std::vector<std::vector<uint8_t>> captured;
+            mem.setGifPacketCallback([&](const uint8_t *packet, uint32_t sizeBytes)
+            {
+                captured.emplace_back(packet, packet + sizeBytes);
+            });
+
+            std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
+            GS gs;
+            gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
+
+            uint8_t *code = mem.getVU1Code();
+            uint8_t *data = mem.getVU1Data();
+            std::memset(code, 0, PS2_VU1_CODE_SIZE);
+            std::memset(data, 0, PS2_VU1_DATA_SIZE);
+
+            const uint64_t image2Tag = makeGifTag(1u, GIF_FMT_IMAGE2, 0u, true);
+            std::memcpy(data, &image2Tag, sizeof(image2Tag));
+            std::memset(data + 16u, 0x5Au, 16u);
+            writeVuInstructionPair(
+                code, 0u,
+                makeVuLowerSpecial(0x6Cu, 1u),
+                kVuUpperNop);
+
+            VU1Interpreter vu1;
+            vu1.state().vi[1] = 0;
+            vu1.execute(code, PS2_VU1_CODE_SIZE,
+                        data, PS2_VU1_DATA_SIZE, gs, &mem,
+                        0u, 0u, 0u, 3u);
+
+            t.Equals(captured.size(), static_cast<size_t>(1u),
+                     "IMAGE2 should complete one PATH1 packet");
+            if (!captured.empty())
+            {
+                t.Equals(captured[0].size(), static_cast<size_t>(32u),
+                         "IMAGE2 PATH1 packet should include its image payload");
+            }
+        });
+
         tc.Run("XGKICK observes stores committed before a future PATH1 qword", [](TestCase &t)
         {
             PS2Memory mem;


### PR DESCRIPTION
## Summary
- recognize GIF `FLG=3` as IMAGE2 instead of a disabled format
- process IMAGE2 payloads through the GS frontend and native upload paths
- size IMAGE2 packets correctly when VU1 XGKICK streams PATH1 data
- label IMAGE2 accurately in the debug panel

## Validation
- `MINITEST_FILTER=IMAGE2 ps2x_tests.exe`
- 2 tests passed, 0 failed
- covers a host-to-local GS upload and VU1 XGKICK packet completion

The PS2 GIF treats `FLG=2` (IMAGE) and `FLG=3` (IMAGE2) as the same payload shape. Previously an IMAGE2 tag aborted the XGKICK pipeline and the regular GS packet parser skipped its payload.