### PR TITLE
Avoid redundant VU cycle work

### DIFF
--- a/ps2xRuntime/src/lib/vu/ps2_vu1_core.cpp
+++ b/ps2xRuntime/src/lib/vu/ps2_vu1_core.cpp
@@ -5,6 +5,7 @@
 #include "ps2_vu1_detail.h"
 
 #include <algorithm>
+#include <bit>
 #include <cfenv>
 #include <cmath>
 #include <cstdio>
@@ -1011,10 +1012,10 @@ uint64_t VU1Interpreter::calculatePairReadyCycle(const DecodedInstructionPair &d
                     ready = std::max(ready, m_vfReady[access.reg][component]);
             }
         }
-        for (uint32_t reg = 1; reg < m_viReady.size(); ++reg)
+        for (uint32_t regs = usage->viRead & 0xFFFEu; regs != 0u; regs &= regs - 1u)
         {
-            if ((usage->viRead & (1u << reg)) != 0u)
-                ready = std::max(ready, m_viReady[reg]);
+            const uint32_t reg = static_cast<uint32_t>(std::countr_zero(regs));
+            ready = std::max(ready, m_viReady[reg]);
         }
         for (uint32_t component = 0; component < 4u; ++component)
         {
@@ -1069,10 +1070,10 @@ void VU1Interpreter::markPairWrites(const DecodedInstructionPair &decoded)
         }
     }
 
-    for (uint32_t reg = 1; reg < m_viReady.size(); ++reg)
+    for (uint32_t regs = decoded.lowerUsage.viWrite & 0xFFFEu; regs != 0u; regs &= regs - 1u)
     {
-        if ((decoded.lowerUsage.viWrite & (1u << reg)) != 0u)
-            m_viReady[reg] = m_cycle + (decoded.lowerUsage.viLatency != 0u ? decoded.lowerUsage.viLatency : decoded.lowerUsage.latency);
+        const uint32_t reg = static_cast<uint32_t>(std::countr_zero(regs));
+        m_viReady[reg] = m_cycle + (decoded.lowerUsage.viLatency != 0u ? decoded.lowerUsage.viLatency : decoded.lowerUsage.latency);
     }
     for (uint32_t component = 0; component < 4u; ++component)
     {
@@ -1669,17 +1670,10 @@ void VU1Interpreter::run(uint8_t *vuCode, uint32_t codeSize,
         if (m_cycle >= budgetEnd)
             break;
 
-        uint8_t writtenVi = 0u;
-        int32_t oldVi = 0;
-        for (uint32_t reg = 1; reg < 16u; ++reg)
-        {
-            if ((decoded.lowerUsage.viWrite & (1u << reg)) != 0u)
-            {
-                writtenVi = static_cast<uint8_t>(reg);
-                oldVi = m_state.vi[reg];
-                break;
-            }
-        }
+        const uint32_t writtenViMask = decoded.lowerUsage.viWrite & 0xFFFEu;
+        const uint8_t writtenVi = writtenViMask != 0u
+            ? static_cast<uint8_t>(std::countr_zero(writtenViMask)) : 0u;
+        const int32_t oldVi = writtenVi != 0u ? m_state.vi[writtenVi] : 0;
 
         const VfAccess upperWrite = decoded.upperUsage.vfWrite;
         const VfAccess lowerWrite = decoded.lowerUsage.vfWrite;

--- a/ps2xRuntime/src/lib/vu/ps2_vu1_core.cpp
+++ b/ps2xRuntime/src/lib/vu/ps2_vu1_core.cpp
@@ -857,10 +857,16 @@ void VU1Interpreter::progressXgkick()
         }
 
         const uint32_t qwordOffset = m_xgkick.copiedBytes;
-        for (uint32_t i = 0; i < 16u; ++i)
+        const uint32_t address = m_xgkick.sourceAddress + qwordOffset;
+        const uint32_t source = address % m_activeVuDataSize;
+        if (address <= UINT32_MAX - 15u && m_activeVuDataSize - source >= 16u)
         {
-            const uint32_t source = (m_xgkick.sourceAddress + m_xgkick.copiedBytes + i) % m_activeVuDataSize;
-            m_xgkick.packet[m_xgkick.copiedBytes + i] = m_activeVuData[source];
+            std::memcpy(m_xgkick.packet.data() + qwordOffset, m_activeVuData + source, 16u);
+        }
+        else
+        {
+            for (uint32_t i = 0; i < 16u; ++i)
+                m_xgkick.packet[qwordOffset + i] = m_activeVuData[(address + i) % m_activeVuDataSize];
         }
         m_xgkick.copiedBytes += 16u;
 
@@ -1633,9 +1639,12 @@ void VU1Interpreter::run(uint8_t *vuCode, uint32_t codeSize,
     const bool useVuRounding = std::fesetround(FE_TOWARDZERO) == 0;
     const uint64_t budgetEnd = m_cycle + maxCycles;
     bool programEnded = false;
+    // Resume may enter with pending work. Subsequent cycle boundaries already
+    // retire pipelines in advanceOneCycle(), before PATH1 reads VU memory.
+    if (m_cycle < budgetEnd && !m_stopRequested)
+        commitReadyPipelines();
     while (m_cycle < budgetEnd && !m_stopRequested)
     {
-        commitReadyPipelines();
         if (m_state.pc + 8u > codeSize)
             break;
 

--- a/ps2xTest/src/ps2_vu1_tests.cpp
+++ b/ps2xTest/src/ps2_vu1_tests.cpp
@@ -634,6 +634,52 @@ void register_ps2_vu1_tests()
                      "ILW-to-IALU dependency should account for all stalled cycles");
         });
 
