### PR TITLE
fix(runtime): route SifSetReg and SifGetReg syscalls

### DIFF
--- a/ps2xRuntime/src/lib/Kernel/Syscalls/Dispatcher.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Syscalls/Dispatcher.cpp
@@ -289,6 +289,12 @@ namespace ps2_syscalls
         case static_cast<uint32_t>(-0x78):
             ps2_stubs::sceSifSetDChain(rdram, ctx, runtime);
             return true;
+        case 0x79:
+            ps2_stubs::sceSifSetReg(rdram, ctx, runtime);
+            return true;
+        case 0x7A:
+            ps2_stubs::sceSifGetReg(rdram, ctx, runtime);
+            return true;
         case 0x7F:
             GetMemorySize(rdram, ctx, runtime);
             return true;

--- a/ps2xTest/src/ps2_runtime_kernel_tests.cpp
+++ b/ps2xTest/src/ps2_runtime_kernel_tests.cpp
@@ -1162,6 +1162,30 @@ void register_ps2_runtime_kernel_tests()
                      "FindAddress should return address of first matching word");
         });
 
+        tc.Run("numeric syscall 0x79/0x7A route SifSetReg/SifGetReg", [](TestCase &t)
+        {
+            TestEnv env;
+            constexpr uint32_t kSifReg = 0x80000000u;
+            constexpr uint32_t kValue = 0x11223344u;
+
+            setRegU32(env.ctx, 4, kSifReg);
+            setRegU32(env.ctx, 5, kValue);
+            t.IsTrue(callSyscall(0x79u, env.rdram.data(), &env.ctx, &env.runtime),
+                     "SifSetReg syscall should dispatch");
+
+            setRegU32(env.ctx, 4, kSifReg);
+            t.IsTrue(callSyscall(0x7Au, env.rdram.data(), &env.ctx, &env.runtime),
+                     "SifGetReg syscall should dispatch");
+            t.Equals(static_cast<uint32_t>(getRegS32(env.ctx, 2)),
+                     kValue,
+                     "SifGetReg should return the value written by SifSetReg");
+
+            // Restore the shared SIF register state for other tests.
+            setRegU32(env.ctx, 4, kSifReg);
+            setRegU32(env.ctx, 5, 0u);
+            callSyscall(0x79u, env.rdram.data(), &env.ctx, &env.runtime);
+        });
+
         tc.Run("numeric syscall 0x83 supports KSEG aliases", [](TestCase &t)
         {
             TestEnv env;


### PR DESCRIPTION
The dispatcher never routed syscalls 0x79 and 0x7A, so SifSetReg and SifGetReg calls fell through to the TODO stub and always returned 0. Both implementations already exist in the SIF stubs, they were just never wired up.

Katamari Damacy needs these during boot: it polls SIF register 4 (IOP boot status) through SifGetReg and spins forever when it gets 0 back.

Adds a regression test that writes a SIF register with SifSetReg and reads it back with SifGetReg.