### PR TITLE
Bind the EE scheduler executor thread on first IRQ dispatch

### DIFF
--- a/ps2xRuntime/src/lib/Kernel/EeScheduler.cpp
+++ b/ps2xRuntime/src/lib/Kernel/EeScheduler.cpp
@@ -1251,6 +1251,10 @@ int EeScheduler::setIrqCauseEnabled(bool dmac, uint32_t cause, bool enabled)
 
 void EeScheduler::dispatchIrq(bool dmac, uint32_t cause)
 {
+    if (m_executorThread == std::thread::id{})
+    {
+        m_executorThread = std::this_thread::get_id();
+    }
     assertExecutor();
     const uint32_t mask = dmac ? m_enabledDmacMask : m_enabledIntcMask;
     if (cause < 32u && (mask & (1u << cause)) == 0u)
@@ -1453,7 +1457,7 @@ uint8_t *EeScheduler::rdram() const noexcept
 
 void EeScheduler::bindMainContextForSyscall(R5900Context &ctx, uint8_t *rdram)
 {
-    if (m_executorThread == std::thread::id{})
+    if (m_executorThread == std::thread::id{} || m_threads.empty())
     {
         reset(rdram, ctx);
         GuestThread *main = selectReady();

--- a/ps2xTest/src/ps2_runtime_kernel_tests.cpp
+++ b/ps2xTest/src/ps2_runtime_kernel_tests.cpp
@@ -1260,6 +1260,19 @@ void register_ps2_runtime_kernel_tests()
                      "SetSyscall should treat the syscall index as a signed offset from the kernel table base");
         });
 
+        tc.Run("an early dispatchIrq without reset cannot break a later syscall bind", [](TestCase &t)
+        {
+            TestEnv env;
+
+            // dispatchIrq can run before reset(); the lazy claim must not skip scheduler init.
+            env.runtime.eeScheduler().dispatchIrq(true, 5u);
+
+            t.IsTrue(callSyscall(0x3Cu, env.rdram.data(), &env.ctx, &env.runtime),
+                     "SetupThread should still dispatch after an early dispatchIrq");
+            t.Equals(env.runtime.eeScheduler().currentThreadId(), EeScheduler::kMainThreadId,
+                     "the syscall bind should fall back to a full scheduler reset");
+        });
+
         tc.Run("guest kernel syscall overrides and mirrors are isolated per runtime", [](TestCase &t)
         {
             TestEnv first;


### PR DESCRIPTION
The EE scheduler requires every scheduler operation to run on the executor thread, which gets bound in reset() or bindMainContextForSyscall(). The SIF DMA path (sceSifSetDma -> dispatchDmacHandlersForCause -> dispatchIrq) never binds it, so any direct call from outside the scheduler run loop trips the executor assertion in Debug builds.

Production is unaffected because guest code always runs inside the scheduler loop, and Release builds compile the assertion out, which is why CI never caught it.

dispatchIrq now binds the executor thread on first use, mirroring the lazy binding already done in bindMainContextForSyscall(). The assertion stays in place for every subsequent call.

Verified with the Debug test suite: previously crashed in PS2SifDma after 283 tests, now all 425 tests pass.