+        tc.Run("integer dependency masks cover every VI source and destination", [](TestCase &t)
+        {
+            Vu1Fixture fx;
+            t.IsTrue(fx.initialize(), "VU1 fixture should initialize");
+            if (!fx.code || !fx.data)
+                return;
+            const uint32_t first = 100u, second = 200u;
+            std::memcpy(fx.data, &first, sizeof(first));
+            std::memcpy(fx.data + 16u, &second, sizeof(second));
+            for (uint8_t left = 0u; left < 16u; ++left)
+            {
+                for (uint8_t right = 0u; right < 16u; ++right)
+                {
+                    const uint8_t dest = (left + right) & 15u;
+                    writeTrackedVuInstructionPair(fx, 0u, makeVuIlw(0x8u, left, 0u, 0), kVuUpperNop);
+                    writeTrackedVuInstructionPair(fx, 8u, makeVuIlw(0x8u, right, 0u, 1), kVuUpperNop);
+                    writeTrackedVuInstructionPair(fx, 16u, makeVuLowerDirect(0x30u, left, right, dest),
+                                                  kVuUpperNop | 0x40000000u);
+                    writeTrackedVuInstructionPair(fx, 24u, 0u, kVuUpperNop);
+                    VU1Interpreter vu;
+                    for (uint32_t reg = 1u; reg < 16u; ++reg)
+                        vu.state().vi[reg] = static_cast<int32_t>(reg * 7u);
+                    vu.execute(fx.code, PS2_VU1_CODE_SIZE, fx.data, PS2_VU1_DATA_SIZE,
+                               fx.gs, &fx.mem, 0u, 0u, 0u, 64u);
+                    const int32_t leftValue = left == 0u ? 0 : (left == right ? 200 : 100);
+                    const int32_t rightValue = right == 0u ? 0 : 200;
+                    for (uint32_t reg = 0u; reg < 16u; ++reg)
+                    {
+                        int32_t expected = static_cast<int32_t>(reg * 7u);
+                        if (reg == left)
+                            expected = 100;
+                        if (reg == right)
+                            expected = 200;
+                        if (reg == dest)
+                            expected = leftValue + rightValue;
+                        if (reg == 0u)
+                            expected = 0;
+                        t.Equals(vu.state().vi[reg], expected, "Only the named VI registers may change");
+                    }
+                    const uint64_t expectedCycles = right != 0u ? 7u : (left != 0u ? 6u : 4u);
+                    t.Equals(vu.state().cycles, expectedCycles, "IADD must wait for its latest nonzero VI input");
+                    t.Equals(vu.state().pc, 32u, "The end-bit delay slot must complete");
+                }
+            }
+        });
+
         tc.Run("DIV and SQRT update the Q register from selected vector components", [](TestCase &t)
         {
             Vu1Fixture fx;

--- a/ps2xTest/src/ps2_vu1_tests.cpp
+++ b/ps2xTest/src/ps2_vu1_tests.cpp
@@ -1136,6 +1136,50 @@ void register_ps2_vu1_tests()
             t.Equals(vu1.state().vi[1], 2, "second execution should rebuild decode after the direct write");
         });
 
