### PR TITLE
Honor GS COLCLAMP during alpha blending

### DIFF
--- a/ps2xRuntime/src/lib/gs/gs_cpu_backend.cpp
+++ b/ps2xRuntime/src/lib/gs/gs_cpu_backend.cpp
@@ -894,10 +894,16 @@ void GSCpuBackend::WritePixel(const GSDrawState &state, int x, int y, int z, uin
                 };
                 int cAlpha = (csel == 0) ? a : (csel == 1) ? da
                                                            : fix;
+                auto finalizeBlendChannel = [&](int value) -> uint8_t
+                {
+                    return (state.colclamp & 0x1u) != 0u
+                        ? clampU8(value)
+                        : static_cast<uint8_t>(value);
+                };
 
-                r = clampU8(((pickRGB(asel, r, dr) - pickRGB(bsel, r, dr)) * cAlpha >> 7) + pickRGB(dsel, r, dr));
-                g = clampU8(((pickRGB(asel, g, dg) - pickRGB(bsel, g, dg)) * cAlpha >> 7) + pickRGB(dsel, g, dg));
-                b = clampU8(((pickRGB(asel, b, db) - pickRGB(bsel, b, db)) * cAlpha >> 7) + pickRGB(dsel, b, db));
+                r = finalizeBlendChannel(((pickRGB(asel, r, dr) - pickRGB(bsel, r, dr)) * cAlpha >> 7) + pickRGB(dsel, r, dr));
+                g = finalizeBlendChannel(((pickRGB(asel, g, dg) - pickRGB(bsel, g, dg)) * cAlpha >> 7) + pickRGB(dsel, g, dg));
+                b = finalizeBlendChannel(((pickRGB(asel, b, db) - pickRGB(bsel, b, db)) * cAlpha >> 7) + pickRGB(dsel, b, db));
             }
             else
             {

--- a/ps2xTest/src/ps2_gs_tests.cpp
+++ b/ps2xTest/src/ps2_gs_tests.cpp
@@ -904,6 +904,49 @@ void register_ps2_gs_tests()
                      "with PABE enabled, high-alpha source pixels should still use the configured ALPHA blend");
         });
 
+        tc.Run("COLCLAMP selects saturated or wrapped alpha blend output", [](TestCase &t)
+        {
+            std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);
+            GS gs;
+            gs.init(vram.data(), static_cast<uint32_t>(vram.size()), nullptr);
+
+            constexpr uint64_t kAlpha =
+                (0ull << 0) |  // A = source
+                (2ull << 2) |  // B = zero
+                (2ull << 4) |  // C = FIX
+                (1ull << 6) |  // D = destination
+                (0x80ull << 32);
+            constexpr uint32_t kColor = 0x801020F0u;
+
+            gs.writeRegister(GS_REG_FRAME_1, (1ull << 16));
+            gs.writeRegister(GS_REG_ZBUF_1, (1ull << 32));
+            gs.writeRegister(GS_REG_SCISSOR_1, 0ull);
+            gs.writeRegister(GS_REG_ALPHA_1, kAlpha);
+            gs.writeRegister(GS_REG_TEST_1, 0x30000ull);
+
+            std::memcpy(vram.data(), &kColor, sizeof(kColor));
+            gs.writeRegister(GS_REG_COLCLAMP, 0ull);
+            gs.writeRegister(GS_REG_PRIM, static_cast<uint64_t>(GS_PRIM_POINT) | (1ull << 6));
+            gs.writeRegister(GS_REG_RGBAQ, kColor);
+            gs.writeRegister(GS_REG_XYZ2, 0ull);
+
+            uint32_t wrappedPixel = 0u;
+            std::memcpy(&wrappedPixel, vram.data(), sizeof(wrappedPixel));
+            t.Equals(wrappedPixel, 0x802040E0u,
+                     "COLCLAMP=0 should retain the low eight bits of overflowing blend channels");
+
+            std::memcpy(vram.data(), &kColor, sizeof(kColor));
+            gs.writeRegister(GS_REG_COLCLAMP, 1ull);
+            gs.writeRegister(GS_REG_PRIM, static_cast<uint64_t>(GS_PRIM_POINT) | (1ull << 6));
+            gs.writeRegister(GS_REG_RGBAQ, kColor);
+            gs.writeRegister(GS_REG_XYZ2, 0ull);
+
+            uint32_t clampedPixel = 0u;
+            std::memcpy(&clampedPixel, vram.data(), sizeof(clampedPixel));
+            t.Equals(clampedPixel, 0x802040FFu,
+                     "COLCLAMP=1 should saturate overflowing blend channels");
+        });
+
         tc.Run("FBA forces the framebuffer alpha high bit on CT32 writes", [](TestCase &t)
         {
             std::vector<uint8_t> vram(PS2_GS_VRAM_SIZE, 0u);


### PR DESCRIPTION
## Summary
- apply the GS `COLCLAMP` register to CPU alpha-blend output
- retain the low eight bits when clamping is disabled
- saturate channels when clamping is enabled
- add a regression test covering both modes with identical blend state

## Rationale
The GS frontend already records `COLCLAMP`, but the CPU backend unconditionally used saturating conversion for alpha-blended RGB. This made `COLCLAMP=0` behave like `COLCLAMP=1` and could turn overflowing effects into saturated colors.

## Tests
- `cmake --build out/colclamp-test --config Release --target ps2x_tests --parallel 1`
- `out/colclamp-test/ps2xTest/Release/ps2x_tests.exe` from repository root: 426 passed, 0 failed