### PR TITLE
Allow disabling IPO for large generated game runners

### DIFF
--- a/ps2xRuntime/CMakeLists.txt
+++ b/ps2xRuntime/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 option(PS2X_ENABLE_RUNNER_UNITY_BUILD "Build ps2EntryRunner with CMake unity build" ON)
 set(PS2X_RUNNER_UNITY_BUILD_BATCH_SIZE 32 CACHE STRING "Unity build batch size for ps2EntryRunner")
 option(PS2X_ENABLE_RUNNER_PCH "Precompile the heavy runtime headers for ps2EntryRunner" ON)
+option(PS2X_ENABLE_RUNNER_IPO "Allow link-time optimization of the generated game target when IPO is enabled" ON)
 option(PS2X_ENABLE_SCCACHE "Use sccache as compiler launcher when available" ON)
 
 option(PS2X_ENABLE_RUNTIME_LOGS "Enable PS2 runtime logs" OFF)
@@ -554,7 +555,12 @@ endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     EnableFastReleaseMode(ps2_runtime)
-    EnableFastReleaseMode(ps2EntryRunner)
+    if(PS2X_ENABLE_RUNNER_IPO)
+        EnableFastReleaseMode(ps2EntryRunner)
+    else()
+        # Large generated games can exceed linker memory limits even with one worker.
+        EnableFastReleaseMode(ps2EntryRunner NO_IPO)
+    endif()
 
     if(WIN32 AND NOT PS2X_SHOW_WINDOWS_CONSOLE)
         if(MSVC)

--- a/ps2xRuntime/cmake/ReleaseMode.cmake
+++ b/ps2xRuntime/cmake/ReleaseMode.cmake
@@ -3,6 +3,7 @@ include(CheckIPOSupported)
 check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_ERROR)
 
 function(EnableFastReleaseMode TargetName)
+    cmake_parse_arguments(RELEASE_MODE "NO_IPO" "" "" ${ARGN})
     message("> Enabling optimization for: ${TargetName}")
     if(MSVC)
         target_compile_options(${TargetName} PRIVATE
@@ -10,7 +11,6 @@ function(EnableFastReleaseMode TargetName)
                 /O2 # speed
                 /Ob2 # inline aggressively
                 /Oi # intrinsics
-                /GL # whole program opt
                 /Gy # function-level linking
                 /Gw # global data in COMDAT
                 /GF # string pooling
@@ -23,20 +23,32 @@ function(EnableFastReleaseMode TargetName)
             >
         )
 
+        if(NOT RELEASE_MODE_NO_IPO)
+            target_compile_options(${TargetName} PRIVATE
+                $<$<CONFIG:Release>:/GL>
+            )
+        endif()
+
         if(TARGET ${TargetName})
             target_link_options(${TargetName} PRIVATE
                 $<$<CONFIG:Release>:
-                    /LTCG # link-time code generation
                     /OPT:REF # remove unreferenced
                     /OPT:ICF # fold identical COMDATs
                 >
             )
+            if(NOT RELEASE_MODE_NO_IPO)
+                target_link_options(${TargetName} PRIVATE
+                    $<$<CONFIG:Release>:/LTCG>
+                )
+            endif()
         endif()
     endif()
 
-    if(IPO_SUPPORTED)
-        set_property(TARGET ${TargetName} PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
-    else()
-        message(WARNING "Interprocedural optimization not supported: ${ipo_error}")
+    if(NOT RELEASE_MODE_NO_IPO)
+        if(IPO_SUPPORTED)
+            set_property(TARGET ${TargetName} PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+        else()
+            message(WARNING "Interprocedural optimization not supported: ${ipo_error}")
+        endif()
     endif()
 endfunction()


### PR DESCRIPTION
## Summary

- add a default-on PS2X_ENABLE_RUNNER_IPO option
- let EnableFastReleaseMode retain the normal Release optimizations while omitting /GL, /LTCG, and CMake IPO for one target
- apply that opt-out only to ps2EntryRunner; runtime libraries keep their existing IPO behavior

## Motivation

Large statically generated game targets can exhaust linker memory even with a single link worker. A 107-translation-unit X-Men Legends runner exceeded a 2 GiB linker-process cap with IPO enabled. Disabling IPO only for the generated runner allowed the complete executable to link under the same cap while preserving /O2 and optimized/IPO-enabled runtime libraries.

The option defaults ON, so existing builds are unchanged.

## Validation

Configured current upstream main with MSVC/Visual Studio 2022, CMAKE_BUILD_TYPE=Release, and global IPO enabled:

- PS2X_ENABLE_RUNNER_IPO=OFF: generated ps2EntryRunner.vcxproj has no WholeProgramOptimization or LinkTimeCodeGeneration; ps2_runtime.vcxproj still has whole-program optimization.
- PS2X_ENABLE_RUNNER_IPO=ON: the runner again has whole-program optimization and LTCG, preserving the default behavior.

The 107-unit game runner was compiled with /O2 and no /GL, linked with /CGTHREADS:1 under the unchanged 2 GiB guard, passed PE section validation, and reached rendered gameplay.