### PR TITLE
Handle 128-bit writes to GS privileged registers

### DIFF
--- a/ps2xRuntime/src/lib/ps2_memory.cpp
+++ b/ps2xRuntime/src/lib/ps2_memory.cpp
@@ -1064,6 +1064,15 @@ void PS2Memory::write128(uint32_t address, __m128i value)
     const bool scratch = isScratchpad(address);
     uint32_t physAddr = translateAddress(address);
 
+    if (isGsPrivReg(physAddr))
+    {
+        // GS privileged registers occupy the low 64 bits of 16-byte EE bus
+        // slots. SQ stores are used by some games for display register updates;
+        // the upper lane addresses padding and must not spill into the next slot.
+        write64(address, static_cast<uint64_t>(_mm_extract_epi64(value, 0)));
+        return;
+    }
+
     if (scratch)
     {
         inRange(physAddr, sizeof(__m128i), PS2_SCRATCHPAD_SIZE, "write128 scratchpad", address);

--- a/ps2xTest/src/ps2_memory_tests.cpp
+++ b/ps2xTest/src/ps2_memory_tests.cpp
@@ -192,6 +192,28 @@ void register_ps2_memory_tests()
             t.Equals(mem.translateAddress(PS2_SCRATCHPAD_ALIAS_BASE + 0x123u), 0x123u, "0xF000 scratchpad alias should translate to local offset");
         });
 
+        tc.Run("quadword stores update one GS privileged register slot", [](TestCase &t)
+        {
+            PS2Memory mem;
+            t.IsTrue(mem.initialize(), "PS2Memory initialize should succeed");
+
+            constexpr uint32_t kDispfb1 = PS2_GS_PRIV_REG_BASE + 0x70u;
+            constexpr uint32_t kDisplay1 = PS2_GS_PRIV_REG_BASE + 0x80u;
+            constexpr uint64_t kDispfbValue = 0x0123456789ABCDEFull;
+            constexpr uint64_t kUnusedUpperLane = 0xFEDCBA9876543210ull;
+            const __m128i value = _mm_set_epi64x(
+                static_cast<int64_t>(kUnusedUpperLane),
+                static_cast<int64_t>(kDispfbValue));
+            const uint64_t display1Before = mem.read64(kDisplay1);
+
+            mem.write128(kDispfb1, value);
+
+            t.Equals(mem.read64(kDispfb1), kDispfbValue,
+                     "SQ should write the low lane to the GS register");
+            t.Equals(mem.read64(kDisplay1), display1Before,
+                     "SQ upper lane should not spill into the next GS register slot");
+        });
+
         tc.Run("EE timer0 count advances from scheduler cycles and can be reset", [](TestCase &t)
         {
             PS2Memory mem;


### PR DESCRIPTION
Handle SQ stores to GS privileged registers by forwarding the low 64-bit lane to the existing register handler and discarding the upper lane. Non-FIFO 128-bit hardware writes use this behavior in PCSX2 as well. Without it, games that update DISPFB through SQ silently lose framebuffer flips.\n\nAdds a PS2Memory regression covering the target register and adjacent-slot preservation.\n\nTested: MINITEST_FILTER='quadword stores update one GS privileged register slot' ps2x_tests.exe