### PR TITLE
Make the VU0 S1/S2 enum coverage test independent of the working directory

### DIFF
--- a/ps2xTest/CMakeLists.txt
+++ b/ps2xTest/CMakeLists.txt
@@ -69,6 +69,11 @@ target_include_directories(ps2_test_lib PRIVATE
     ${CMAKE_SOURCE_DIR}/ps2xRuntime/src/lib
 )
 
+# Test reads ps2recomp/instructions.h by absolute path so it works from any working directory.
+target_compile_definitions(ps2_test_lib PRIVATE
+    PS2X_RECOMP_INCLUDE_DIR="${CMAKE_SOURCE_DIR}/ps2xRecomp/include"
+)
+
 target_link_libraries(ps2_test_lib PRIVATE
     ps2_recomp_lib
     ps2_analyzer_lib

--- a/ps2xTest/src/code_generator_tests.cpp
+++ b/ps2xTest/src/code_generator_tests.cpp
@@ -1140,6 +1140,9 @@ void register_code_generator_tests()
 
         tc.Run("VU0 macro mappings cover all S1/S2 enums", [](TestCase &t) {
             const std::vector<std::string> candidates = {
+#ifdef PS2X_RECOMP_INCLUDE_DIR
+                std::string(PS2X_RECOMP_INCLUDE_DIR) + "/ps2recomp/instructions.h",
+#endif
                 "ps2xRecomp/include/ps2recomp/instructions.h",
                 "../ps2xRecomp/include/ps2recomp/instructions.h",
                 "../../ps2xRecomp/include/ps2recomp/instructions.h"


### PR DESCRIPTION
Closes #101

The VU0 S1/S2 enum coverage test looked for instructions.h via paths relative to the current directory, so it only passed when ps2x_tests was run from the repo root. Running it from anywhere else failed with an empty file read.

CMake now passes the absolute path to the ps2xRecomp include dir as a compile definition, and the test tries that path first. The old relative paths stay as a fallback.