+        tc.Run("XGKICK preserves qword bytes across arbitrary memory boundaries", [](TestCase &t)
+        {
+            Vu1Fixture fx;
+            t.IsTrue(fx.initialize(), "VU1 fixture should initialize");
+            if (!fx.code || !fx.data)
+                return;
+            writeTrackedVuInstructionPair(fx, 0u, makeVuLowerSpecial(0x6Cu, 1u), kVuUpperNop);
+            writeTrackedVuInstructionPair(fx, 8u, 0u, kVuUpperNop);
+            writeTrackedVuInstructionPair(fx, 16u, 0u, kVuUpperNop);
+            std::vector<uint8_t> expected(32u, 0u), captured;
+            const uint64_t tag = makeGifTag(1u, GIF_FMT_IMAGE, 0u, true);
+            std::memcpy(expected.data(), &tag, sizeof(tag));
+            for (uint32_t i = 16u; i < 32u; ++i)
+                expected[i] = static_cast<uint8_t>(0xA0u + i);
+            fx.mem.setGifPacketCallback([&](const uint8_t *packet, uint32_t size)
+            {
+                captured.assign(packet, packet + size);
+            });
+            for (const uint32_t size : {32u, 33u, 47u, 64u, uint32_t{PS2_VU1_DATA_SIZE}})
+            {
+                const uint32_t source = ((size - 1u) / 16u) * 16u;
+                std::vector<uint8_t> data(size + 16u, 0xCDu);
+                for (uint32_t i = 0; i < expected.size(); ++i)
+                    data[(source + i) % size] = expected[i];
+                VU1Interpreter vu;
+                vu.state().vi[1] = static_cast<int32_t>(source / 16u);
+                captured.clear();
+                vu.execute(fx.code, PS2_VU1_CODE_SIZE, data.data(), size,
+                           fx.gs, &fx.mem, 0u, 0u, 0u, 1u);
+                t.IsTrue(captured.empty(), "The first cycle must transfer only the tag");
+                vu.resume(fx.code, PS2_VU1_CODE_SIZE, data.data(), size,
+                          fx.gs, &fx.mem, 0u, 0u, 0u);
+                t.Equals(vu.state().cycles, uint64_t{1u}, "A zero-cycle resume must not advance PATH1");
+                t.IsTrue(captured.empty(), "A zero-cycle resume must not emit the packet");
+                vu.resume(fx.code, PS2_VU1_CODE_SIZE, data.data(), size,
+                          fx.gs, &fx.mem, 0u, 0u, 1u);
+                t.IsTrue(captured.empty(), "The payload must still be pending at cycle two");
+                vu.resume(fx.code, PS2_VU1_CODE_SIZE, data.data(), size,
+                          fx.gs, &fx.mem, 0u, 0u, 1u);
+                t.Equals(vu.state().cycles, uint64_t{3u}, "The payload must finish at cycle three");
+                t.IsTrue(captured == expected, "Every wrapped tag and payload byte must match");
+            }
+        });
+
         tc.Run("XGKICK sends a VU memory GIF packet through PATH1", [](TestCase &t)
         {
             PS2Memory mem;


### PR DESCRIPTION
## Summary

- Retire pending VU pipelines once on entry to an executable slice. Subsequent
  instruction boundaries already retire them in `advanceOneCycle()`, before
  PATH1 reads VU memory, so the next loop iteration need not repeat that scan.
- Copy a contiguous PATH1 qword with one address calculation and `memcpy`.
  Retain byte-wise wrapping for split qwords and unsigned address overflow.
- Visit only the set bits of existing VI read/write masks during dependency
  checks, write-readiness updates, and first-written-register selection. VI0
  remains excluded and registers are still visited in ascending order.
- Add a synthetic regression covering 32-, 33-, 47-, 64-, and 16384-byte memory
  boundaries, complete packet equality, and zero/one-cycle resume timing.
- Add all 256 pairs of VI input registers, covering every destination, repeated
  loads to the same register, VI0, high registers, final values, cycle counts,
  and the end-bit delay slot.

No instruction arithmetic, pipeline latency, event order, packet batching, or
game-specific behavior is changed. This PR is based directly on upstream main
`14b1e5c` and does not depend on the occupancy-mask or operand-preparation PRs.

## Validation

- Windows x64 Release, Visual Studio 2022, one BelowNormal build worker.
- Unmodified upstream main: 425/425 tests pass.
- Initial cycle-work commit: 426/426 tests pass; current branch: 427/427.
- The boundary test also passed against the original byte-wise packet copy.
- The bring-up integration passes 98/98 local VU tests. Its other known suite
  failures are not represented as passing by this result.
- Private, process-local replay of 32 real VU slices checks full canonical
  register/pipeline state, all 16 KiB of VU data, and every emitted GIF byte and
  emission cycle. All 4096 timed executions match, digest `75d4ff1e67bbbc4c`.
  The replay tool is not part of this PR, and no retail microcode or data is
  included or redistributed.

Nine interleaved runs of the captured workload measured median execution times
of 589.740 ms before and 564.147 ms after removing the duplicate retirement scan
(about 4.3%). This measurement is from the bring-up branch, not this clean
upstream branch. Packet-copy-only timings were noisy, so no separate gain is
claimed. These are VU workload timings, not whole-game FPS measurements.

For the VI-mask follow-up, a longer nine-pair comparison alternated execution
order and used 512 repeats per captured case (16,384 timed slices and 20,891,136
VU cycles per run). Median execution time fell from 2299.731 ms to 1981.324 ms,
about 13.85%, with the same state/memory/GIF digest throughout. Every candidate
run in that batch was faster than every baseline run. These numbers are also
from the bring-up branch and do not constitute an end-to-end FPS claim.
